### PR TITLE
Set Yoast roles as allowed by default on new installs

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -118,7 +118,7 @@ function duplicate_post_plugin_upgrade() {
 			'administrator',
 			'editor',
 			'wpseo_manager',
-            'wpseo_editor'
+			'wpseo_editor',
 		);
 
 		// Cycle all roles and assign capability if its level >= duplicate_post_copy_user_level.

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -115,8 +115,10 @@ function duplicate_post_plugin_upgrade() {
 	if ( empty( $installed_version ) ) {
 		// Get default roles.
 		$default_roles = array(
-			3 => 'editor',
-			8 => 'administrator',
+			'administrator',
+			'editor',
+			'wpseo_manager',
+            'wpseo_editor'
 		);
 
 		// Cycle all roles and assign capability if its level >= duplicate_post_copy_user_level.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On new installations, the Administrator and Editor roles are given by default the `copy_posts` capability. We should add it to the two roles that Yoast SEO (SEO Manager and SEO Editor) adds when installed.

## Summary

This PR can be summarized in the following changelog entry:

*  Enables the two Yoast SEO roles by default if found on first installation

## Relevant technical choices:

* The `copy_posts` capability is added  when the plugin is activated on a new installation (= no option `duplicate_post_version` in the DB). If Yoast SEO is activated _after_ Yoast Duplicate Post, the roles won't have the capability.
* On new installs, Yoast SEO could add the capability on his own
* This would leave only the cases where the two plugins are already installed and activated, and users should enable the two roles _if they want_ and _if they haven't done it yet_: a reminder would probably be the best choice for this purpose.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. **On a clean installation**, install and activate Yoast SEO (no need to tun the wizard)
2. Install and activate Yoast Duplicate Post from this PR
3. Visit "Settings"→"Duplicate Post", second tab "Permissions"
4. Observe that the following roles are allowed to copy posts:
  * Administrator
  * Editor
  * SEO Manager
  * SEO Editor

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended