### PR TITLE
Added post_type filter for Duplicate Post settings

### DIFF
--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -627,6 +627,7 @@ function duplicate_post_options() {
                             <legend class="screen-reader-text"><?php esc_html_e( 'Enable for these post types', 'duplicate-post' ); ?></legend>
 							<?php
 							$post_types = get_post_types( array( 'show_ui' => true ), 'objects' );
+							$post_types = apply_filters( 'duplicate_post_post_types', $post_types );
 							foreach ( $post_types as $post_type_object ) :
 								if ( 'attachment' === $post_type_object->name ) {
 									continue;


### PR DESCRIPTION
Hi there,

I found that Duplicate Post feature does not work as expected on some complex post types (Like sfwd-quiz in LearnDash LMS).

In this case, it would be good to have a filter at the point when the post types are fetched from the database.