### PR TITLE
Enqueue CSS file for Quick Edit (#17)

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -289,16 +289,25 @@ function duplicate_post_quick_edit_remove_original( $column_name, $post_type ) {
 	}
 
 	printf(
-'<fieldset class="inline-edit-col-right" id="duplicate_post_quick_edit_fieldset">
+'<fieldset class="inline-edit-col-left" id="duplicate_post_quick_edit_fieldset">
 			<div class="inline-edit-col">
-        		<label class="alignleft">
-					<input type="checkbox" name="duplicate_post_remove_original" value="duplicate_post_remove_original">
+                <input type="checkbox" 
+                name="duplicate_post_remove_original" 
+                id="duplicate-post-remove-original" 
+                value="duplicate_post_remove_original"
+                aria-describedby="duplicate-post-remove-original-description">
+                <label for="duplicate-post-remove-original">
 					<span class="checkbox-title">%s</span>
 				</label>
+				<span id="duplicate-post-remove-original-description" class="checkbox-title">%s</span>
 			</div>
 		</fieldset>',
 		__(
-			'Delete reference to original item: <span class="duplicate_post_original_item_title_span"></span>',
+			'Delete reference to original item.',
+			'duplicate-post'
+			),
+        __(
+			'The original item this was copied from is: <span class="duplicate_post_original_item_title_span"></span>',
 			'duplicate-post'
 			)
 	);
@@ -351,10 +360,20 @@ function duplicate_post_custom_box_html( $post ) {
 	$original_item = duplicate_post_get_original( $post->ID );
 	if ( $original_item ) {
 	?>
-	<label>
-		<input type="checkbox" name="duplicate_post_remove_original" value="duplicate_post_remove_original">
-		<?php printf( __( 'Delete reference to original item: <span class="duplicate_post_original_item_title_span">%s</span>', 'duplicate-post' ), duplicate_post_get_edit_or_view_link( $original_item ) ); ?>
-	</label>
+    <p>
+        <input type="checkbox"
+               name="duplicate_post_remove_original"
+               id="duplicate-post-remove-original"
+               value="duplicate_post_remove_original"
+               aria-describedby="duplicate-post-remove-original-description">
+        <label for="duplicate-post-remove-original">
+            <?php esc_html_e( 'Delete reference to original item.', 'duplicate-post' ); ?>
+        </label>
+    </p>
+    <p id="duplicate-post-remove-original-description">
+        <?php printf( __( 'The original item this was copied from is: <span class="duplicate_post_original_item_title_span">%s</span>', 'duplicate-post' ), duplicate_post_get_edit_or_view_link( $original_item ) ); ?>
+    </p>
+
 	<?php
 	} else { ?>
 		<script>

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -186,6 +186,10 @@ function duplicate_post_admin_bar_render() {
 	}
 }
 
+function duplicate_post_enqueue_css() {
+	wp_enqueue_style ( 'duplicate-post', plugins_url('/duplicate-post.css', __FILE__), array(), DUPLICATE_POST_CURRENT_VERSION );
+}
+
 function duplicate_post_add_css() {
 	if(!is_admin_bar_showing()) return;
 	$current_object = get_queried_object();
@@ -196,7 +200,7 @@ function duplicate_post_add_css() {
 			&& ( $post_type_object->show_ui || 'attachment' == $current_object->post_type )
 			&& (duplicate_post_is_post_type_enabled($current_object->post_type) ) )
 		{
-			wp_enqueue_style ( 'duplicate-post', plugins_url('/duplicate-post.css', __FILE__), array(), DUPLICATE_POST_CURRENT_VERSION );
+			duplicate_post_enqueue_css();
 		}
 	} else if ( is_admin() && isset( $_GET['post'] )){
 		$id = $_GET['post'];
@@ -204,11 +208,25 @@ function duplicate_post_add_css() {
 		if( !is_null($post)
 				&& duplicate_post_is_current_user_allowed_to_copy()
 				&& duplicate_post_is_post_type_enabled($post->post_type)) {
-					wp_enqueue_style ( 'duplicate-post', plugins_url('/duplicate-post.css', __FILE__), array(), DUPLICATE_POST_CURRENT_VERSION );
+					duplicate_post_enqueue_css();
 				}
 	}
 }
 
+function duplicate_post_add_css_to_post_list() {
+	if ( is_admin() ) {
+		$current_screen = get_current_screen();
+		if ( ! is_null( $current_screen ) ) {
+			if ( 'edit' === $current_screen->base ) {
+				$post_type = $current_screen->post_type;
+				if ( duplicate_post_is_current_user_allowed_to_copy()
+				     && duplicate_post_is_post_type_enabled( $post_type ) ) {
+					duplicate_post_enqueue_css();
+				}
+			}
+		}
+	}
+}
 
 add_action('init', 'duplicate_post_init');
 
@@ -218,6 +236,7 @@ function duplicate_post_init(){
 		add_action ( 'wp_enqueue_scripts', 'duplicate_post_add_css' );
 		add_action ( 'admin_enqueue_scripts', 'duplicate_post_add_css' );
 	}
+	add_action ( 'admin_enqueue_scripts', 'duplicate_post_add_css_to_post_list' );
 }
 
 /**

--- a/duplicate-post.css
+++ b/duplicate-post.css
@@ -7,7 +7,7 @@
 	#wpadminbar li#wp-admin-bar-new_draft{
 		display: block;
 	}
-	
+
 	#wpadminbar #wp-admin-bar-new_draft > .ab-item {
     	text-indent: 100%;
     	white-space: nowrap;
@@ -17,7 +17,7 @@
     	color: #999;
     	position: relative;
 	}
-	
+
 	#wpadminbar #wp-admin-bar-new_draft > .ab-item::before {
     	display: block;
     	text-indent: 0;
@@ -29,4 +29,18 @@
     	-webkit-font-smoothing: antialiased;
     	-moz-osx-font-smoothing: grayscale;
 	}
+}
+
+fieldset#duplicate_post_quick_edit_fieldset{
+	clear: both;
+}
+
+fieldset#duplicate_post_quick_edit_fieldset label{
+	display: inline;
+	margin: 0;
+	vertical-align: unset;
+}
+
+fieldset#duplicate_post_quick_edit_fieldset a{
+	text-decoration: underline;
 }


### PR DESCRIPTION
In this PR:

* improved accessibility of the checkbox "Delete reference to original item" in the Quick Edit and in the Metabox
* added the styles to the CSS file to improve the display of the checkbox in the Quick Edit
* added an action to enqueue the CSS file in the post list (for allowed users and allowed post types)

### To Test:
* in the Posts / Pages overview pages, clone a post/page using e.g. the row action "Clone" link
* open the Quick Edit for the copy and look at the "Delete reference to original item" checkbox, label and description:
  * they should be accessible
  * they should be displayed in the same line and with correct alignment

Must be also check that `duplicate-post.css` is enqueued (and then requested to the server) only if all these conditions are true:
* the user can perform duplication (Duplicate Post settings, second tab)
* items of the current post type can be duplicated (Duplicate Post settings, second tab)
* one of the following is true:
  * you are looking at a single post in the frontend, the toolbar is displayed (you are logged in + your profile doesn't hide the toolbar), and the settings for displaying a link in the toolbar (Duplicate Post settings, third tab) is checked
  * you are editing at a single post and the settings for displaying a link in the toolbar (Duplicate Post settings, third tab) is checked
  * you are looking at the Posts / Pages / Custom type items list