### PR TITLE
P3-251 Introduce autoloading and initial class folder structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ php:
 
 matrix:
   include:
-    - php: '5.2'
-      dist: precise
     - php: '5.3'
       dist: precise
     - php: '5.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       env: SNIFF=1
 
 before_install:
+  - composer self-update 1.10.16
   - if [[ "$SNIFF" == "1" ]]; then composer install; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ matrix:
       env: SNIFF=1
 
 before_install:
-  - composer self-update 1.10.16
-  - if [[ "$SNIFF" == "1" ]]; then composer install; fi
+  - if [[ "$SNIFF" == "1" ]]; then composer self-update 1.10.16 && composer install; fi
 
 script:
   - find -L . compat/ -maxdepth 1 -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,14 @@
         "phpcompatibility/phpcompatibility-wp": "*",
         "automattic/vipwpcs": "^2.0"
     },
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
     "scripts": {
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -p *.php compat/*.php --runtime-set ignore_warnings_on_exit 1"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -p *.php compat/*.php src/*.php --runtime-set ignore_warnings_on_exit 1"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9,30 +9,31 @@
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.0.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "fc02f491dc9f51da7c32941ac579f70b9ed300c5"
+                "reference": "4d0612461232b313d06321f1501c3989bd6aecf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/fc02f491dc9f51da7c32941ac579f70b9ed300c5",
-                "reference": "fc02f491dc9f51da7c32941ac579f70b9ed300c5",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/4d0612461232b313d06321f1501c3989bd6aecf9",
+                "reference": "4d0612461232b313d06321f1501c3989bd6aecf9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "squizlabs/php_codesniffer": "^3.3.1",
-                "wp-coding-standards/wpcs": "^2.1"
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.8.3",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpunit/phpunit": "^5 || ^6 || ^7"
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -51,7 +52,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-07-12T08:47:36+00:00"
+            "time": "2020-09-07T10:45:45+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -280,17 +281,65 @@
             "time": "2019-08-28T14:22:28+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
+                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+                "sirbrillig/phpcs-import-detection": "^1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "time": "2020-10-07T23:32:29+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -328,20 +377,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
-                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -351,6 +400,7 @@
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
@@ -373,7 +423,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2020-02-04T02:52:06+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],
@@ -382,6 +432,5 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -100,8 +100,6 @@ function duplicate_post_admin_init() {
 	add_filter( 'plugin_row_meta', 'duplicate_post_add_plugin_links', 10, 2 );
 
 	add_action( 'admin_notices', 'duplicate_post_action_admin_notice' );
-
-	add_action( 'enqueue_block_editor_assets', 'duplicate_post_admin_enqueue_block_editor_scripts' );
 }
 
 /**
@@ -450,65 +448,6 @@ function duplicate_post_admin_enqueue_scripts( $hook ) {
 	if ( 'edit.php' === $hook ) {
 		wp_enqueue_script( 'duplicate_post_admin_script', plugins_url( 'duplicate_post_admin_script.js', __FILE__ ), false, DUPLICATE_POST_CURRENT_VERSION, true );
 	}
-}
-
-/**
- * Flattens a version number for use in a filename.
- *
- * @param string $version The original version number.
- *
- * @return string The flattened version number.
- */
-function duplicate_post_flatten_version( $version ) {
-	$parts = explode( '.', $version );
-
-	if ( count( $parts ) === 2 && preg_match( '/^\d+$/', $parts[1] ) === 1 ) {
-		$parts[] = '0';
-	}
-
-	return implode( '', $parts );
-}
-
-/**
- * Enqueues the necessary JavaScript code for the block editor.
- *
- * @return void
- */
-function duplicate_post_admin_enqueue_block_editor_scripts() {
-	wp_enqueue_script(
-		'duplicate_post_edit_script',
-		plugins_url( sprintf( 'js/dist/duplicate-post-edit-%s.js', duplicate_post_flatten_version( DUPLICATE_POST_CURRENT_VERSION ) ), __FILE__ ),
-		array(
-			'wp-blocks',
-			'wp-element',
-			'wp-i18n',
-		),
-		DUPLICATE_POST_CURRENT_VERSION,
-		true
-	);
-
-	wp_localize_script(
-		'duplicate_post_edit_script',
-		'duplicatePostRewriteRepost',
-		array(
-			'permalink' => duplicate_post_get_rewrite_republish_permalink(),
-		)
-	);
-}
-
-/**
- * Generates a rewrite and republish permalink for the current post.
- *
- * @return string The permalink. Returns empty if the post hasn't been published yet.
- */
-function duplicate_post_get_rewrite_republish_permalink() {
-	$post = get_post();
-	// phpcs:ignore WordPress.PHP.YodaConditions
-	if ( $post->post_status !== 'publish' ) {
-		return '';
-	}
-
-	return duplicate_post_get_clone_post_link( $post->ID );
 }
 
 /**

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -33,7 +33,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
 
+if ( ! defined( 'DUPLICATE_POST_FILE' ) ) {
+	define( 'DUPLICATE_POST_FILE', __FILE__ );
+}
+
 define( 'DUPLICATE_POST_CURRENT_VERSION', '4.0alpha' );
+
+$duplicate_post_autoload_file = __DIR__ . '/vendor/autoload.php';
+
+if ( is_readable( $duplicate_post_autoload_file ) ) {
+	require $duplicate_post_autoload_file;
+
+	// Initialize the main autoloaded class.
+	add_action( 'plugins_loaded', '__duplicate_post_main' );
+}
+
+/**
+ * Loads the Duplicate Post main class.
+ *
+ * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore,WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function name change would be BC-break.
+ */
+function __duplicate_post_main() {
+	new Duplicate_Post();
+}
+// phpcs:enable
 
 /**
  * Initialises the internationalisation domain.

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -29,6 +29,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
+use Yoast\WP\Duplicate_Post\Duplicate_Post;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: 				duplicate post, copy, clone
 Requires at least: 	3.6
 Tested up to: 		5.5
 Stable tag: 		3.2.6
-Requires PHP:		5.2.4
+Requires PHP:		5.3.0
 License: 			GPLv2 or later
 License URI: 		http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/src/class-duplicate-post-user-interface.php
+++ b/src/class-duplicate-post-user-interface.php
@@ -5,6 +5,8 @@
  * @package Duplicate_Post
  */
 
+namespace Yoast\WP\Duplicate_Post\Duplicate_Post_User_Interface;
+
 /**
  * Represents the Duplicate Post User Interface class.
  */

--- a/src/class-duplicate-post-user-interface.php
+++ b/src/class-duplicate-post-user-interface.php
@@ -5,7 +5,7 @@
  * @package Duplicate_Post
  */
 
-namespace Yoast\WP\Duplicate_Post\Duplicate_Post_User_Interface;
+namespace Yoast\WP\Duplicate_Post;
 
 /**
  * Represents the Duplicate Post User Interface class.

--- a/src/class-duplicate-post-user-interface.php
+++ b/src/class-duplicate-post-user-interface.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Duplicate Post user interface.
+ *
+ * @package Duplicate_Post
+ */
+
+/**
+ * Represents the Duplicate Post User Interface class.
+ */
+class Duplicate_Post_User_Interface {
+
+	/**
+	 * Initializes the class.
+	 */
+	public function __construct() {
+		$this->register_hooks();
+	}
+
+	/**
+	 * Adds hooks to integrate with WordPress.
+	 */
+	private function register_hooks() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'duplicate_post_admin_enqueue_block_editor_scripts' ) );
+	}
+
+	/**
+	 * Enqueues the necessary JavaScript code for the block editor.
+	 *
+	 * @return void
+	 */
+	public function duplicate_post_admin_enqueue_block_editor_scripts() {
+		\wp_enqueue_script(
+			'duplicate_post_edit_script',
+			\plugins_url( \sprintf( 'js/dist/duplicate-post-edit-%s.js', $this->duplicate_post_flatten_version( DUPLICATE_POST_CURRENT_VERSION ) ), DUPLICATE_POST_FILE ),
+			array(
+				'wp-blocks',
+				'wp-element',
+				'wp-i18n',
+			),
+			DUPLICATE_POST_CURRENT_VERSION,
+			true
+		);
+
+		\wp_localize_script(
+			'duplicate_post_edit_script',
+			'duplicatePostRewriteRepost',
+			array(
+				'permalink' => $this->duplicate_post_get_rewrite_republish_permalink(),
+			)
+		);
+	}
+
+	/**
+	 * Generates a rewrite and republish permalink for the current post.
+	 *
+	 * @return string The permalink. Returns empty if the post hasn't been published yet.
+	 */
+	private function duplicate_post_get_rewrite_republish_permalink() {
+		$post = get_post();
+		// phpcs:ignore WordPress.PHP.YodaConditions
+		if ( $post->post_status !== 'publish' ) {
+			return '';
+		}
+
+		return \duplicate_post_get_clone_post_link( $post->ID );
+	}
+
+	/**
+	 * Flattens a version number for use in a filename.
+	 *
+	 * @param string $version The original version number.
+	 *
+	 * @return string The flattened version number.
+	 */
+	private function duplicate_post_flatten_version( $version ) {
+		$parts = \explode( '.', $version );
+
+		if ( \count( $parts ) === 2 && \preg_match( '/^\d+$/', $parts[1] ) === 1 ) {
+			$parts[] = '0';
+		}
+
+		return \implode( '', $parts );
+	}
+}

--- a/src/class-duplicate-post.php
+++ b/src/class-duplicate-post.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Duplicate Post main class.
+ *
+ * @package Duplicate_Post
+ */
+
+/**
+ * Represents the Duplicate Post main class.
+ */
+class Duplicate_Post {
+
+	/**
+	 * Initializes the main class.
+	 */
+	public function __construct() {
+
+		// Handle the user interface.
+		new Duplicate_Post_User_Interface();
+	}
+}

--- a/src/class-duplicate-post.php
+++ b/src/class-duplicate-post.php
@@ -5,6 +5,8 @@
  * @package Duplicate_Post
  */
 
+namespace Yoast\WP\Duplicate_Post;
+
 /**
  * Represents the Duplicate Post main class.
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to ensure that future expansion of the code remains stable and testable by switching over to a class-based folder structure use autoloading in Composer.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces class autoloading in Composer and initial class folder structure.

## Relevant technical choices:

Please note this is a first pass at implementing autoloading. There are some architectural choices that should be discussed with architects (e.g. folder structure, Coding Standards to use) and there are no tests for now.

- adds a basic autoloading implementation
- adds initial class folder structure: note that at the moment the file names and class names are based on the WordPress PHPCS
- adds the class folder to the coding standards checks
- introduces a main class `Duplicate_Post`
- introduces a class `Duplicate_Post_User_Interface` meant to handle the plugin user interface
- moves some existing code into the `Duplicate_Post_User_Interface`:
  - for now, moves only the code related to the "Rewrite & Republish" link displayed in the Gutenberg sidebar
  - I opted to not move other code because it seems to me it's a bit intertwined with the legacy code
  - note: not sure whether the call to `duplicate_post_get_clone_post_link` in `Duplicate_Post_User_Interface` at line 66 is correct, please double check

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- run `composer install`, `yarn`, and `grunt build:js` to build the plugin
- run `composer check-cs` and observe there are only warnings related to pre-existing code
- activate the plugin
- edit a gutenberg **published** post
- observe there is a link "Rewrite & Republish" in the gutenberg sidebar (above "Mote to trash")
- check in your console there are no JS errors related to this link
- check the link works correctly: click on it and check it generates a copy of the post and redirects you to the copy


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

- No test instructions for QA: it was agreed this feature should be checked as a whole when implementation is complete.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-251]
