### PR TITLE
Deprecates duplicate_post_blacklist_filter in favor of duplicate_post_excludelist_filter

### DIFF
--- a/compat/duplicate-post-jetpack.php
+++ b/compat/duplicate-post-jetpack.php
@@ -3,20 +3,20 @@ add_action( 'admin_init', 'duplicate_post_jetpack_init' );
 
 
 function duplicate_post_jetpack_init() {
-	add_filter('duplicate_post_blacklist_filter', 'duplicate_post_jetpack_add_to_blacklist', 10, 1 );
-	
+	add_filter('duplicate_post_excludelist_filter', 'duplicate_post_jetpack_add_to_excludelist', 10, 1 );
+
 	if (class_exists('WPCom_Markdown')){
 		add_action('duplicate_post_pre_copy', 'duplicate_post_jetpack_disable_markdown', 10);
 		add_action('duplicate_post_post_copy', 'duplicate_post_jetpack_enable_markdown', 10);
-	}	
+	}
 }
 
-function duplicate_post_jetpack_add_to_blacklist($meta_blacklist) {
+function duplicate_post_jetpack_add_to_excludelist($meta_blacklist) {
 	$meta_blacklist[] = '_wpas*'; //Jetpack Publicize
 	$meta_blacklist[] = '_publicize*'; //Jetpack Publicize
-	
+
 	$meta_blacklist[] = '_jetpack*'; //Jetpack Subscriptions etc.
-	
+
 	return $meta_blacklist;
 }
 

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -608,7 +608,8 @@ function duplicate_post_copy_post_meta_info($new_id, $post) {
 		$meta_blacklist[] = '_thumbnail_id';
 	}
 
-	$meta_blacklist = apply_filters( 'duplicate_post_blacklist_filter' , $meta_blacklist );
+	$meta_blacklist = apply_filters_deprecated( 'duplicate_post_blacklist_filter' , $meta_blacklist, '3.2.5', 'duplicate_post_excludelist_filter' );
+	$meta_blacklist = apply_filters( 'duplicate_post_excludelist_filter' , $meta_blacklist );
 
 	$meta_blacklist_string = '('.implode(')|(',$meta_blacklist).')';
 	if(strpos($meta_blacklist_string, '*') !== false){

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -608,7 +608,7 @@ function duplicate_post_copy_post_meta_info($new_id, $post) {
 		$meta_blacklist[] = '_thumbnail_id';
 	}
 
-	$meta_blacklist = apply_filters_deprecated( 'duplicate_post_blacklist_filter' , $meta_blacklist, '3.2.5', 'duplicate_post_excludelist_filter' );
+	$meta_blacklist = apply_filters_deprecated( 'duplicate_post_blacklist_filter' , array( $meta_blacklist ), '3.2.5', 'duplicate_post_excludelist_filter' );
 	$meta_blacklist = apply_filters( 'duplicate_post_excludelist_filter' , $meta_blacklist );
 
 	$meta_blacklist_string = '('.implode(')|(',$meta_blacklist).')';


### PR DESCRIPTION
This PR adds a deprecation warning for `duplicate_post_blacklist_filter` to be substituted by `duplicate_post_excludelist_filter`.

The new filter is used by the JetPack compatibility functions to make sure that the custom fields related to the Publicize extensions are filtered out.

The new filter was already documented in [the developer's guide](https://developer.yoast.com/duplicate-post/filters-actions#duplicate_post_excludelist_filter).

### To test 

We can use the code in `compat/duplicate-post-jetpack.php` to test the change: it hooks a function to the filter that prevers from copying custom fields named `_wpas*`, `_publicize*`, `_jetpack*` (these are wildcards).

1. Edit a post
2. Add some custom fields: at least one which does not match the wildcards above and one which does.
3. Save the post
4. Clone the post and check that the copy has all the custom fields except the ones matching one of the wildcards above
5. Also check the log to make sure there is no warning related to the cloning operation
6. Change `compat/duplicate-post-jetpack.php` at line 6 to use the deprecated hook, so it looks as the following:
`	add_filter('duplicate_post_blacklist_filter', 'duplicate_post_jetpack_add_to_excludelist', 10, 1 );`
7. Clone again the original post, check that the copy has all the custom fields except the ones matching one of the wildcards above.
8. Check the log and verify it shows a warning like:
`PHP Deprecated:  duplicate_post_blacklist_filter is <strong>deprecated</strong> since version 3.2.5! Use duplicate_post_excludelist_filter instead.`