### PR TITLE
Settings pages accessibility first run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ tests/cli/vendor
 /tests/bin/tmp
 /tests/e2e-tests/config/local-*.json
 /tests/e2e-tests/config/local.json
+
+############
+## Composer
+############
+/vendor/

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -122,12 +122,17 @@ function duplicate_post_options() {
 		return false;
 	});
 
-	function toggle_private_taxonomies(){
-		jQuery('.taxonomy_private').toggle(300);
-	}
-
 	jQuery( function() {
 		jQuery( '.taxonomy_private' ).hide();
+
+		jQuery( '.toggle-private-taxonomies' )
+			.on( 'click', function() {
+				buttonElement = jQuery( this );
+				jQuery( '.taxonomy_private' ).toggle( 300, function() {
+					console.log( 'expanded done', buttonElement );
+					buttonElement.attr( 'aria-expanded', jQuery( this ).is( ":visible" ) );
+				} );
+			} );
 	} );
 
 	</script>
@@ -165,8 +170,8 @@ label.taxonomy_private {
 	font-style: italic;
 }
 
-a.toggle_link {
-	font-size: small;
+.toggle-private-taxonomies.button-link {
+	margin-top: 1em;
 }
 
 img#donate-button {
@@ -396,43 +401,46 @@ img#donate-button {
 				<tr>
 					<th scope="row">
 						<?php esc_html_e( 'Do not copy these taxonomies', 'duplicate-post' ); ?><br />
-						<a class="toggle_link hide-if-no-js" href="#"
-						onclick="toggle_private_taxonomies();return false;"><?php esc_html_e( 'Show/hide private taxonomies', 'duplicate-post' ); ?>
-					</a></th>
+					</th>
 					<td>
-					<?php
+						<fieldset>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Do not copy these taxonomies', 'duplicate-post' ); ?></legend>
+							<?php
 
-					$taxonomies = get_taxonomies( array(), 'objects' );
-					usort( $taxonomies, 'duplicate_post_tax_obj_cmp' );
-					$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
-					if ( '' === $taxonomies_blacklist ) {
-						$taxonomies_blacklist = array();
-					}
-					foreach ( $taxonomies as $taxonomy ) :
-						if ( 'post_format' === $taxonomy->name ) {
-							continue;
-						}
-						?>
-						<span class="taxonomy_<?php echo ( $taxonomy->public ) ? 'public' : 'private'; ?>">
-							<input type="checkbox"
-								name="duplicate_post_taxonomies_blacklist[]"
-								id="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
-								value="<?php echo esc_attr( $taxonomy->name ); ?>"
-								<?php
-								if ( in_array( $taxonomy->name, $taxonomies_blacklist, true ) ) {
-									echo 'checked="checked"';
+							$taxonomies = get_taxonomies( array(), 'objects' );
+							usort( $taxonomies, 'duplicate_post_tax_obj_cmp' );
+							$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
+							if ( '' === $taxonomies_blacklist ) {
+								$taxonomies_blacklist = array();
+							}
+							foreach ( $taxonomies as $taxonomy ) :
+								if ( 'post_format' === $taxonomy->name ) {
+									continue;
 								}
 								?>
-							/>
-							<label
-								for="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
-							>
-								<?php echo esc_html( $taxonomy->labels->name . ' [' . $taxonomy->name . ']' ); ?>
-							</label>
-						</span><br />
-					<?php endforeach; ?>
-					<span class="description"><?php esc_html_e( "Select the taxonomies you don't want to be copied", 'duplicate-post' ); ?>
-					</span></td>
+							<div class="taxonomy_<?php echo ( $taxonomy->public ) ? 'public' : 'private'; ?>">
+								<input type="checkbox"
+									name="duplicate_post_taxonomies_blacklist[]"
+									id="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
+									value="<?php echo esc_attr( $taxonomy->name ); ?>"
+									<?php
+									if ( in_array( $taxonomy->name, $taxonomies_blacklist, true ) ) {
+										echo 'checked="checked"';
+									}
+									?>
+								/>
+								<label
+									for="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
+								>
+									<?php echo esc_html( $taxonomy->labels->name . ' [' . $taxonomy->name . ']' ); ?>
+								</label><br />
+							</div>
+							<?php endforeach; ?>
+							<button type="button" class="button-link hide-if-no-js toggle-private-taxonomies" aria-expanded="false">
+								<?php esc_html_e( 'Show/hide private taxonomies', 'duplicate-post' ); ?>
+							</button>
+						</fieldset>
+					</td>
 				</tr>
 			</table>
 		</section>
@@ -564,8 +572,8 @@ img#donate-button {
 			</table>
 		</section>
 		<p class="submit">
-			<input type="submit" class="button-primary"
-				value="<?php esc_html_e( 'Save Changes', 'duplicate-post' ); ?>" />
+			<input type="submit" class="button button-primary"
+				value="<?php esc_html_e( 'Save changes', 'duplicate-post' ); ?>" />
 		</p>
 
 	</form>

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -92,9 +92,6 @@ function duplicate_post_options() {
 	}
 	?>
 <div class="wrap">
-	<div id="icon-options-general" class="icon32">
-		<br>
-	</div>
 	<h1>
 		<?php esc_html_e( 'Duplicate Post Options', 'duplicate-post' ); ?>
 	</h1>
@@ -129,9 +126,9 @@ function duplicate_post_options() {
 		jQuery('.taxonomy_private').toggle(300);
 	}
 
-	jQuery(function(){
-		jQuery('.taxonomy_private').hide(300);
-	});
+	jQuery( function() {
+		jQuery( '.taxonomy_private' ).hide();
+	} );
 
 	</script>
 
@@ -164,10 +161,6 @@ function duplicate_post_options() {
 	border: 0;
 }
 
-label {
-	display: block;
-}
-
 label.taxonomy_private {
 	font-style: italic;
 }
@@ -197,175 +190,216 @@ img#donate-button {
 
 		<section>
 
-			<table class="form-table">
-				<tr valign="top">
+			<table class="form-table" role="presentation">
+				<tr>
 					<th scope="row"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?>
 					</th>
-					<td colspan="2"><label> <input type="checkbox"
-							name="duplicate_post_copytitle" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copytitle' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Title', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copydate" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copydate' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Date', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copystatus" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copystatus' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Status', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyslug" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copyslug' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Slug', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyexcerpt" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copyexcerpt' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Excerpt', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copycontent" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copycontent' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Content', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copythumbnail" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copythumbnail' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Featured Image', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copytemplate" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copytemplate' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Template', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyformat" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copyformat' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php echo esc_html_x( 'Format', 'post format', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyauthor" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copyauthor' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Author', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copypassword" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copypassword' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Password', 'default' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyattachments" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copyattachments' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Attachments', 'duplicate-post' ); ?> <small>(<?php esc_html_e( 'you probably want this unchecked, unless you have very special requirements', 'duplicate-post' ); ?>)</small>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copychildren" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copychildren' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Children', 'duplicate-post' ); ?>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copycomments" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copycomments' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Comments', 'default' ); ?> <small>(<?php esc_html_e( 'except pingbacks and trackbacks', 'duplicate-post' ); ?>)</small>
-					</label> <label> <input type="checkbox"
-							name="duplicate_post_copymenuorder" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_copymenuorder' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Menu order', 'default' ); ?>
-					</label></td>
+					<td>
+						<fieldset>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?></legend>
+							<input type="checkbox"
+								name="duplicate_post_copytitle" value="1"
+								id="duplicate-post-copytitle"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copytitle' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copytitle"><?php esc_html_e( 'Title', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copydate" value="1"
+								id="duplicate-post-copydate"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copydate' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copydate"><?php esc_html_e( 'Date', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copystatus" value="1"
+								id="duplicate-post-copystatus"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copystatus' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copystatus"><?php esc_html_e( 'Status', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copyslug" value="1"
+								id="duplicate-post-copyslug"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copyslug' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copyslug"><?php esc_html_e( 'Slug', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copyexcerpt" value="1"
+								id="duplicate-post-copyexcerpt"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copyexcerpt' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copyexcerpt"><?php esc_html_e( 'Excerpt', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copycontent" value="1"
+								id="duplicate-post-copycontent"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copycontent' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copycontent"><?php esc_html_e( 'Content', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copythumbnail" value="1"
+								id="duplicate-post-copythumbnail"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copythumbnail' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copythumbnail"><?php esc_html_e( 'Featured Image', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copytemplate" value="1"
+								id="duplicate-post-copytemplate"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copytemplate' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copytemplate"><?php esc_html_e( 'Template', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copyformat" value="1"
+								id="duplicate-post-copyformat"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copyformat' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copyformat"><?php echo esc_html_x( 'Format', 'post format', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copyauthor" value="1"
+								id="duplicate-post-copyauthor"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copyauthor' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copyauthor"><?php esc_html_e( 'Author', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copypassword" value="1"
+								id="duplicate-post-copypassword"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copypassword' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copypassword"><?php esc_html_e( 'Password', 'default' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copyattachments" value="1"
+								id="duplicate-post-copyattachments"
+								aria-describedby="duplicate-post-copyattachments-description"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copyattachments' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copyattachments"><?php esc_html_e( 'Attachments', 'duplicate-post' ); ?></label>
+							<span id="duplicate-post-copyattachments-description">(<?php esc_html_e( 'you probably want this unchecked, unless you have very special requirements', 'duplicate-post' ); ?>)</span><br />
+							<input type="checkbox"
+								name="duplicate_post_copychildren" value="1"
+								id="duplicate-post-copychildren"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copychildren' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copychildren"><?php esc_html_e( 'Children', 'duplicate-post' ); ?></label><br />
+							<input type="checkbox"
+								name="duplicate_post_copycomments" value="1"
+								id="duplicate-post-copycomments"
+								aria-describedby="duplicate-post-copycomments-description"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copycomments' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copycomments"><?php esc_html_e( 'Comments', 'default' ); ?></label>
+							<span id="duplicate-post-copycomments-description">(<?php esc_html_e( 'except pingbacks and trackbacks', 'duplicate-post' ); ?>)</span><br />
+							<input type="checkbox"
+								name="duplicate_post_copymenuorder" value="1"
+								id="duplicate-post-copymenuorder"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_copymenuorder' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-copymenuorder"><?php esc_html_e( 'Menu order', 'default' ); ?></label>
+						<fieldset>
+					</td>
 				</tr>
-				<tr valign="top">
-					<th scope="row"><?php esc_html_e( 'Title prefix', 'duplicate-post' ); ?>
+				<tr>
+					<th scope="row">
+						<label for="duplicate-post-title-prefix"><?php esc_html_e( 'Title prefix', 'duplicate-post' ); ?></label>
 					</th>
 					<td><input type="text" name="duplicate_post_title_prefix"
+						id="duplicate-post-title-prefix"
+						aria-describedby="duplicate-post-title-prefix-description"
 						value="<?php form_option( 'duplicate_post_title_prefix' ); ?>" />
+						<p id="duplicate-post-title-prefix-description">
+							<?php esc_html_e( 'Prefix to be added before the title, e.g. "Copy of" (blank for no prefix)', 'duplicate-post' ); ?>
+						</p>
 					</td>
-					<td><span class="description"><?php esc_html_e( 'Prefix to be added before the title, e.g. "Copy of" (blank for no prefix)', 'duplicate-post' ); ?>
-					</span></td>
 				</tr>
-				<tr valign="top">
-					<th scope="row"><?php esc_html_e( 'Title suffix', 'duplicate-post' ); ?>
+				<tr>
+					<th scope="row">
+						<label for="duplicate-post-title-suffix"><?php esc_html_e( 'Title suffix', 'duplicate-post' ); ?></label>
 					</th>
 					<td><input type="text" name="duplicate_post_title_suffix"
+						id="duplicate-post-title-suffix"
+						aria-describedby="duplicate-post-title-suffix-description"
 						value="<?php form_option( 'duplicate_post_title_suffix' ); ?>" />
+						<p id="duplicate-post-title-suffix-description">
+							<?php esc_html_e( 'Suffix to be added after the title, e.g. "(dup)" (blank for no suffix)', 'duplicate-post' ); ?>
+						</p>
 					</td>
-					<td><span class="description"><?php esc_html_e( 'Suffix to be added after the title, e.g. "(dup)" (blank for no suffix)', 'duplicate-post' ); ?>
-					</span></td>
 				</tr>
-				<tr valign="top">
-					<th scope="row"><?php esc_html_e( 'Increase menu order by', 'duplicate-post' ); ?>
+				<tr>
+					<th scope="row">
+						<label for="duplicate-post-increase-menu-order-by"><?php esc_html_e( 'Increase menu order by', 'duplicate-post' ); ?></label>
 					</th>
 					<td><input type="number" min="0" step="1" name="duplicate_post_increase_menu_order_by"
+						id="duplicate-post-increase-menu-order-by"
+						aria-describedby="duplicate-post-increase-menu-order-by-description"
 						value="<?php form_option( 'duplicate_post_increase_menu_order_by' ); ?>" />
+						<p id="duplicate-post-increase-menu-order-by-description">
+							<?php esc_html_e( 'Add this number to the original menu order (blank or zero to retain the value)', 'duplicate-post' ); ?>
+						</p>
 					</td>
-					<td><span class="description"><?php esc_html_e( 'Add this number to the original menu order (blank or zero to retain the value)', 'duplicate-post' ); ?>
-					</span></td>
 				</tr>
-				<tr valign="top">
-					<th scope="row"><?php esc_html_e( 'Do not copy these fields', 'duplicate-post' ); ?>
+				<tr>
+					<th scope="row">
+						<label for="duplicate-post-blacklist"><?php esc_html_e( 'Do not copy these fields', 'duplicate-post' ); ?></label>
 					</th>
 					<td id="textfield"><input type="text"
 						name="duplicate_post_blacklist"
-						value="<?php form_option( 'duplicate_post_blacklist' ); ?>" /></td>
-					<td><span class="description"><?php esc_html_e( 'Comma-separated list of meta fields that must not be copied', 'duplicate-post' ); ?><br />
-							<small><?php esc_html_e( 'You can use * to match zero or more alphanumeric characters or underscores: e.g. field*', 'duplicate-post' ); ?>
-						</small> </span></td>
+						id="duplicate-post-blacklist"
+						aria-describedby="duplicate-post-blacklist-description"
+						value="<?php form_option( 'duplicate_post_blacklist' ); ?>" />
+						<p id="duplicate-post-blacklist-description">
+							<?php esc_html_e( 'Comma-separated list of meta fields that must not be copied.', 'duplicate-post' ); ?>
+							<?php esc_html_e( 'You can use * to match zero or more alphanumeric characters or underscores: e.g. field*', 'duplicate-post' ); ?>
+						</p>
+					</td>
 				</tr>
-				<tr valign="top">
-					<th scope="row"><?php esc_html_e( 'Do not copy these taxonomies', 'duplicate-post' ); ?><br />
+				<tr>
+					<th scope="row">
+						<?php esc_html_e( 'Do not copy these taxonomies', 'duplicate-post' ); ?><br />
 						<a class="toggle_link hide-if-no-js" href="#"
 						onclick="toggle_private_taxonomies();return false;"><?php esc_html_e( 'Show/hide private taxonomies', 'duplicate-post' ); ?>
 					</a></th>
-					<td colspan="2">
+					<td>
 					<?php
 
 					$taxonomies = get_taxonomies( array(), 'objects' );
@@ -379,25 +413,33 @@ img#donate-button {
 							continue;
 						}
 						?>
