### PR TITLE
Porting "Show original" from svntrunk + some a11y fixes

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -349,7 +349,7 @@ function duplicate_post_show_original_item( $column_name, $post_id ) {
  * @param string $post_type    The post type for the current post.
  */
 function duplicate_post_quick_edit_remove_original( $column_name, $post_type ) {
-	if ( 'duplicate_post_original_item' != $column_name ) {
+	if ( 'duplicate_post_original_item' !== $column_name ) {
 		return;
 	}
 	echo esc_html(

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -352,19 +352,33 @@ function duplicate_post_quick_edit_remove_original( $column_name, $post_type ) {
 	if ( 'duplicate_post_original_item' !== $column_name ) {
 		return;
 	}
-	echo esc_html(
-		sprintf(
-			'<fieldset class="inline-edit-col-right" id="duplicate_post_quick_edit_fieldset">
-						<div class="inline-edit-col">
-							<label class="alignleft">
-							<input type="checkbox" name="duplicate_post_remove_original" value="duplicate_post_remove_original">
-								<span class="checkbox-title">%s</span>
-							</label>
-						</div>
-					</fieldset>',
+	printf(
+		'<fieldset class="inline-edit-col-left" id="duplicate_post_quick_edit_fieldset">
+			<div class="inline-edit-col">
+                <input type="checkbox" 
+                name="duplicate_post_remove_original" 
+                id="duplicate-post-remove-original" 
+                value="duplicate_post_remove_original"
+                aria-describedby="duplicate-post-remove-original-description">
+                <label for="duplicate-post-remove-original">
+					<span class="checkbox-title">%s</span>
+				</label>
+				<span id="duplicate-post-remove-original-description" class="checkbox-title">%s</span>
+			</div>
+		</fieldset>',
+		esc_html__(
+			'Delete reference to original item.',
+			'duplicate-post'
+		),
+		wp_kses(
 			__(
-				'Delete reference to original item: <span class="duplicate_post_original_item_title_span"></span>',
+				'The original item this was copied from is: <span class="duplicate_post_original_item_title_span"></span>',
 				'duplicate-post'
+			),
+			array(
+				'span' => array(
+					'class' => array(),
+				),
 			)
 		)
 	);
@@ -455,21 +469,35 @@ function duplicate_post_custom_box_html( $post ) {
 	$original_item = duplicate_post_get_original( $post->ID );
 	if ( $original_item ) {
 		?>
-	<label>
-		<input type="checkbox" name="duplicate_post_remove_original" value="duplicate_post_remove_original">
+	<p>
+		<input type="checkbox"
+			name="duplicate_post_remove_original"
+			id="duplicate-post-remove-original"
+			value="duplicate_post_remove_original"
+			aria-describedby="duplicate-post-remove-original-description">
+		<label for="duplicate-post-remove-original">
+			<?php esc_html_e( 'Delete reference to original item.', 'duplicate-post' ); ?>
+		</label>
+	</p>
+	<p id="duplicate-post-remove-original-description">
 		<?php
-		echo esc_html(
-			sprintf(
+		printf(
+			wp_kses(
 				/* translators: %s: post title */
 				__(
-					'Delete reference to original item: <span class="duplicate_post_original_item_title_span">%s</span>',
+					'The original item this was copied from is: <span class="duplicate_post_original_item_title_span">%s</span>',
 					'duplicate-post'
 				),
-				duplicate_post_get_edit_or_view_link( $original_item )
-			)
+				array(
+					'span' => array(
+						'class' => array(),
+					),
+				)
+			),
+			duplicate_post_get_edit_or_view_link( $original_item )  // phpcs:ignore WordPress.Security.EscapeOutput
 		);
 		?>
-	</label>
+	</p>
 		<?php
 	} else {
 		?>

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -198,11 +198,11 @@ function duplicate_post_is_post_type_viewable( $post_type ) {
  * Shows link in the Toolbar.
  *
  * @global WP_Query $wp_the_query.
- *
- * @param WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
+ * @global WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
  */
-function duplicate_post_admin_bar_render( $wp_admin_bar ) {
+function duplicate_post_admin_bar_render() {
 	global $wp_the_query;
+	global $wp_admin_bar;
 
 	if ( is_admin() ) {
 		$current_screen = get_current_screen();
@@ -265,6 +265,15 @@ function duplicate_post_admin_bar_render( $wp_admin_bar ) {
 }
 
 /**
+ * Enqueues the CSS file for Toolbar and Quick Edit display.
+ *
+ * @ignore
+ */
+function duplicate_post_enqueue_css() {
+	wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ), array(), DUPLICATE_POST_CURRENT_VERSION );
+}
+
+/**
  * Links stylesheet for Toolbar link.
  *
  * @global WP_Query $wp_the_query.
@@ -298,7 +307,7 @@ function duplicate_post_add_css() {
 			&& ( $post_type_object->public )
 			&& ( $post_type_object->show_in_admin_bar )
 			&& ( duplicate_post_is_post_type_enabled( $post->post_type ) ) ) {
-			wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ), array(), DUPLICATE_POST_CURRENT_VERSION );
+			duplicate_post_enqueue_css();
 		}
 	} else {
 		$current_object = $wp_the_query->get_queried_object();
@@ -319,7 +328,25 @@ function duplicate_post_add_css() {
 			&& duplicate_post_is_current_user_allowed_to_copy()
 			&& ( $post_type_object->show_in_admin_bar )
 			&& ( duplicate_post_is_post_type_enabled( $current_object->post_type ) ) ) {
-			wp_enqueue_style( 'duplicate-post', plugins_url( '/duplicate-post.css', __FILE__ ), array(), DUPLICATE_POST_CURRENT_VERSION );
+			duplicate_post_enqueue_css();
+		}
+	}
+}
+
+/**
+ * Links stylesheet for Quick Edit fieldset.
+ */
+function duplicate_post_add_css_to_post_list() {
+	if ( is_admin() ) {
+		$current_screen = get_current_screen();
+		if ( ! is_null( $current_screen ) ) {
+			if ( 'edit' === $current_screen->base ) {
+				$post_type = $current_screen->post_type;
+				if ( duplicate_post_is_current_user_allowed_to_copy()
+					&& duplicate_post_is_post_type_enabled( $post_type ) ) {
+					duplicate_post_enqueue_css();
+				}
+			}
 		}
 	}
 }
@@ -335,6 +362,7 @@ function duplicate_post_init() {
 		add_action( 'wp_enqueue_scripts', 'duplicate_post_add_css' );
 		add_action( 'admin_enqueue_scripts', 'duplicate_post_add_css' );
 	}
+	add_action( 'admin_enqueue_scripts', 'duplicate_post_add_css_to_post_list' );
 }
 
 /**

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -139,7 +139,7 @@ function duplicate_post_get_edit_or_view_link( $post ) {
 	$title            = _draft_or_post_title( $post );
 	$post_type_object = get_post_type_object( $post->post_type );
 
-	if ( $can_edit_post && 'trash' != $post->post_status ) {
+	if ( $can_edit_post && 'trash' !== $post->post_status ) {
 		return sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
 			get_edit_post_link( $post->ID ),
@@ -150,7 +150,7 @@ function duplicate_post_get_edit_or_view_link( $post ) {
 	} elseif ( duplicate_post_is_post_type_viewable( $post_type_object ) ) {
 		if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ) ) ) {
 			if ( $can_edit_post ) {
-				$preview_link    = get_preview_post_link( $post );
+				$preview_link = get_preview_post_link( $post );
 				return sprintf(
 					'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
 					esc_url( $preview_link ),
@@ -159,7 +159,7 @@ function duplicate_post_get_edit_or_view_link( $post ) {
 					$title
 				);
 			}
-		} elseif ( 'trash' != $post->post_status ) {
+		} elseif ( 'trash' !== $post->post_status ) {
 			return sprintf(
 				'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
 				get_permalink( $post->ID ),

--- a/duplicate-post-options.css
+++ b/duplicate-post-options.css
@@ -1,0 +1,46 @@
+#duplicate_post_settings_form header.nav-tab-wrapper {
+	margin: 22px 0 0 0;
+}
+
+#duplicate_post_settings_form header .nav-tab{
+	cursor: pointer;
+}
+
+#duplicate_post_settings_form header .nav-tab:focus {
+	color: #555;
+	box-shadow: none;
+	outline: 1px dotted #000000;
+}
+
+.no-js #duplicate_post_settings_form header.nav-tab-wrapper {
+	display: none;
+}
+
+.no-js #duplicate_post_settings_form section {
+	border-top: 1px dashed #aaa;
+	margin-top: 22px;
+	padding-top: 22px;
+}
+
+.no-js #duplicate_post_settings_form section:first-of-type {
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.no-js #duplicate_post_settings_form section[hidden] {
+	display: block;
+}
+
+.js #duplicate_post_settings_form section h2 {
+	display: none
+}
+
+#duplicate_post_settings_form label.taxonomy_private {
+	font-style: italic;
+}
+
+#duplicate_post_settings_form .toggle-private-taxonomies.button-link {
+	font-size: small;
+	margin-top: 1em;
+}

--- a/duplicate-post-options.css
+++ b/duplicate-post-options.css
@@ -32,10 +32,6 @@
 	display: block;
 }
 
-.js #duplicate_post_settings_form section h2 {
-	display: none
-}
-
 #duplicate_post_settings_form label.taxonomy_private {
 	font-style: italic;
 }

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -184,7 +184,7 @@ function duplicate_post_options() {
 					else if (pressed === keys.left || pressed === keys.up) {
 						focusLastTab();
 					}
-					else if (pressed === keys.right || pressed == keys.down) {
+					else if (pressed === keys.right || pressed === keys.down) {
 						focusFirstTab();
 					}
 				}

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -328,7 +328,7 @@ function duplicate_post_options() {
 				role="tabpanel"
 				id="what-tab"
 				aria-labelledby="what">
-			<h2><?php esc_html_e( 'What to copy', 'duplicate-post' ); ?></h2>
+			<h2 class="hide-if-js"><?php esc_html_e( 'What to copy', 'duplicate-post' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?></th>
@@ -581,7 +581,7 @@ function duplicate_post_options() {
 				id="who-tab"
 				aria-labelledby="who"
 				hidden="hidden">
-			<h2><?php esc_html_e( 'Permissions', 'duplicate-post' ); ?></h2>
+			<h2 class="hide-if-js"><?php esc_html_e( 'Permissions', 'duplicate-post' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<?php if ( current_user_can( 'promote_users' ) ) { ?>
 				<tr>
@@ -662,7 +662,7 @@ function duplicate_post_options() {
 				id="where-tab"
 				aria-labelledby="where"
 				hidden="hidden">
-			<h2><?php esc_html_e( 'Display', 'duplicate-post' ); ?></h2>
+			<h2 class="hide-if-js"><?php esc_html_e( 'Display', 'duplicate-post' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?></th>

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -45,6 +45,9 @@ function duplicate_post_register_settings() {
 	register_setting( 'duplicate_post_group', 'duplicate_post_show_adminbar' );
 	register_setting( 'duplicate_post_group', 'duplicate_post_show_submitbox' );
 	register_setting( 'duplicate_post_group', 'duplicate_post_show_bulkactions' );
+	register_setting( 'duplicate_post_group', 'duplicate_post_show_original_column' );
+	register_setting( 'duplicate_post_group', 'duplicate_post_show_original_in_post_states' );
+	register_setting( 'duplicate_post_group', 'duplicate_post_show_original_meta_box' );
 	register_setting( 'duplicate_post_group', 'duplicate_post_show_notice' );
 }
 
@@ -96,103 +99,262 @@ function duplicate_post_options() {
 		<?php esc_html_e( 'Duplicate Post Options', 'duplicate-post' ); ?>
 	</h1>
 
-	<div
-		style="margin: 9px 15px 4px 0; padding: 5px 30px; text-align: center; float: left; clear: left; border: solid 3px #cccccc; width: 600px;">
-		<p>
-		<?php esc_html_e( 'Help me develop the plugin, add new features and improve support!', 'duplicate-post' ); ?>
-		<br />
-		<?php esc_html_e( 'Donate whatever sum you choose, even just 10¢.', 'duplicate-post' ); ?>
-		<br /> <a href="https://duplicate-post.lopo.it/donate"><img
-				id="donate-button" style="margin: 0 auto;"
-				src="<?php echo esc_url( plugins_url( 'donate.png', __FILE__ ) ); ?>"
-				alt="Donate" /></a> <br /> <a href="https://duplicate-post.lopo.it/"><?php esc_html_e( 'Documentation', 'duplicate-post' ); ?></a>
-			- <a
-				href="https://translate.wordpress.org/projects/wp-plugins/duplicate-post"><?php esc_html_e( 'Translate', 'duplicate-post' ); ?></a>
-			- <a href="https://wordpress.org/support/plugin/duplicate-post"><?php esc_html_e( 'Support Forum', 'duplicate-post' ); ?></a>
-		</p>
-	</div>
-
-
 	<script>
-	jQuery(document).on( 'click', '.nav-tab-wrapper a', function() {
-		jQuery('.nav-tab').removeClass('nav-tab-active');
-		jQuery(this).addClass('nav-tab-active');
-		jQuery('section').hide();
-		jQuery('section').eq(jQuery(this).index()).show();
-		return false;
-	});
+		var tablist;
+		var tabs;
+		var panels;
 
-	jQuery( function() {
-		jQuery( '.taxonomy_private' ).hide();
+		// For easy reference
+		var keys = {
+			end: 35,
+			home: 36,
+			left: 37,
+			up: 38,
+			right: 39,
+			down: 40,
+			delete: 46
+		};
 
-		jQuery( '.toggle-private-taxonomies' )
-			.on( 'click', function() {
-				buttonElement = jQuery( this );
-				jQuery( '.taxonomy_private' ).toggle( 300, function() {
-					buttonElement.attr( 'aria-expanded', jQuery( this ).is( ":visible" ) );
+		// Add or substract depending on key pressed
+		var direction = {
+			37: -1,
+			38: -1,
+			39: 1,
+			40: 1
+		};
+
+
+		function generateArrays () {
+			tabs = document.querySelectorAll('#duplicate_post_settings_form [role="tab"]');
+			panels = document.querySelectorAll('#duplicate_post_settings_form [role="tabpanel"]');
+		}
+
+		function addListeners (index) {
+			tabs[index].addEventListener('click', function(event){
+				var tab = event.target;
+				activateTab(tab, false);
+			});
+			tabs[index].addEventListener('keydown', function(event) {
+				var key = event.keyCode;
+
+				switch (key) {
+					case keys.end:
+						event.preventDefault();
+						// Activate last tab
+						activateTab(tabs[tabs.length - 1]);
+						break;
+					case keys.home:
+						event.preventDefault();
+						// Activate first tab
+						activateTab(tabs[0]);
+						break;
+				}
+			});
+			tabs[index].addEventListener('keyup', function(event) {
+				var key = event.keyCode;
+
+				switch (key) {
+					case keys.left:
+					case keys.right:
+						switchTabOnArrowPress(event);
+						break;
+				}
+			});
+
+			// Build an array with all tabs (<button>s) in it
+			tabs[index].index = index;
+		}
+
+
+		// Either focus the next, previous, first, or last tab
+		// depening on key pressed
+		function switchTabOnArrowPress (event) {
+			var pressed = event.keyCode;
+
+			for (x = 0; x < tabs.length; x++) {
+				tabs[x].addEventListener('focus', focusEventHandler);
+			}
+
+			if (direction[pressed]) {
+				var target = event.target;
+				if (target.index !== undefined) {
+					if (tabs[target.index + direction[pressed]]) {
+						tabs[target.index + direction[pressed]].focus();
+					}
+					else if (pressed === keys.left || pressed === keys.up) {
+						focusLastTab();
+					}
+					else if (pressed === keys.right || pressed == keys.down) {
+						focusFirstTab();
+					}
+				}
+			}
+		}
+
+		// Activates any given tab panel
+		function activateTab (tab, setFocus) {
+			setFocus = setFocus || true;
+			// Deactivate all other tabs
+			deactivateTabs();
+
+			// Remove tabindex attribute
+			tab.removeAttribute('tabindex');
+
+			// Set the tab as selected
+			tab.setAttribute('aria-selected', 'true');
+
+			tab.classList.add('nav-tab-active');
+
+			// Get the value of aria-controls (which is an ID)
+			var controls = tab.getAttribute('aria-controls');
+
+			// Remove hidden attribute from tab panel to make it visible
+			document.getElementById(controls).removeAttribute('hidden');
+
+			// Set focus when required
+			if (setFocus) {
+				tab.focus();
+			}
+		}
+
+		// Deactivate all tabs and tab panels
+		function deactivateTabs () {
+			for (t = 0; t < tabs.length; t++) {
+				tabs[t].setAttribute('tabindex', '-1');
+				tabs[t].setAttribute('aria-selected', 'false');
+				tabs[t].classList.remove('nav-tab-active');
+				tabs[t].removeEventListener('focus', focusEventHandler);
+			}
+
+			for (p = 0; p < panels.length; p++) {
+				panels[p].setAttribute('hidden', 'hidden');
+			}
+		}
+
+		// Make a guess
+		function focusFirstTab () {
+			tabs[0].focus();
+		}
+
+		// Make a guess
+		function focusLastTab () {
+			tabs[tabs.length - 1].focus();
+		}
+
+		//
+		function focusEventHandler (event) {
+			var target = event.target;
+
+			checkTabFocus(target);
+		}
+
+		// Only activate tab on focus if it still has focus after the delay
+		function checkTabFocus (target) {
+			focused = document.activeElement;
+
+			if (target === focused) {
+				activateTab(target, false);
+			}
+		}
+
+		document.addEventListener("DOMContentLoaded", function () {
+			tablist = document.querySelectorAll('#duplicate_post_settings_form [role="tablist"]')[0];
+
+			generateArrays();
+
+			// Bind listeners
+			for (i = 0; i < tabs.length; ++i) {
+				addListeners(i);
+			}
+		});
+
+		jQuery(function(){
+			jQuery('.taxonomy_private').hide();
+
+			jQuery( '.toggle-private-taxonomies' )
+				.on( 'click', function() {
+					buttonElement = jQuery( this );
+					jQuery( '.taxonomy_private' ).toggle( 300, function() {
+						buttonElement.attr( 'aria-expanded', jQuery( this ).is( ":visible" ) );
+					} );
 				} );
-			} );
-	} );
-
+		});
 	</script>
 
 	<style>
-.nav-tab-wrapper {
-	margin: 22px 0 0 0;
-}
+		header.nav-tab-wrapper {
+			margin: 22px 0 0 0;
+		}
 
-.js section {
-	display: none;
-}
+		header .nav-tab:focus {
+			color: #555;
+			box-shadow: none;
+		}
 
-.js section:first-of-type {
-	display: block;
-}
+		.no-js header.nav-tab-wrapper {
+			display: none;
+		}
 
-.no-js .nav-tab-wrapper {
-	display: none;
-}
+		.no-js section {
+			border-top: 1px dashed #aaa;
+			margin-top: 22px;
+			padding-top: 22px;
+		}
 
-.no-js section {
-	border-top: 1px dashed #aaa;
-	margin-top: 22px;
-	padding-top: 22px;
-}
+		.no-js section:first-of-type {
+			margin: 0;
+			padding: 0;
+			border: 0;
+		}
 
-.no-js section:first-of-type {
-	margin: 0;
-	padding: 0;
-	border: 0;
-}
+		label.taxonomy_private {
+			font-style: italic;
+		}
 
-label.taxonomy_private {
-	font-style: italic;
-}
-
-.toggle-private-taxonomies.button-link {
-	margin-top: 1em;
-}
-
-img#donate-button {
-	vertical-align: middle;
-}
+		.toggle-private-taxonomies.button-link {
+			font-size: small;
+			margin-top: 1em;
+		}
 	</style>
 
 
 	<form method="post" action="options.php" style="clear: both">
 		<?php settings_fields( 'duplicate_post_group' ); ?>
 
-		<h2 class="nav-tab-wrapper">
-			<a class="nav-tab nav-tab-active"
-				href="<?php echo esc_url( admin_url( '/index.php?page=duplicate-post-what' ) ); ?>"><?php esc_html_e( 'What to copy', 'duplicate-post' ); ?>
-			</a> <a class="nav-tab"
-				href="<?php echo esc_url( admin_url( '/index.php?page=duplicate-post-who' ) ); ?>"><?php esc_html_e( 'Permissions', 'duplicate-post' ); ?>
-			</a> <a class="nav-tab"
-				href="<?php echo esc_url( admin_url( '/index.php?page=duplicate-post-where' ) ); ?>"><?php esc_html_e( 'Display', 'duplicate-post' ); ?>
-			</a>
-		</h2>
+		<header role="tablist" aria-label="<?php esc_attr_e( 'Settings sections', 'duplicate-post' ); ?>" class="nav-tab-wrapper">
+			<button
+					type="button"
+					role="tab"
+					class="nav-tab nav-tab-active"
+					aria-selected="true"
+					aria-controls="what-tab"
+					id="what"><?php esc_html_e( 'What to copy', 'duplicate-post' ); ?>
+			</button>
+			<button
+					type="button"
+					role="tab"
+					class="nav-tab"
+					aria-selected="false"
+					aria-controls="who-tab"
+					id="who"
+					tabindex="-1"><?php esc_html_e( 'Permissions', 'duplicate-post' ); ?>
+			</button>
+			<button
+					type="button"
+					role="tab"
+					class="nav-tab"
+					aria-selected="false"
+					aria-controls="where-tab"
+					id="where"
+					tabindex="-1"><?php esc_html_e( 'Display', 'duplicate-post' ); ?>
+			</button>
+		</header>
 
-		<section>
+		<section
+				tabindex="0"
+				role="tabpanel"
+				id="what-tab"
+				aria-labelledby="what">
 
 			<table class="form-table" role="presentation">
 				<tr>
@@ -440,12 +602,16 @@ img#donate-button {
 				</tr>
 			</table>
 		</section>
-		<section>
+		<section
+				tabindex="0"
+				role="tabpanel"
+				id="who-tab"
+				aria-labelledby="who"
+				hidden="hidden">
 			<table class="form-table" role="presentation">
 				<?php if ( current_user_can( 'promote_users' ) ) { ?>
 				<tr>
-					<th scope="row"><?php esc_html_e( 'Roles allowed to copy', 'duplicate-post' ); ?>
-					</th>
+					<th scope="row"><?php esc_html_e( 'Roles allowed to copy', 'duplicate-post' ); ?></th>
 					<td>
 						<fieldset>
 							<legend class="screen-reader-text"><?php esc_html_e( 'Roles allowed to copy', 'duplicate-post' ); ?></legend>
@@ -516,7 +682,12 @@ img#donate-button {
 				</tr>
 			</table>
 		</section>
-		<section>
+		<section
+				tabindex="0"
+				role="tabpanel"
+				id="where-tab"
+				aria-labelledby="where"
+				hidden="hidden">
 			<table class="form-table" role="presentation">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?></th>
@@ -591,8 +762,52 @@ img#donate-button {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><?php esc_html_e( 'Update notice', 'duplicate-post' ); ?>
-					</th>
+					<th scope="row"><?php esc_html_e( 'Show original item:', 'duplicate-post' ); ?></th>
+					<td>
+						<input
+								type="checkbox"
+								name="duplicate_post_show_original_meta_box"
+								id="duplicate-post-show-original-meta-box"
+								aria-describedby="duplicate-post-show-original-meta-box-description"
+								value="1"
+							<?php
+							if ( 1 === intval( get_option( 'duplicate_post_show_original_meta_box' ) ) ) {
+								echo 'checked="checked"';
+							}
+							?>
+								/>
+						<label for="duplicate-post-show-original-meta-box"><?php esc_html_e( 'In a metabox in the Edit screen [Classic editor]', 'duplicate-post' ); ?></label>
+						<p id="duplicate-post-show-original-meta-box-description">(<?php esc_html_e( "you'll also be able to delete the reference to the original item with a checkbox", 'duplicate-post' ); ?>)</p><br/>
+						<input
+								type="checkbox"
+								name="duplicate_post_show_original_column"
+								id="duplicate-post-show-original-column"
+								aria-describedby="duplicate-post-show-original-column-description"
+								value="1"
+							<?php
+							if ( 1 === intval( get_option( 'duplicate_post_show_original_column' ) ) ) {
+								echo 'checked="checked"';
+							}
+							?>
+								/>
+						<label for="duplicate-post-show-original-column"><?php esc_html_e( 'In a column in the Post list', 'duplicate-post' ); ?></label>
+						<p id="duplicate-post-show-original-column-description">(<?php esc_html_e( "you'll also be able to delete the reference to the original item with a checkbox in Quick Edit", 'duplicate-post' ); ?>)</p><br/>
+						<input
+								type="checkbox"
+								name="duplicate_post_show_original_in_post_states"
+								id="duplicate-post-show-original-in-post-states"
+								value="1"
+							<?php
+							if ( 1 === intval( get_option( 'duplicate_post_show_original_in_post_states' ) ) ) {
+								echo 'checked="checked"';
+							}
+							?>
+								/>
+						<label for="duplicate-post-show-original-in-post-states"><?php esc_html_e( 'After the title in the Post list', 'duplicate-post' ); ?></label>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Update notice', 'duplicate-post' ); ?></th>
 					<td>
 						<input
 							type="checkbox"

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -55,13 +55,23 @@ function duplicate_post_register_settings() {
  * Adds options page to menu.
  */
 function duplicate_post_menu() {
-	add_options_page(
+	$page_hook = add_options_page(
 		__( 'Duplicate Post Options', 'duplicate-post' ),
 		__( 'Duplicate Post', 'duplicate-post' ),
 		'manage_options',
 		'duplicatepost',
 		'duplicate_post_options'
 	);
+	add_action( $page_hook, 'duplicate_post_add_options_page_css' );
+}
+
+/**
+ * Enqueues a CSS file with styles for the options page.
+ *
+ * @ignore
+ */
+function duplicate_post_add_options_page_css() {
+	wp_enqueue_style( 'duplicate-post-options', plugins_url( '/duplicate-post-options.css', __FILE__ ), array(), DUPLICATE_POST_CURRENT_VERSION );
 }
 
 /**
@@ -281,44 +291,7 @@ function duplicate_post_options() {
 		});
 	</script>
 
-	<style>
-		header.nav-tab-wrapper {
-			margin: 22px 0 0 0;
-		}
-
-		header .nav-tab:focus {
-			color: #555;
-			box-shadow: none;
-		}
-
-		.no-js header.nav-tab-wrapper {
-			display: none;
-		}
-
-		.no-js section {
-			border-top: 1px dashed #aaa;
-			margin-top: 22px;
-			padding-top: 22px;
-		}
-
-		.no-js section:first-of-type {
-			margin: 0;
-			padding: 0;
-			border: 0;
-		}
-
-		label.taxonomy_private {
-			font-style: italic;
-		}
-
-		.toggle-private-taxonomies.button-link {
-			font-size: small;
-			margin-top: 1em;
-		}
-	</style>
-
-
-	<form method="post" action="options.php" style="clear: both">
+	<form id="duplicate_post_settings_form" method="post" action="options.php" style="clear: both">
 		<?php settings_fields( 'duplicate_post_group' ); ?>
 
 		<header role="tablist" aria-label="<?php esc_attr_e( 'Settings sections', 'duplicate-post' ); ?>" class="nav-tab-wrapper">
@@ -355,7 +328,7 @@ function duplicate_post_options() {
 				role="tabpanel"
 				id="what-tab"
 				aria-labelledby="what">
-
+			<h2><?php esc_html_e( 'What to copy', 'duplicate-post' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Post/page elements to copy', 'duplicate-post' ); ?></th>
@@ -608,6 +581,7 @@ function duplicate_post_options() {
 				id="who-tab"
 				aria-labelledby="who"
 				hidden="hidden">
+			<h2><?php esc_html_e( 'Permissions', 'duplicate-post' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<?php if ( current_user_can( 'promote_users' ) ) { ?>
 				<tr>
@@ -688,6 +662,7 @@ function duplicate_post_options() {
 				id="where-tab"
 				aria-labelledby="where"
 				hidden="hidden">
+			<h2><?php esc_html_e( 'Display', 'duplicate-post' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Show links in', 'duplicate-post' ); ?></th>

--- a/duplicate-post.css
+++ b/duplicate-post.css
@@ -29,3 +29,17 @@
 		-moz-osx-font-smoothing: grayscale;
 	}
 }
+
+fieldset#duplicate_post_quick_edit_fieldset{
+	clear: both;
+}
+
+fieldset#duplicate_post_quick_edit_fieldset label{
+	display: inline;
+	margin: 0;
+	vertical-align: unset;
+}
+
+fieldset#duplicate_post_quick_edit_fieldset a{
+	text-decoration: underline;
+}

--- a/duplicate_post_admin_script.js
+++ b/duplicate_post_admin_script.js
@@ -1,0 +1,33 @@
+/**
+ * Injects column data about original post into the Quick Edit.
+ *
+ * @package Duplicate Post
+ * @since 3.2.4
+ */
+
+(function(jQuery) {
+	var $wp_inline_edit = inlineEditPost.edit;
+	inlineEditPost.edit = function( id ) {
+		$wp_inline_edit.apply( this, arguments );
+		var $post_id = 0;
+		if ( typeof( id ) == 'object' ) {
+			$post_id = parseInt( this.getId( id ) );
+		}
+		if ( $post_id > 0 ) {
+			var $edit_row = jQuery( '#edit-' + $post_id );
+			var $post_row = jQuery( '#post-' + $post_id );
+
+			var has_original = ( jQuery( '.duplicate_post_original_item span[data-no_original]', $post_row ).length === 0 );
+			var original = jQuery( '.duplicate_post_original_item', $post_row ).html();
+
+			if ( has_original ) {
+				jQuery( '.duplicate_post_original_item_title_span', $edit_row ).html( original );
+				jQuery( '#duplicate_post_quick_edit_fieldset', $edit_row ).show();
+			} else {
+				jQuery( '#duplicate_post_quick_edit_fieldset', $edit_row ).hide();
+				jQuery( '.duplicate_post_original_item_title_span', $edit_row ).html( '' );
+			}
+		}
+	};
+
+} )( jQuery );


### PR DESCRIPTION
This PR:
* ports the feature "Show original" from `svntrunk` branch + derivatives, adding PHPDocs and passing WPCS tests.
* moves the styles for the Options page to a CSS file which is enqueued