### PR TITLE
Composer: update dependency for Composer 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: SNIFF=1
 
 before_install:
-  - if [[ "$SNIFF" == "1" ]]; then composer self-update 1.10.16 && composer install; fi
+  - if [[ "$SNIFF" == "1" ]]; then composer install; fi
 
 script:
   - find -L . compat/ -maxdepth 1 -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "wp-coding-standards/wpcs": "^2.1",
         "squizlabs/php_codesniffer": "^3.5",
         "phpcompatibility/phpcompatibility-wp": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54299e9ec1e57c6c8a3a0d2589602658",
+    "content-hash": "b50faf29410327184c8aaa08a101188f",
     "packages": [],
     "packages-dev": [
         {
@@ -56,22 +56,22 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -118,7 +118,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "time": "2020-06-25T14:57:39+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -432,5 +432,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
## Context

* Update dev dependency for compatibility with Composer 2.0

## Summary

This PR can be summarized in the following changelog entry:

* Update dev dependency for compatibility with Composer 2.0

## Relevant technical choices:

The DealerDirect PHPCS Composer plugin is the only dependency which needs an update for compatibility with Composer 2.0.

Version `0.7.0`, which was released last June, is compatible with both Composer 1.x as well as 2.x.

This also removes the need for the `composer self-update` in the Travis script.

Ref:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Using `master`:
    - Using Composer 1.x, run `composer install` and see it works.
    - Update to Composer 2.x `composer self-update --2`
    - Run `composer install` again and see it fail.
* Switch to this branch, follow the same steps, but now successful for both Composer 1.x as well as 2.x.


### Test instructions for QA when the code is in the RC

N/A

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

