### PR TITLE
Docs: various fixes

### DIFF
--- a/compat/duplicate-post-gutenberg.php
+++ b/compat/duplicate-post-gutenberg.php
@@ -13,12 +13,12 @@ add_filter( 'duplicate_post_get_clone_post_link', 'duplicate_post_classic_editor
  *
  * @see duplicate_post_get_clone_post_link()
  *
- * @param string  $url The duplicate post link URL.
- * @param int     $post_id The original post ID.
- * @param string  $context The context in which the URL is used.
- * @param boolean $draft Whether the link is "New Draft" or "Clone".
+ * @param string $url     The duplicate post link URL.
+ * @param int    $post_id The original post ID.
+ * @param string $context The context in which the URL is used.
+ * @param bool   $draft   Whether the link is "New Draft" or "Clone".
  *
- * @return string $url
+ * @return string
  */
 function duplicate_post_classic_editor_clone_link( $url, $post_id, $context, $draft ) {
 	$post = get_post( $post_id );

--- a/compat/duplicate-post-wpml.php
+++ b/compat/duplicate-post-wpml.php
@@ -27,12 +27,12 @@ $duplicated_posts = array(); // phpcs:ignore WordPress.NamingConventions.PrefixA
 /**
  * Copy post translations.
  *
- * @global SitePress() $sitepress Instance of the Main WPML class.
- * @global array() $duplicated_posts Array of duplicated posts.
+ * @global SitePress $sitepress        Instance of the Main WPML class.
+ * @global array     $duplicated_posts Array of duplicated posts.
  *
- * @param integer $post_id ID of the copy.
- * @param WP_Post $post Original post object.
- * @param string  $status Status of the new post.
+ * @param int     $post_id ID of the copy.
+ * @param WP_Post $post    Original post object.
+ * @param string  $status  Status of the new post.
  */
 function duplicate_post_wpml_copy_translations( $post_id, $post, $status = '' ) {
 	global $sitepress;

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -742,6 +742,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 		if ( intval( get_option( 'duplicate_post_copyformat' ) ) === 0 ) {
 			$taxonomies_blacklist[] = 'post_format';
 		}
+
 		/**
 		 * Filters the taxonomy excludelist when copying a post.
 		 *
@@ -1034,6 +1035,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	 * @param integer $parent_id The parent post ID if we are calling this recursively.
 	 */
 	do_action( 'duplicate_post_pre_copy', $post, $status, $parent_id );
+
 	/**
 	 * Filter allowing to copy post.
 	 *
@@ -1205,7 +1207,7 @@ function duplicate_post_add_plugin_links( $links, $file ) {
 	return $links;
 }
 
-/*** NOTICES */
+/* NOTICES */
 
 /**
  * Shows a notice after the copy has succeeded.
@@ -1232,7 +1234,7 @@ function duplicate_post_action_admin_notice() {
 	}
 }
 
-/*** BULK ACTIONS */
+/* BULK ACTIONS */
 
 add_action( 'admin_init', 'duplicate_post_add_bulk_filters' );
 

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -294,7 +294,7 @@ function duplicate_post_show_update_notice() {
 /**
  * Dismisses the notice.
  *
- * @return boolean.
+ * @return bool
  */
 function duplicate_post_dismiss_notice() {
 	$result = update_site_option( 'duplicate_post_show_notice', 0 );
@@ -327,7 +327,7 @@ function duplicate_post_show_original_column() {
  * @ignore
  *
  * @param array $post_columns The post columns array.
- * @return array.
+ * @return array
  */
 function duplicate_post_add_original_column( $post_columns ) {
 	$post_columns['duplicate_post_original_item'] = __( 'Original item', 'duplicate-post' );
@@ -339,8 +339,8 @@ function duplicate_post_add_original_column( $post_columns ) {
  *
  * @ignore
  *
- * @param string  $column_name  The name for the current column.
- * @param integer $post_id     The ID for the current post.
+ * @param string $column_name The name for the current column.
+ * @param int    $post_id     The ID for the current post.
  */
 function duplicate_post_show_original_item( $column_name, $post_id ) {
 	if ( 'duplicate_post_original_item' === $column_name ) {
@@ -358,8 +358,8 @@ function duplicate_post_show_original_item( $column_name, $post_id ) {
  *
  * @ignore
  *
- * @param string $column_name  The name for the current column.
- * @param string $post_type    The post type for the current post.
+ * @param string $column_name The name for the current column.
+ * @param string $post_type   The post type for the current post.
  */
 function duplicate_post_quick_edit_remove_original( $column_name, $post_type ) {
 	if ( 'duplicate_post_original_item' !== $column_name ) {
@@ -402,7 +402,7 @@ function duplicate_post_quick_edit_remove_original( $column_name, $post_type ) {
  *
  * @ignore
  *
- * @param integer $post_id The current post ID.
+ * @param int $post_id The current post ID.
  * @return void
  */
 function duplicate_post_save_quick_edit_data( $post_id ) {
@@ -425,7 +425,7 @@ function duplicate_post_save_quick_edit_data( $post_id ) {
  * @ignore
  *
  * @param array    $post_states The array of post states.
- * @param \WP_Post $post The current post.
+ * @param \WP_Post $post        The current post.
  * @return array
  */
 function duplicate_post_show_original_in_post_states( $post_states, $post ) {
@@ -527,8 +527,8 @@ function duplicate_post_custom_box_html( $post ) {
  * Adds the link to action list for post_row_actions.
  *
  * @param array   $actions The actions array.
- * @param WP_Post $post The post object.
- * @return array.
+ * @param WP_Post $post    The post object.
+ * @return array
  */
 function duplicate_post_make_duplicate_link_row( $actions, $post ) {
 	// $title = empty( $post->post_title ) ? __( '(no title)', 'duplicate-post' ) : $post->post_title;
@@ -622,7 +622,7 @@ function duplicate_post_save_as_new_post_draft() {
  * @ignore
  *
  * @param array $removable_query_args Array of query args keys.
- * @return array.
+ * @return array
  */
 function duplicate_post_add_removable_query_arg( $removable_query_args ) {
 	$removable_query_args[] = 'cloned';
@@ -720,8 +720,8 @@ function duplicate_post_save_as_new_post( $status = '' ) {
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param integer $new_id New post ID.
- * @param WP_Post $post The original post object.
+ * @param int     $new_id New post ID.
+ * @param WP_Post $post   The original post object.
  */
 function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 	global $wpdb;
@@ -748,7 +748,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 		 *
 		 * @param array $taxonomies_blacklist The taxonomy excludelist from the options.
 		 *
-		 * @return array.
+		 * @return array
 		 */
 		$taxonomies_blacklist = apply_filters( 'duplicate_post_taxonomies_excludelist_filter', $taxonomies_blacklist );
 
@@ -768,8 +768,8 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 /**
  * Copies the meta information of a post to another post
  *
- * @param integer $new_id The new post ID.
- * @param WP_Post $post The original post object.
+ * @param int     $new_id The new post ID.
+ * @param WP_Post $post   The original post object.
  */
 function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	$post_meta_keys = get_post_custom_keys( $post->ID );
@@ -798,7 +798,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	 *
 	 * @param array $meta_blacklist The meta fields excludelist from the options.
 	 *
-	 * @return array.
+	 * @return array
 	 */
 	$meta_blacklist = apply_filters( 'duplicate_post_blacklist_filter', $meta_blacklist );
 
@@ -821,7 +821,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	 *
 	 * @param array $meta_keys The list of meta fields name, with the ones in the excludelist already removed.
 	 *
-	 * @return array.
+	 * @return array
 	 */
 	$meta_keys = apply_filters( 'duplicate_post_meta_keys_filter', $meta_keys );
 
@@ -841,7 +841,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
  * @ignore
  *
  * @param mixed $value Array or object to be recursively slashed.
- * @return string|mixed.
+ * @return string|mixed
  */
 function duplicate_post_addslashes_deep( $value ) {
 	if ( function_exists( 'map_deep' ) ) {
@@ -857,7 +857,7 @@ function duplicate_post_addslashes_deep( $value ) {
  * @ignore
  *
  * @param mixed $value Value to slash only if string.
- * @return string|mixed.
+ * @return string|mixed
  */
 function duplicate_post_addslashes_to_strings_only( $value ) {
 	return is_string( $value ) ? addslashes( $value ) : $value;
@@ -869,7 +869,7 @@ function duplicate_post_addslashes_to_strings_only( $value ) {
  * @ignore
  *
  * @param mixed $value What to add slash to.
- * @return mixed.
+ * @return mixed
  */
 function duplicate_post_wp_slash( $value ) {
 	return duplicate_post_addslashes_deep( $value );
@@ -878,8 +878,8 @@ function duplicate_post_wp_slash( $value ) {
 /**
  * Copies attachments, including physical files.
  *
- * @param integer $new_id The new post ID.
- * @param WP_Post $post The original post object.
+ * @param int     $new_id The new post ID.
+ * @param WP_Post $post   The original post object.
  */
 function duplicate_post_copy_attachments( $new_id, $post ) {
 	// get thumbnail ID.
@@ -941,8 +941,8 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 /**
  * Copies child posts.
  *
- * @param integer $new_id The new post ID.
- * @param WP_Post $post The original post object.
+ * @param int     $new_id The new post ID.
+ * @param WP_Post $post   The original post object.
  * @param string  $status Optional. The destination status.
  */
 function duplicate_post_copy_children( $new_id, $post, $status = '' ) {
@@ -967,8 +967,8 @@ function duplicate_post_copy_children( $new_id, $post, $status = '' ) {
 /**
  * Copies comments.
  *
- * @param integer $new_id The new post ID.
- * @param WP_Post $post The original post object.
+ * @param int     $new_id The new post ID.
+ * @param WP_Post $post   The original post object.
  */
 function duplicate_post_copy_comments( $new_id, $post ) {
 	$comments = get_comments(
@@ -1021,30 +1021,30 @@ function duplicate_post_copy_comments( $new_id, $post ) {
  *
  * This is the main functions that does the cloning.
  *
- * @param WP_Post $post The original post object.
- * @param string  $status Optional. The intended destination status.
+ * @param WP_Post $post      The original post object.
+ * @param string  $status    Optional. The intended destination status.
  * @param string  $parent_id Optional. The parent post ID if we are calling this recursively.
- * @return number|WP_Error.
+ * @return number|WP_Error
  */
 function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' ) {
 	/**
 	 * Fires before duplicating a post.
 	 *
 	 * @param WP_Post $post      The original post object.
-	 * @param boolean $status    The intended destination status.
-	 * @param integer $parent_id The parent post ID if we are calling this recursively.
+	 * @param bool    $status    The intended destination status.
+	 * @param int     $parent_id The parent post ID if we are calling this recursively.
 	 */
 	do_action( 'duplicate_post_pre_copy', $post, $status, $parent_id );
 
 	/**
 	 * Filter allowing to copy post.
 	 *
-	 * @param boolean $can_duplicate Default to `true`.
+	 * @param bool    $can_duplicate Default to `true`.
 	 * @param WP_Post $post          The original post object.
-	 * @param boolean $status        The intended destination status.
-	 * @param integer $parent_id     The parent post ID if we are calling this recursively.
+	 * @param bool    $status        The intended destination status.
+	 * @param int     $parent_id     The parent post ID if we are calling this recursively.
 	 *
-	 * @return boolean.
+	 * @return bool
 	 */
 	$can_duplicate = apply_filters( 'duplicate_post_allow', true, $post, $status, $parent_id );
 	if ( ! $can_duplicate ) {
@@ -1161,7 +1161,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	 * @param array   $new_post New post values.
 	 * @param WP_Post $post     Original post object.
 	 *
-	 * @return array.
+	 * @return array
 	 */
 	$new_post    = apply_filters( 'duplicate_post_new_post', $new_post, $post );
 	$new_post_id = wp_insert_post( wp_slash( $new_post ), true );
@@ -1183,10 +1183,10 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	/**
 	 * Fires after duplicating a post.
 	 *
-	 * @param integer|WP_Error $new_post_id The new post id or WP_Error object on error.
-	 * @param WP_Post          $post        The original post object.
-	 * @param boolean          $status      The intended destination status.
-	 * @param integer          $parent_id   The parent post ID if we are calling this recursively.
+	 * @param int|WP_Error $new_post_id The new post id or WP_Error object on error.
+	 * @param WP_Post      $post        The original post object.
+	 * @param bool         $status      The intended destination status.
+	 * @param int          $parent_id   The parent post ID if we are calling this recursively.
 	 */
 	do_action( 'duplicate_post_post_copy', $new_post_id, $post, $status, $parent_id );
 
@@ -1197,8 +1197,8 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
  * Adds some links on the plugin page.
  *
  * @param array  $links The links array.
- * @param string $file The file name.
- * @return array.
+ * @param string $file  The file name.
+ * @return array
  */
 function duplicate_post_add_plugin_links( $links, $file ) {
 	if ( plugin_basename( dirname( __FILE__ ) . '/duplicate-post.php' ) === $file ) {
@@ -1281,9 +1281,9 @@ function duplicate_post_register_bulk_action( $bulk_actions ) {
  * @ignore
  *
  * @param string $redirect_to The URL to redirect to.
- * @param string $doaction The action that has been called.
- * @param array  $post_ids The array of marked post IDs.
- * @return string.
+ * @param string $doaction    The action that has been called.
+ * @param array  $post_ids    The array of marked post IDs.
+ * @return string
  */
 function duplicate_post_action_handler( $redirect_to, $doaction, $post_ids ) {
 	if ( 'duplicate_post_clone' !== $doaction ) {
@@ -1314,9 +1314,9 @@ function duplicate_post_action_handler( $redirect_to, $doaction, $post_ids ) {
  *
  * @ignore
  *
- * @param WP_Post $post The post object.
+ * @param WP_Post $post     The post object.
  * @param array   $post_ids The array of marked post IDs.
- * @return boolean.
+ * @return bool
  */
 function duplicate_post_has_ancestors_marked( $post, $post_ids ) {
 	$ancestors_in_array = 0;

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -87,10 +87,10 @@ function duplicate_post_get_clone_post_link( $id = 0, $context = 'display', $dra
 /**
  * Displays duplicate post link for post.
  *
- * @param string $link   Optional. Anchor text.
- * @param string $before Optional. Display before edit link.
- * @param string $after  Optional. Display after edit link.
- * @param int    $id     Optional. Post ID.
+ * @param string|null $link   Optional. Anchor text.
+ * @param string      $before Optional. Display before edit link.
+ * @param string      $after  Optional. Display after edit link.
+ * @param int         $id     Optional. Post ID.
  */
 function duplicate_post_clone_post_link( $link = null, $before = '', $after = '', $id = 0 ) {
 	$post = get_post( $id );
@@ -123,8 +123,8 @@ function duplicate_post_clone_post_link( $link = null, $before = '', $after = ''
 /**
  * Gets the original post.
  *
- * @param int    $post   Optional. Post ID or Post object.
- * @param string $output Optional, default is Object. Either OBJECT, ARRAY_A, or ARRAY_N.
+ * @param int|null $post   Optional. Post ID or Post object.
+ * @param string   $output Optional, default is Object. Either OBJECT, ARRAY_A, or ARRAY_N.
  * @return mixed Post data.
  */
 function duplicate_post_get_original( $post = null, $output = OBJECT ) {
@@ -146,7 +146,7 @@ function duplicate_post_get_original( $post = null, $output = OBJECT ) {
  * @ignore
  *
  * @param WP_Post $post Post ID or Post object.
- * @return string
+ * @return string|null
  */
 function duplicate_post_get_edit_or_view_link( $post ) {
 	$post = get_post( $post );

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -9,7 +9,7 @@
 /**
  * Tests if the user is allowed to copy posts.
  *
- * @return boolean.
+ * @return bool
  */
 function duplicate_post_is_current_user_allowed_to_copy() {
 	return current_user_can( 'copy_posts' );
@@ -19,7 +19,7 @@ function duplicate_post_is_current_user_allowed_to_copy() {
  * Tests if post type is enable to be copied.
  *
  * @param string $post_type The post type to check.
- * @return boolean.
+ * @return bool
  */
 function duplicate_post_is_post_type_enabled( $post_type ) {
 	$duplicate_post_types_enabled = get_option( 'duplicate_post_types_enabled', array( 'post', 'page' ) );
@@ -32,10 +32,10 @@ function duplicate_post_is_post_type_enabled( $post_type ) {
 /**
  * Template tag to retrieve/display duplicate post link for post.
  *
- * @param int     $id Optional. Post ID.
- * @param string  $context Optional, default to display. How to write the '&', defaults to '&amp;'.
- * @param boolean $draft Optional, default to true.
- * @return string.
+ * @param int    $id      Optional. Post ID.
+ * @param string $context Optional, default to display. How to write the '&', defaults to '&amp;'.
+ * @param bool   $draft   Optional, default to true.
+ * @return string
  */
 function duplicate_post_get_clone_post_link( $id = 0, $context = 'display', $draft = true ) {
 	if ( ! duplicate_post_is_current_user_allowed_to_copy() ) {
@@ -72,10 +72,10 @@ function duplicate_post_get_clone_post_link( $id = 0, $context = 'display', $dra
 		/**
 		 * Filter on the URL of the clone link
 		 *
-		 * @param string $url  The URL of the clone link.
-		 * @param int    $ID   The ID of the post
+		 * @param string $url     The URL of the clone link.
+		 * @param int    $ID      The ID of the post
 		 * @param string $context The context in which the URL is used.
-		 * @param bool   $draft Whether to clone to a new draft.
+		 * @param bool   $draft   Whether to clone to a new draft.
 		 *
 		 * @return string
 		 */
@@ -87,10 +87,10 @@ function duplicate_post_get_clone_post_link( $id = 0, $context = 'display', $dra
 /**
  * Displays duplicate post link for post.
  *
- * @param string $link Optional. Anchor text.
+ * @param string $link   Optional. Anchor text.
  * @param string $before Optional. Display before edit link.
- * @param string $after Optional. Display after edit link.
- * @param int    $id Optional. Post ID.
+ * @param string $after  Optional. Display after edit link.
+ * @param int    $id     Optional. Post ID.
  */
 function duplicate_post_clone_post_link( $link = null, $before = '', $after = '', $id = 0 ) {
 	$post = get_post( $id );
@@ -123,7 +123,7 @@ function duplicate_post_clone_post_link( $link = null, $before = '', $after = ''
 /**
  * Gets the original post.
  *
- * @param int    $post Optional. Post ID or Post object.
+ * @param int    $post   Optional. Post ID or Post object.
  * @param string $output Optional, default is Object. Either OBJECT, ARRAY_A, or ARRAY_N.
  * @return mixed Post data.
  */
@@ -196,7 +196,7 @@ function duplicate_post_get_edit_or_view_link( $post ) {
  *
  * @ignore
  *
- * @param mixed $post_type  The post type to check.
+ * @param mixed $post_type The post type to check.
  * @return bool
  */
 function duplicate_post_is_post_type_viewable( $post_type ) {
@@ -216,7 +216,7 @@ function duplicate_post_is_post_type_viewable( $post_type ) {
 /**
  * Shows link in the Toolbar.
  *
- * @global WP_Query $wp_the_query.
+ * @global WP_Query     $wp_the_query
  * @global WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
  */
 function duplicate_post_admin_bar_render() {
@@ -338,7 +338,7 @@ function duplicate_post_init() {
  * @ignore
  * @param WP_Taxonomy $a First taxonomy object.
  * @param WP_Taxonomy $b Second taxonomy object.
- * @return boolean.
+ * @return bool
  */
 function duplicate_post_tax_obj_cmp( $a, $b ) {
 	return ( $a->public < $b->public );

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -108,6 +108,7 @@ function duplicate_post_clone_post_link( $link = null, $before = '', $after = ''
 	}
 
 	$link = '<a class="post-clone-link" href="' . $url . '">' . $link . '</a>';
+
 	/**
 	 * Filter on the clone link HTML
 	 *

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -77,8 +77,8 @@ function duplicate_post_add_options_page_css() {
 /**
  * Show options page.
  *
- * @global WP_Roles $wp_roles WordPress User Roles.
- * @global string $wp_version The WordPress version string.
+ * @global WP_Roles $wp_roles   WordPress User Roles.
+ * @global string   $wp_version The WordPress version string.
  */
 function duplicate_post_options() {
 	global $wp_roles, $wp_version;

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -10,9 +10,7 @@
  *
  * @package Duplicate Post
  * @since 0.1
- **/
-
-/*
+ *
  * Copyright 2020 Yoast BV (email : info@yoast.com)
  *
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
## Context

* Improved code documentation

## Summary

This PR can be summarized in the following changelog entry:

* Improved code documentation

## Relevant technical choices:

### CS: minor comment format fixes

* Have only one file comment.
* Only use docblock syntax for documenting structural elements.
* Always have a blank line above a docblock.

### CS: various documentation fixes

* Use short form type keywords, i.e. `int` instead of `integer`, `bool` instead of `boolean`.
* Alignment of variable names and descriptions in `@param` and `@global` tags.
* Remove redundant variable name in `@return` tag. The variable name is an implementation detail and not exposed to the calling function.
* Remove stray punctuation. Proper punctuation should definitely be used when there is a description, but if a `@return` tag only provides the `type` without further description, there should not be a period `.` at the end.

### Docs: add missing types

Fix a few parameter/return tags for allowing a `null` default value/returning `null`, but not saying so in the docs.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ These are documentation only changes.