### PR TITLE
Update check for comment type after WordPress 5.5 changes

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -745,7 +745,7 @@ function duplicate_post_copy_comments($new_id, $post){
 			'comment_author_email' => $comment->comment_author_email,
 			'comment_author_url' => $comment->comment_author_url,
 			'comment_content' => $comment->comment_content,
-			'comment_type' => '',
+			'comment_type' => $comment->comment_type,
 			'comment_parent' => $parent,
 			'user_id' => $comment->user_id,
 			'comment_author_IP' => $comment->comment_author_IP,

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -737,7 +737,7 @@ function duplicate_post_copy_comments($new_id, $post){
 	$old_id_to_new = array();
 	foreach ($comments as $comment){
 		//do not copy pingbacks or trackbacks
-		if(!empty($comment->comment_type)) continue;
+		if( $comment->comment_type === "pingback" || $comment->comment_type === "trackback" ) continue;
 		$parent = ($comment->comment_parent && $old_id_to_new[$comment->comment_parent])?$old_id_to_new[$comment->comment_parent]:0;
 		$commentdata = array(
 			'comment_post_ID' => $new_id,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WordPress 5.5 has introduced the default value `comment` for `comment_type` instead of the empty string (see [Trac issue](https://core.trac.wordpress.org/ticket/49236)). The comments having that value already set don't get copied even if the related option is enabled.
Moreover, that change is meant to pave the way for custom comment types, so it sounds more reasonable to explicitly filter out pingbacks and trackbacks.

## Summary

This PR can be summarized in the following changelog entry:

*  Update check for comment type to make it compatible with values other from "pingback" and "trackback".

## Relevant technical choices:

* The change is applied to `develop` branch, expecting it to be rolled out in a bugfix patch release.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Set up a new install of WordPress 5.5
2. Checkout the plugin from this branch
3. Enable the option for "Comments" in Settings→Duplicate Post, first tab "What to copy"
4. Visit the post list and "Clone" the Hello World! post, which should have a comment by default
5. See that the new copy has a copy of the comment

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended