### PR TITLE
Improve update notice 

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -206,6 +206,15 @@ function duplicate_post_plugin_upgrade() {
  */
 function duplicate_post_show_update_notice() {
 	if(!current_user_can( 'manage_options')) return;
+
+	$current_screen = get_current_screen();
+	if ( empty( $current_screen ) ||
+		 empty( $current_screen->base ) ||
+         ( $current_screen->base !== "dashboard" && $current_screen->base !== "plugins" )
+    ) {
+	    return;
+    }
+
 	$class = 'notice is-dismissible';
 	/* translators: %1$s: Yoast, %2$s: version number */
 	$message = '<p style="margin: 0;"><strong>' . sprintf( __( 'What\'s new in %1$s Duplicate Post version %2$s:', 'duplicate-post' ), 'Yoast', DUPLICATE_POST_CURRENT_VERSION ) . '</strong></p>';

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -193,12 +193,13 @@ function duplicate_post_plugin_upgrade() {
 	delete_option('duplicate_post_view_user_level');
 	delete_option('dp_notice');
 
+	delete_option('duplicate_post_show_notice' );
+	if ( version_compare( $installed_version, '3.2.5' ) < 0) {
+		update_site_option( 'duplicate_post_show_notice', 1 );
+	}
+
 	delete_site_option('duplicate_post_version');
 	update_option( 'duplicate_post_version', duplicate_post_get_current_version() );
-
-	delete_option('duplicate_post_show_notice', 0);
-	update_site_option('duplicate_post_show_notice', 1);
-
 }
 
 /**

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -210,10 +210,10 @@ function duplicate_post_show_update_notice() {
 
 	$current_screen = get_current_screen();
 	if ( empty( $current_screen ) ||
-		 empty( $current_screen->base ) ||
-         ( $current_screen->base !== "dashboard" && $current_screen->base !== "plugins" )
+		empty( $current_screen->base ) ||
+		( $current_screen->base !== "dashboard" && $current_screen->base !== "plugins" )
     ) {
-	    return;
+		return;
     }
 
 	$class = 'notice is-dismissible';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The update notice is currently displayed on all admin screens until dismissed, and it's restored any time the plugin is upgraded from an earlier version. We should show the notice only on selected screens (Dashboard and Plugins list), and restore it (if dismissed) only when upgrading from a version before the first Yoast-branded one.

## Summary

This PR can be summarized in the following changelog entry:

*  Change update notice behaviour to be shown only on selected screens, and to be restored only for users upgrading from version below 3.2.5

## Relevant technical choices:

* The change is applied to `develop` branch, expecting it to be rolled out in a bugfix patch release.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Either install Duplicate Post version < 3.2.5 or change the value of `duplicate_post_version` in `wp_options` to a similar value
2. See that the update notice is present everywhere in the backend.
3. Dismiss it
4. Checkout this branch
5. See that the update notice is restored, and it's present only in the Dashboard and in the Plugins list.
6. Dismiss it
7. Change the value of `duplicate_post_version` in `wp_options` to `3.2.5`
8. Navigate the backend to see that the update notice is still dismissed.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended