### PR TITLE
Adds duplicate_post_default_post_types_enabled filter

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -153,7 +153,14 @@ function duplicate_post_plugin_upgrade() {
 	add_option( 'duplicate_post_copymenuorder', '1' );
 	add_option( 'duplicate_post_taxonomies_blacklist', array() );
 	add_option( 'duplicate_post_blacklist', '' );
-	add_option( 'duplicate_post_types_enabled', array( 'post', 'page' ) );
+	/**
+	 * Filter to modify the default post types that are enabled to be copied.
+	 *
+	 * @param array $post_types List of default post types enabled to be copied
+	 *
+	 * @return array Modified list of default post types enabled to be copied
+	 */
+	add_option( 'duplicate_post_types_enabled', apply_filters( 'duplicate_post_default_post_types_enabled', array( 'post', 'page' ) ) );
 	add_option( 'duplicate_post_show_row', '1' );
 	add_option( 'duplicate_post_show_adminbar', '1' );
 	add_option( 'duplicate_post_show_submitbox', '1' );
@@ -935,7 +942,7 @@ function duplicate_post_add_bulk_filters_for_enabled_post_types() {
 	if ( 1 !== intval( get_option( 'duplicate_post_show_bulkactions' ) ) ) {
 		return;
 	}
-	$duplicate_post_types_enabled = get_option( 'duplicate_post_types_enabled', array( 'post', 'page' ) );
+	$duplicate_post_types_enabled = duplicate_post_post_types_enabled();
 	if ( ! is_array( $duplicate_post_types_enabled ) ) {
 		$duplicate_post_types_enabled = array( $duplicate_post_types_enabled );
 	}

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -22,7 +22,7 @@ function duplicate_post_is_current_user_allowed_to_copy() {
  * @return boolean.
  */
 function duplicate_post_is_post_type_enabled( $post_type ) {
-	$duplicate_post_types_enabled = get_option( 'duplicate_post_types_enabled', array( 'post', 'page' ) );
+	$duplicate_post_types_enabled = duplicate_post_post_types_enabled();
 	if ( ! is_array( $duplicate_post_types_enabled ) ) {
 		$duplicate_post_types_enabled = array( $duplicate_post_types_enabled );
 	}
@@ -275,4 +275,19 @@ function duplicate_post_init() {
  */
 function duplicate_post_tax_obj_cmp( $a, $b ) {
 	return ( $a->public < $b->public );
+}
+
+/**
+ * Returns all post types that are enabled to be copied.
+ *
+ * @return array
+ */
+function duplicate_post_post_types_enabled() {
+	/** This filter is documented in duplicate-post-admin.php */
+	$default_post_types = apply_filters(
+		'duplicate_post_default_post_types_enabled',
+		array( 'post', 'page' )
+	);
+
+	return get_option( 'duplicate_post_types_enabled', $default_post_types );
 }


### PR DESCRIPTION
This is a pull request in relation to issue #12.

It creates a new duplicate_post_default_post_types_enabled filter. This filter allows a developer to add custom post types to the list of default post types that are enabled for duplication. This list originally contains "page" and "post" types.

This filter does not override the actual option entered and saved by the user. It only affects newly created sites where the user has not yet modified the list of post types enabled for duplication.