### PR TITLE
QA: use strict type checking when using `in_array()`

### DIFF
--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -166,7 +166,7 @@ function duplicate_post_get_edit_or_view_link( $post ) {
 			$title
 		);
 	} elseif ( duplicate_post_is_post_type_viewable( $post_type_object ) ) {
-		if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ) ) ) {
+		if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ), true ) ) {
 			if ( $can_edit_post ) {
 				$preview_link = get_preview_post_link( $post );
 				return sprintf(


### PR DESCRIPTION
## Context

* Code quality/Bug prevention

## Summary

This PR can be summarized in the following changelog entry:

* Code quality/Bug prevention

## Relevant technical choices:

Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

This is especially important when comparing variables which are expected to be strings, as when one of the two operands - for whatever reason, other plugins interfering, errors etc - is not a string, the other operand will be juggled to the type of the first operand which can lead to unexpected results and hard to debug bugs.

For array functions which do loose type comparisons, setting the third `$strict` parameter to `false` can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.

Ref: http://php.net/manual/en/function.in-array.php

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a code only change and should have no effect on functionality (except in case of a very rare and hard to reproduce bug)
