### PR TITLE
Second round of accessibility improvements.

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -215,7 +215,7 @@ function duplicate_post_show_update_notice() {
 	) . '</strong><br/>';
 	$message .= __( 'Simple compatibility with Gutenberg user interface: enable "Admin bar" under the Settings', 'duplicate-post' ) . ' — '
 			. __( '"Slug" option unset by default on new installations', 'duplicate-post' ) . '<br/>';
-	$message .= '<em><a href="https://duplicate-post.lopo.it/" title="Duplicate Post official site">' . __( 'Check out the documentation', 'duplicate-post' ) . '</a> — ' . sprintf(
+	$message .= '<em><a href="https://duplicate-post.lopo.it/">' . __( 'Check out the documentation', 'duplicate-post' ) . '</a> — ' . sprintf(
 		/* translators: %s: Options page URL */
 		__( 'Please <a href="%s">review the settings</a> to make sure it works as you expect.', 'duplicate-post' ),
 		admin_url( 'options-general.php?page=duplicatepost' )
@@ -253,7 +253,7 @@ function duplicate_post_show_update_notice() {
 					jQuery('#duplicate-post-notice').hide();
 				});
 			}
-	
+
 			jQuery(document).ready(function(){
 				jQuery('body').on('click', '.notice-dismiss', function(){
 					duplicate_post_dismiss_notice();
@@ -280,6 +280,8 @@ function duplicate_post_dismiss_notice() {
  * @return array.
  */
 function duplicate_post_make_duplicate_link_row( $actions, $post ) {
+	$title = empty( $post->post_title ) ? __( '(no title)', 'duplicate-post' ) : $post->post_title;
+
 	/**
 	 * Filter allowing displaying duplicate post link for current post.
 	 *
@@ -289,10 +291,19 @@ function duplicate_post_make_duplicate_link_row( $actions, $post ) {
 	 * @return boolean
 	 */
 	if ( apply_filters( 'duplicate_post_show_link', duplicate_post_is_current_user_allowed_to_copy() && duplicate_post_is_post_type_enabled( $post->post_type ), $post ) ) {
-		$actions['clone']             = '<a href="' . duplicate_post_get_clone_post_link( $post->ID, 'display', false ) . '" title="' .
-			esc_attr__( 'Clone this item', 'duplicate-post' ) . '">' . esc_html__( 'Clone', 'duplicate-post' ) . '</a>';
-		$actions['edit_as_new_draft'] = '<a href="' . duplicate_post_get_clone_post_link( $post->ID ) . '" title="' .
-			esc_attr__( 'Copy to a new draft', 'duplicate-post' ) . '">' . esc_html__( 'New Draft', 'duplicate-post' ) .
+		$actions['clone'] = '<a href="' . duplicate_post_get_clone_post_link( $post->ID, 'display', false ) .
+			'" aria-label="' . esc_attr(
+				/* translators: %s: Post title. */
+				sprintf( __( 'Clone &#8220;%s&#8221;', 'duplicate-post' ), $title )
+			) . '">' .
+			esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
+
+		$actions['edit_as_new_draft'] = '<a href="' . duplicate_post_get_clone_post_link( $post->ID ) .
+			'" aria-label="' . esc_attr(
+				/* translators: %s: Post title. */
+				sprintf( __( 'New draft of &#8220;%s&#8221;', 'duplicate-post' ), $title )
+			) . '">' .
+			esc_html__( 'New Draft', 'duplicate-post' ) .
 			'</a>';
 	}
 	return $actions;
@@ -770,10 +781,14 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 		}
 		$title = trim( $prefix . $title . $suffix );
 
-		if ( '' === $title ) {
-			// empty title.
-			$title = __( 'Untitled', 'default' );
-		}
+		/*
+		 * Not sure we should force a title. Instead, we should respect what WP does.
+		 * if ( '' === $title ) {
+		 * 	// empty title.
+		 * 	$title = __( 'Untitled', 'default' );
+		 * }
+		 */
+
 		if ( 0 === intval( get_option( 'duplicate_post_copystatus' ) ) ) {
 			$new_post_status = 'draft';
 		} else {
@@ -906,7 +921,7 @@ function duplicate_post_action_admin_notice() {
 	if ( ! empty( $_REQUEST['cloned'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 		$copied_posts = intval( $_REQUEST['cloned'] ); // phpcs:ignore WordPress.Security.NonceVerification
 		printf(
-			'<div id="message" class="updated fade"><p>' .
+			'<div id="message" class="notice notice-success fade"><p>' .
 				esc_html(
 					/* translators: %s: Number of posts copied. */
 					_n(

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -97,8 +97,7 @@ function duplicate_post_clone_post_link( $link = null, $before = '', $after = ''
 		$link = esc_html__( 'Copy to a new draft', 'duplicate-post' );
 	}
 
-	$link = '<a class="post-clone-link" href="' . $url . '" title="' .
-		esc_attr__( 'Copy to a new draft', 'duplicate-post' ) . '">' . $link . '</a>';
+	$link = '<a class="post-clone-link" href="' . $url . '">' . $link . '</a>';
 	echo esc_html( $before . apply_filters( 'duplicate_post_clone_post_link', $link, $post->ID ) . $after );
 }
 


### PR DESCRIPTION
In this PR:

Note: needs to be rebased onto the `svntrunk` branch.

- improved the row-action links in the Posts and Pages overview by adding `aria-label` attributes
- removed redundant `title` attributes 
- post with no post title should stay with no title when cloned (please double check this)
- made sure to use the WordPress default string "(no title)" instead of "Untitled" 
- removed the legacy CSS class `updated` in favor of `notice notice-success`

## To test:
- in the Posts / Pages overview pages, make sure the "Clone" and "New Draft" row action links do have `aria-label` attributes that contain the post title
- create a post with no title
- clone the post
- observe the cloned post is still with no title
  - keep in mind WordPress adds a `(no title)` string in the Posts overview, but that's only for visual purposes: actually, the post has no title
- check the removed `title` attributes in this PR and double check they didn't add any relevant information