### PR TITLE
QA: remove two redundant htmlspecialchars() calls

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -662,7 +662,7 @@ function duplicate_post_save_as_new_post( $status = '' ) {
 			wp_die(
 				esc_html(
 					__( 'Copy creation failed, could not find original:', 'duplicate-post' ) . ' '
-					. htmlspecialchars( $id )
+					. $id
 				)
 			);
 		}
@@ -709,7 +709,7 @@ function duplicate_post_save_as_new_post( $status = '' ) {
 		wp_die(
 			esc_html(
 				__( 'Copy creation failed, could not find original:', 'duplicate-post' ) . ' '
-				. htmlspecialchars( $id )
+				. $id
 			)
 		);
 	}


### PR DESCRIPTION
## Context

* Code quality/performance/PHP cross-version compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Code quality/performance/PHP cross-version compatibility

## Relevant technical choices:

In both cases, `esc_htm()` is already used, so there is no need for the additional call to `htmlspecialchars()`.

This fixes a PHP cross-version incompatibility as the default charset value for `htmlspecialchars()` has changed across PHP versions, which means that the output could previously be inconsistent across PHP versions.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This change should have no effect on the functionality.