### PR TITLE
Remove old code about unused options

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -119,7 +119,7 @@ function duplicate_post_plugin_upgrade() {
 			8 => 'administrator',
 		);
 
-		// Cycle all roles and assign capability if its level >= duplicate_post_copy_user_level.
+		// Cycle all roles and assign capability.
 		foreach ( $default_roles as $level => $name ) {
 			$role = get_role( $name );
 			if ( ! empty( $role ) ) {
@@ -179,15 +179,8 @@ function duplicate_post_plugin_upgrade() {
 	}
 	update_option( 'duplicate_post_blacklist', implode( ',', $meta_blacklist ) );
 
-	delete_option( 'duplicate_post_admin_user_level' );
-	delete_option( 'duplicate_post_create_user_level' );
-	delete_option( 'duplicate_post_view_user_level' );
-	delete_option( 'dp_notice' );
-
-	delete_site_option( 'duplicate_post_version' );
 	update_option( 'duplicate_post_version', duplicate_post_get_current_version() );
 
-	delete_option( 'duplicate_post_show_notice' );
 	update_site_option( 'duplicate_post_show_notice', 1 );
 }
 

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -126,27 +126,6 @@ function duplicate_post_plugin_upgrade() {
 				$role->add_cap( 'copy_posts' );
 			}
 		}
-	} else {
-		$min_user_level = get_option( 'duplicate_post_copy_user_level' );
-
-		if ( ! empty( $min_user_level ) ) {
-			// Get default roles.
-			$default_roles = array(
-				1 => 'contributor',
-				2 => 'author',
-				3 => 'editor',
-				8 => 'administrator',
-			);
-
-			// Cycle all roles and assign capability if its level >= duplicate_post_copy_user_level.
-			foreach ( $default_roles as $level => $name ) {
-				$role = get_role( $name );
-				if ( $role && $min_user_level <= $level ) {
-					$role->add_cap( 'copy_posts' );
-				}
-			}
-			delete_option( 'duplicate_post_copy_user_level' );
-		}
 	}
 
 	add_option( 'duplicate_post_copytitle', '1' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Yoast Duplicate Post contains some old code which was added to support transistion from the options that were set by the oldest versions to the ones that are currently used.
* Some options were removed since version 2.1 (2012), others from version 3.0 (October 2016)
* Usage stats tell us that 93.4% of installations have version 3.2.*

## Summary

This PR can be summarized in the following changelog entry:

* Removes code that was used to delete unused options and convert some of their value to the current options 

## Relevant technical choices:

* Deleted references about the following options:
  * `duplicate_post_copy_user_level`
  * `duplicate_post_admin_user_level`
  * `duplicate_post_create_user_level`
  * `duplicate_post_view_user_level`
  * `dp_notice`
  * `duplicate_post_version` (as a multisite option)
  * `duplicate_post_show_notice` (as a non-multisite option)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. install or upgrade Yoast Duplicate Post from this PR
2. Observe the Upgrade notice is correctly displayed
3. Visit "Settings"→"Duplicate Post", second tab "Permissions"
4. Observe that the Roles options are correctly set.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended