### PR TITLE
Update template tag documentation link

### DIFF
--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -725,7 +725,7 @@ function duplicate_post_options() {
 								esc_html__( 'You can also use the template tag %1$sduplicate_post_clone_post_link( $link, $before, $after, $id )%2$s. %3$sMore info on the template tag%4$s.', 'duplicate-post' ),
 								'<code>',
 								'</code>',
-								'<a href="' . esc_url( 'https://duplicate-post.lopo.it/docs/developers-guide/functions-template-tags/duplicate_post_clone_post_link/' ) . '">',
+								'<a href="' . esc_url( 'https://developer.yoast.com/duplicate-post/functions-template-tags#duplicate_post_clone_post_link' ) . '">',
 								'</a>'
 							);
 							?>


### PR DESCRIPTION
The "More info on the template tag" link in the options page is outdated, and redirects to a non-existent page ([this link][old link] redirects [here][old link redirect]), so I've updated the link to head to the new documentation on developer.yoast.com

[old link]: https://duplicate-post.lopo.it/docs/developers-guide/functions-template-tags/duplicate_post_clone_post_link/
[old link redirect]: https://developer.yoast.com/duplicate-post/overviewfunctions-template-tags/duplicate_post_clone_post_link/