-					<label class="taxonomy_<?php echo ( $taxonomy->public ) ? 'public' : 'private'; ?>">
+						<span class="taxonomy_<?php echo ( $taxonomy->public ) ? 'public' : 'private'; ?>">
 							<input type="checkbox"
-							name="duplicate_post_taxonomies_blacklist[]"
-							value="<?php echo esc_attr( $taxonomy->name ); ?>"
-							<?php
-							if ( in_array( $taxonomy->name, $taxonomies_blacklist, true ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php echo esc_html( $taxonomy->labels->name . ' [' . $taxonomy->name . ']' ); ?>
-					</label> <?php endforeach; ?> <span class="description"><?php esc_html_e( "Select the taxonomies you don't want to be copied", 'duplicate-post' ); ?>
+								name="duplicate_post_taxonomies_blacklist[]"
+								id="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
+								value="<?php echo esc_attr( $taxonomy->name ); ?>"
+								<?php
+								if ( in_array( $taxonomy->name, $taxonomies_blacklist, true ) ) {
+									echo 'checked="checked"';
+								}
+								?>
+							/>
+							<label
+								for="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
+							>
+								<?php echo esc_html( $taxonomy->labels->name . ' [' . $taxonomy->name . ']' ); ?>
+							</label>
+						</span><br />
+					<?php endforeach; ?>
+					<span class="description"><?php esc_html_e( "Select the taxonomies you don't want to be copied", 'duplicate-post' ); ?>
 					</span></td>
 				</tr>
 			</table>
 		</section>
 		<section>
-			<table class="form-table">
+			<table class="form-table" role="presentation">
 				<?php if ( current_user_can( 'promote_users' ) ) { ?>
-				<tr valign="top">
+				<tr>
 					<th scope="row"><?php esc_html_e( 'Roles allowed to copy', 'duplicate-post' ); ?>
 					</th>
 					<td>
@@ -430,7 +472,7 @@ img#donate-button {
 					</span></td>
 				</tr>
 				<?php } ?>
-				<tr valign="top">
+				<tr>
 					<th scope="row"><?php esc_html_e( 'Enable for these post types', 'duplicate-post' ); ?>
 					</th>
 					<td>
@@ -457,8 +499,8 @@ img#donate-button {
 			</table>
 		</section>
 		<section>
-			<table class="form-table">
-				<tr valign="top">
+			<table class="form-table" role="presentation">
+				<tr>
 					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?>
 					</th>
 					<td><label><input type="checkbox" name="duplicate_post_show_row"
@@ -498,8 +540,8 @@ img#donate-button {
 							<?php } ?>
 					</td>
 				</tr>
-				<tr valign="top">
-					<td colspan="2"><span class="description"><?php esc_html_e( 'Whether the links are displayed for custom post types registered by themes or plugins depends on their use of standard WordPress UI elements', 'duplicate-post' ); ?>
+				<tr>
+					<td><span class="description"><?php esc_html_e( 'Whether the links are displayed for custom post types registered by themes or plugins depends on their use of standard WordPress UI elements', 'duplicate-post' ); ?>
 							<br />
 							<?php
 							/* translators: %s: URL of the template tag documentation */
@@ -507,7 +549,7 @@ img#donate-button {
 							?>
 					</span></td>
 				</tr>
-				<tr valign="top">
+				<tr>
 					<th scope="row"><?php esc_html_e( 'Show update notice', 'duplicate-post' ); ?>
 					</th>
 					<td><input type="checkbox" name="duplicate_post_show_notice"

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -121,7 +121,7 @@ function duplicate_post_options() {
 		jQuery('.nav-tab').removeClass('nav-tab-active');
 		jQuery(this).addClass('nav-tab-active');
 		jQuery('section').hide();
-		jQuery('section').eq(jQuery(this).index()).show();	
+		jQuery('section').eq(jQuery(this).index()).show();
 		return false;
 	});
 
@@ -136,37 +136,20 @@ function duplicate_post_options() {
 	</script>
 
 	<style>
-h2.nav-tab-wrapper {
+.nav-tab-wrapper {
 	margin: 22px 0 0 0;
 }
 
-h2 .nav-tab:focus {
-	color: #555;
-	box-shadow: none;
-}
-
-#sections {
-	padding: 22px;
-	background: #fff;
-	border: 1px solid #ccc;
-	border-top: 0;
-}
-
-section {
+.js section {
 	display: none;
 }
 
-section:first-of-type {
+.js section:first-of-type {
 	display: block;
 }
 
-.no-js h2.nav-tab-wrapper {
+.no-js .nav-tab-wrapper {
 	display: none;
-}
-
-.no-js #sections {
-	border-top: 1px solid #ccc;
-	margin-top: 22px;
 }
 
 .no-js section {
@@ -175,7 +158,7 @@ section:first-of-type {
 	padding-top: 22px;
 }
 
-.no-js section:first-child {
+.no-js section:first-of-type {
 	margin: 0;
 	padding: 0;
 	border: 0;
@@ -219,7 +202,7 @@ img#donate-button {
 					<th scope="row"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?>
 					</th>
 					<td colspan="2"><label> <input type="checkbox"
-							name="duplicate_post_copytitle" value="1" 
+							name="duplicate_post_copytitle" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copytitle' ) ) ) {
 								echo 'checked="checked"';}
@@ -227,7 +210,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Title', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copydate" value="1" 
+							name="duplicate_post_copydate" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copydate' ) ) ) {
 								echo 'checked="checked"';}
@@ -235,7 +218,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Date', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copystatus" value="1" 
+							name="duplicate_post_copystatus" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copystatus' ) ) ) {
 								echo 'checked="checked"';}
@@ -243,7 +226,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Status', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyslug" value="1" 
+							name="duplicate_post_copyslug" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copyslug' ) ) ) {
 								echo 'checked="checked"';}
@@ -251,7 +234,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Slug', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyexcerpt" value="1" 
+							name="duplicate_post_copyexcerpt" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copyexcerpt' ) ) ) {
 								echo 'checked="checked"';}
@@ -259,7 +242,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Excerpt', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copycontent" value="1" 
+							name="duplicate_post_copycontent" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copycontent' ) ) ) {
 								echo 'checked="checked"';}
@@ -267,7 +250,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Content', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copythumbnail" value="1" 
+							name="duplicate_post_copythumbnail" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copythumbnail' ) ) ) {
 								echo 'checked="checked"';}
@@ -275,7 +258,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Featured Image', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copytemplate" value="1" 
+							name="duplicate_post_copytemplate" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copytemplate' ) ) ) {
 								echo 'checked="checked"';}
@@ -283,7 +266,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Template', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyformat" value="1" 
+							name="duplicate_post_copyformat" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copyformat' ) ) ) {
 								echo 'checked="checked"';}
@@ -291,7 +274,7 @@ img#donate-button {
 />
 							<?php echo esc_html_x( 'Format', 'post format', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyauthor" value="1" 
+							name="duplicate_post_copyauthor" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copyauthor' ) ) ) {
 								echo 'checked="checked"';}
@@ -299,7 +282,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Author', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copypassword" value="1" 
+							name="duplicate_post_copypassword" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copypassword' ) ) ) {
 								echo 'checked="checked"';}
@@ -307,7 +290,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Password', 'default' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copyattachments" value="1" 
+							name="duplicate_post_copyattachments" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copyattachments' ) ) ) {
 								echo 'checked="checked"';}
@@ -315,7 +298,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Attachments', 'duplicate-post' ); ?> <small>(<?php esc_html_e( 'you probably want this unchecked, unless you have very special requirements', 'duplicate-post' ); ?>)</small>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copychildren" value="1" 
+							name="duplicate_post_copychildren" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copychildren' ) ) ) {
 								echo 'checked="checked"';}
@@ -323,7 +306,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Children', 'duplicate-post' ); ?>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copycomments" value="1" 
+							name="duplicate_post_copycomments" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copycomments' ) ) ) {
 								echo 'checked="checked"';}
@@ -331,7 +314,7 @@ img#donate-button {
 />
 							<?php esc_html_e( 'Comments', 'default' ); ?> <small>(<?php esc_html_e( 'except pingbacks and trackbacks', 'duplicate-post' ); ?>)</small>
 					</label> <label> <input type="checkbox"
-							name="duplicate_post_copymenuorder" value="1" 
+							name="duplicate_post_copymenuorder" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_copymenuorder' ) ) ) {
 								echo 'checked="checked"';}
@@ -379,7 +362,7 @@ img#donate-button {
 				</tr>
 				<tr valign="top">
 					<th scope="row"><?php esc_html_e( 'Do not copy these taxonomies', 'duplicate-post' ); ?><br />
-						<a class="toggle_link" href="#"
+						<a class="toggle_link hide-if-no-js" href="#"
 						onclick="toggle_private_taxonomies();return false;"><?php esc_html_e( 'Show/hide private taxonomies', 'duplicate-post' ); ?>
 					</a></th>
 					<td colspan="2">
@@ -479,33 +462,33 @@ img#donate-button {
 					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?>
 					</th>
 					<td><label><input type="checkbox" name="duplicate_post_show_row"
-							value="1" 
+							value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_show_row' ) ) ) {
 								echo 'checked="checked"';}
 							?>
 />
 							<?php esc_html_e( 'Post list', 'duplicate-post' ); ?> </label> <label><input
-							type="checkbox" name="duplicate_post_show_submitbox" value="1" 
+							type="checkbox" name="duplicate_post_show_submitbox" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_show_submitbox' ) ) ) {
 								echo 'checked="checked"';}
 							?>
 />
 							<?php esc_html_e( 'Edit screen', 'duplicate-post' ); ?> </label> <label><input
-							type="checkbox" name="duplicate_post_show_adminbar" value="1" 
+							type="checkbox" name="duplicate_post_show_adminbar" value="1"
 							<?php
 							if ( 1 === intval( get_option( 'duplicate_post_show_adminbar' ) ) ) {
 								echo 'checked="checked"';}
 							?>
 />
-							<?php esc_html_e( 'Admin bar', 'duplicate-post' ); ?> 
-							<small>(<?php esc_html_e( 'now works on Edit screen too - check this option to use with Gutenberg enabled', 'duplicate-post' ); ?>)</small></label> 
+							<?php esc_html_e( 'Admin bar', 'duplicate-post' ); ?>
+							<small>(<?php esc_html_e( 'now works on Edit screen too - check this option to use with Gutenberg enabled', 'duplicate-post' ); ?>)</small></label>
 							<?php
 							if ( version_compare( $wp_version, '4.7' ) >= 0 ) {
 								?>
 													<label><input type="checkbox"
-													name="duplicate_post_show_bulkactions" value="1" 
+													name="duplicate_post_show_bulkactions" value="1"
 													<?php
 													if ( 1 === intval( get_option( 'duplicate_post_show_bulkactions' ) ) ) {
 														echo 'checked="checked"';}
@@ -528,7 +511,7 @@ img#donate-button {
 					<th scope="row"><?php esc_html_e( 'Show update notice', 'duplicate-post' ); ?>
 					</th>
 					<td><input type="checkbox" name="duplicate_post_show_notice"
-						value="1" 
+						value="1"
 						<?php
 						if ( 1 === intval( get_option( 'duplicate_post_show_notice' ) ) ) {
 							echo 'checked="checked"';}

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -197,8 +197,7 @@ img#donate-button {
 
 			<table class="form-table" role="presentation">
 				<tr>
-					<th scope="row"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?>
-					</th>
+					<th scope="row"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?></th>
 					<td>
 						<fieldset>
 							<legend class="screen-reader-text"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?></legend>
@@ -341,7 +340,7 @@ img#donate-button {
 								?>
 							/>
 							<label for="duplicate-post-copymenuorder"><?php esc_html_e( 'Menu order', 'default' ); ?></label>
-						<fieldset>
+						</fieldset>
 					</td>
 				</tr>
 				<tr>
@@ -429,9 +428,7 @@ img#donate-button {
 									}
 									?>
 								/>
-								<label
-									for="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>"
-								>
+								<label for="duplicate-post-<?php echo esc_attr( $taxonomy->name ); ?>">
 									<?php echo esc_html( $taxonomy->labels->name . ' [' . $taxonomy->name . ']' ); ?>
 								</label><br />
 							</div>
@@ -451,122 +448,165 @@ img#donate-button {
 					<th scope="row"><?php esc_html_e( 'Roles allowed to copy', 'duplicate-post' ); ?>
 					</th>
 					<td>
-					<?php
+						<fieldset>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Roles allowed to copy', 'duplicate-post' ); ?></legend>
+							<?php
 
-					$roles             = $wp_roles->get_names();
-					$post_types        = get_post_types( array( 'show_ui' => true ), 'objects' );
-					$edit_capabilities = array( 'edit_posts' => true );
-					foreach ( $post_types as $post_type ) {
-						$edit_capabilities[ $post_type->cap->edit_posts ] = true;
-					}
-					foreach ( $roles as $name => $display_name ) :
-						$role = get_role( $name );
-						if ( count( array_intersect_key( $role->capabilities, $edit_capabilities ) ) > 0 ) :
-							?>
-			<label> <input type="checkbox"	name="duplicate_post_roles[]" value="<?php echo esc_attr( $name ); ?>"
-							<?php
-							if ( $role->has_cap( 'copy_posts' ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php echo esc_html( translate_user_role( $display_name ) ); ?>
-					</label>
-							<?php
-							endif;
+							$roles             = $wp_roles->get_names();
+							$post_types        = get_post_types( array( 'show_ui' => true ), 'objects' );
+							$edit_capabilities = array( 'edit_posts' => true );
+							foreach ( $post_types as $post_type ) {
+								$edit_capabilities[ $post_type->cap->edit_posts ] = true;
+							}
+							foreach ( $roles as $name => $display_name ) :
+								$role = get_role( $name );
+								if ( count( array_intersect_key( $role->capabilities, $edit_capabilities ) ) > 0 ) :
+									?>
+							<input type="checkbox"
+								name="duplicate_post_roles[]"
+								id="duplicate-post-<?php echo esc_attr( $name ); ?>"
+								value="<?php echo esc_attr( $name ); ?>"
+									<?php
+									if ( $role->has_cap( 'copy_posts' ) ) {
+										echo 'checked="checked"';}
+									?>
+							/>
+							<label for="duplicate-post-<?php echo esc_attr( $name ); ?>"><?php echo esc_html( translate_user_role( $display_name ) ); ?></label><br />
+									<?php
+								endif;
 							endforeach;
-					?>
-					<span class="description"><?php esc_html_e( 'Warning: users will be able to copy all posts, even those of other users', 'duplicate-post' ); ?><br />
-							<?php esc_html_e( 'Passwords and contents of password-protected posts may become visible to undesired users and visitors', 'duplicate-post' ); ?>
-					</span></td>
+							?>
+							<p>
+								<?php esc_html_e( 'Warning: users will be able to copy all posts, even those of other users.', 'duplicate-post' ); ?><br />
+								<?php esc_html_e( 'Passwords and contents of password-protected posts may become visible to undesired users and visitors.', 'duplicate-post' ); ?>
+							</p>
+						</fieldset>
+					</td>
 				</tr>
 				<?php } ?>
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Enable for these post types', 'duplicate-post' ); ?>
 					</th>
 					<td>
-					<?php
-					$post_types = get_post_types( array( 'show_ui' => true ), 'objects' );
-					foreach ( $post_types as $post_type_object ) :
-						if ( 'attachment' === $post_type_object->name ) {
-							continue;
-						}
-						?>
-		<label> <input type="checkbox"
-							name="duplicate_post_types_enabled[]"
-							value="<?php echo esc_attr( $post_type_object->name ); ?>"
+						<fieldset>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Enable for these post types', 'duplicate-post' ); ?></legend>
 							<?php
-							if ( duplicate_post_is_post_type_enabled( $post_type_object->name ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php echo esc_html( $post_type_object->labels->name ); ?>
-					</label> <?php endforeach; ?> <span class="description"><?php esc_html_e( 'Select the post types you want the plugin to be enabled', 'duplicate-post' ); ?>
-							<br /> <?php esc_html_e( 'Whether the links are displayed for custom post types registered by themes or plugins depends on their use of standard WordPress UI elements', 'duplicate-post' ); ?>
-					</span></td>
+							$post_types = get_post_types( array( 'show_ui' => true ), 'objects' );
+							foreach ( $post_types as $post_type_object ) :
+								if ( 'attachment' === $post_type_object->name ) {
+									continue;
+								}
+								?>
+							<input type="checkbox"
+								name="duplicate_post_types_enabled[]"
+								id="duplicate-post-<?php echo esc_attr( $post_type_object->name ); ?>"
+								value="<?php echo esc_attr( $post_type_object->name ); ?>"
+								<?php
+								if ( duplicate_post_is_post_type_enabled( $post_type_object->name ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-<?php echo esc_attr( $post_type_object->name ); ?>"><?php echo esc_html( $post_type_object->labels->name ); ?></label><br />
+							<?php endforeach; ?>
+							<p>
+								<?php esc_html_e( 'Select the post types you want the plugin to be enabled for.', 'duplicate-post' ); ?><br />
+								<?php esc_html_e( 'Whether the links are displayed for custom post types registered by themes or plugins depends on their use of standard WordPress UI elements.', 'duplicate-post' ); ?>
+							</p>
+						</fieldset>
+					</td>
 				</tr>
 			</table>
 		</section>
 		<section>
 			<table class="form-table" role="presentation">
 				<tr>
-					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?>
-					</th>
-					<td><label><input type="checkbox" name="duplicate_post_show_row"
-							value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_show_row' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Post list', 'duplicate-post' ); ?> </label> <label><input
-							type="checkbox" name="duplicate_post_show_submitbox" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_show_submitbox' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Edit screen', 'duplicate-post' ); ?> </label> <label><input
-							type="checkbox" name="duplicate_post_show_adminbar" value="1"
-							<?php
-							if ( 1 === intval( get_option( 'duplicate_post_show_adminbar' ) ) ) {
-								echo 'checked="checked"';}
-							?>
-/>
-							<?php esc_html_e( 'Admin bar', 'duplicate-post' ); ?>
-							<small>(<?php esc_html_e( 'now works on Edit screen too - check this option to use with Gutenberg enabled', 'duplicate-post' ); ?>)</small></label>
+					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?></th>
+					<td>
+						<fieldset>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?></legend>
+							<input
+								type="checkbox"
+								name="duplicate_post_show_row"
+								id="duplicate-post-show-row"
+								value="1"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_show_row' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-show-row"><?php esc_html_e( 'Post list', 'duplicate-post' ); ?></label><br />
+							<input
+								type="checkbox"
+								name="duplicate_post_show_submitbox"
+								id="duplicate-post-show-submitbox"
+								value="1"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_show_submitbox' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-show-submitbox"><?php esc_html_e( 'Edit screen', 'duplicate-post' ); ?></label><br />
+							<input
+								type="checkbox"
+								name="duplicate_post_show_adminbar"
+								id="duplicate-post-show-adminbar"
+								aria-describedby="duplicate-post-show-adminbar-description"
+								value="1"
+								<?php
+								if ( 1 === intval( get_option( 'duplicate_post_show_adminbar' ) ) ) {
+									echo 'checked="checked"';}
+								?>
+							/>
+							<label for="duplicate-post-show-adminbar"><?php esc_html_e( 'Admin bar', 'duplicate-post' ); ?></label>
+							<span id="duplicate-post-show-adminbar-description">(<?php esc_html_e( 'now works on Edit screen too - check this option to use with Gutenberg enabled', 'duplicate-post' ); ?>)</span><br />
 							<?php
 							if ( version_compare( $wp_version, '4.7' ) >= 0 ) {
 								?>
-													<label><input type="checkbox"
-													name="duplicate_post_show_bulkactions" value="1"
-													<?php
-													if ( 1 === intval( get_option( 'duplicate_post_show_bulkactions' ) ) ) {
-														echo 'checked="checked"';}
-													?>
-/>
-								<?php esc_html_e( 'Bulk Actions', 'default' ); ?> </label>
+								<input
+									type="checkbox"
+									name="duplicate_post_show_bulkactions"
+									id="duplicate-post-show-bulkactions"
+									value="1"
+									<?php
+									if ( 1 === intval( get_option( 'duplicate_post_show_bulkactions' ) ) ) {
+										echo 'checked="checked"';}
+									?>
+								/>
+								<label for="duplicate-post-show-bulkactions"><?php esc_html_e( 'Bulk Actions', 'default' ); ?></label>
 							<?php } ?>
+						</fieldset>
+						<p>
+							<?php esc_html_e( 'Whether the links are displayed for custom post types registered by themes or plugins depends on their use of standard WordPress UI elements.', 'duplicate-post' ); ?>
+							<br />
+							<?php
+							printf(
+								/* translators: 1: Code start tag, 2: Code closing tag, 3: Link start tag to the template tag documentation, 4: Link closing tag. */
+								esc_html__( 'You can also use the template tag %1$sduplicate_post_clone_post_link( $link, $before, $after, $id )%2$s. %3$sMore info on the template tag%4$s.', 'duplicate-post' ),
+								'<code>',
+								'</code>',
+								'<a href="' . esc_url( 'https://duplicate-post.lopo.it/docs/developers-guide/functions-template-tags/duplicate_post_clone_post_link/' ) . '">',
+								'</a>'
+							);
+							?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<td><span class="description"><?php esc_html_e( 'Whether the links are displayed for custom post types registered by themes or plugins depends on their use of standard WordPress UI elements', 'duplicate-post' ); ?>
-							<br />
-							<?php
-							/* translators: %s: URL of the template tag documentation */
-							printf( esc_html__( 'You can also use the template tag duplicate_post_clone_post_link( $link, $before, $after, $id ). More info <a href="%s">here</a>', 'duplicate-post' ), 'https://duplicate-post.lopo.it/docs/developers-guide/functions-template-tags/duplicate_post_clone_post_link/' );
-							?>
-					</span></td>
-				</tr>
-				<tr>
-					<th scope="row"><?php esc_html_e( 'Show update notice', 'duplicate-post' ); ?>
+					<th scope="row"><?php esc_html_e( 'Update notice', 'duplicate-post' ); ?>
 					</th>
-					<td><input type="checkbox" name="duplicate_post_show_notice"
-						value="1"
-						<?php
-						if ( 1 === intval( get_option( 'duplicate_post_show_notice' ) ) ) {
-							echo 'checked="checked"';}
-						?>
-/>
+					<td>
+						<input
+							type="checkbox"
+							name="duplicate_post_show_notice"
+							id="duplicate-post-show-notice"
+							value="1"
+							<?php
+							if ( 1 === intval( get_option( 'duplicate_post_show_notice' ) ) ) {
+								echo 'checked="checked"';
+							}
+							?>
+						/>
+						<label for="duplicate-post-show-notice"><?php esc_html_e( 'Show update notice', 'duplicate-post' ); ?></label>
 					</td>
 				</tr>
 			</table>

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -129,7 +129,6 @@ function duplicate_post_options() {
 			.on( 'click', function() {
 				buttonElement = jQuery( this );
 				jQuery( '.taxonomy_private' ).toggle( 300, function() {
-					console.log( 'expanded done', buttonElement );
 					buttonElement.attr( 'aria-expanded', jQuery( this ).is( ":visible" ) );
 				} );
 			} );

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -43,7 +43,7 @@ function duplicate_post_load_plugin_textdomain() {
 }
 add_action( 'plugins_loaded', 'duplicate_post_load_plugin_textdomain' );
 
-add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'duplicate_post_plugin_actions', 10, 4 );
+add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'duplicate_post_plugin_actions', 10 );
 
 /**
  * Adds 'Settings' link to plugin entry in the Plugins list.
@@ -51,17 +51,20 @@ add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'duplicate_pos
  * @ignore
  * @see 'plugin_action_links_$plugin_file'
  *
- * @param array  $actions An array of plugin action links.
- * @param string $plugin_file Path to the plugin file relative to the plugins directory.
- * @param array  $plugin_data An array of plugin data.
- * @param string $context The plugin context.
+ * @param array $actions An array of plugin action links.
  * @return array
  */
-function duplicate_post_plugin_actions( $actions, $plugin_file, $plugin_data, $context ) {
-	array_unshift(
-		$actions,
-		'<a href="' . menu_page_url( 'duplicatepost', false ) . '">' . esc_html__( 'Settings', 'default' ) . '</a>'
+function duplicate_post_plugin_actions( $actions ) {
+	$settings_action = array(
+		'settings' => sprintf(
+			'<a href="%1$s" %2$s>%3$s</a>',
+			menu_page_url( 'duplicatepost', false ),
+			'aria-label="' . __( 'Settings for Duplicate Post', 'duplicate-post' ) . '"',
+			esc_html__( 'Settings', 'default' )
+		),
 	);
+
+	$actions = $settings_action + $actions;
 	return $actions;
 }
 


### PR DESCRIPTION
This PR seeks to improve accessibility on the plugin Settings pages:

Note: needs to be rebased onto the `svntrunk` branch

- associates `<label>` elements with all form controls via for/id attributes
- groups checkboxes in `<fieldset>` elements with a visually hidden `<legend>` element
- adds `aria-describedby` attributes to associate some descriptions to their form fields
- adds aria-expanded to the button to toggle private taxonomies visibility
- also, this was a link with a `href="#"` attribute and now it's a button
- minor CSS improvements
- improves the "Settings" link on the Plugins overview page 
- git-ignores the `/vendor/` directory 
- note that my editor automatically removes trailing spaces so you will find unrelated changes to some lines, for a good reason 

Note: the 3 tabs content panels are wrapped in `<section>` elements. We may want to consider to remove the sections later, as they're not ideal for this usage (they also lack a required heading).

## To test
- clone this repo in your WordPress plugins directory and activate the plugin
- go to Settings > Duplicate Post
- check all the form controls within the 3 tabs have properly associated labels: you can do this by clicking on the labels and verifying the associated form control gets focused
- check everything works as expected