### PR TITLE
P3-235 allow duplicate focus keywords

### DIFF
--- a/src/class-duplicate-post-user-interface.php
+++ b/src/class-duplicate-post-user-interface.php
@@ -35,8 +35,8 @@ class Duplicate_Post_User_Interface {
 	 * @return void
 	 */
 	private function register_hooks() {
-		add_action( 'enqueue_block_editor_assets', array( $this, 'duplicate_post_admin_enqueue_block_editor_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'should_previously_used_keyword_assessment_run' ), 9 );
+		\add_action( 'enqueue_block_editor_assets', array( $this, 'duplicate_post_admin_enqueue_block_editor_scripts' ) );
+		\add_action( 'admin_enqueue_scripts', array( $this, 'should_previously_used_keyword_assessment_run' ), 9 );
 	}
 
 	/**
@@ -45,20 +45,20 @@ class Duplicate_Post_User_Interface {
 	 * @return void
 	 */
 	public function should_previously_used_keyword_assessment_run() {
-		if ( ! in_array( $this->pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
+		if ( ! \in_array( $this->pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
 			return;
 		}
 
-		$post = get_post();
+		$post = \get_post();
 
-		if ( null === $post ) {
+		if ( ! $post ) {
 			return;
 		}
 
-		$skip_assessment = get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true );
+		$skip_assessment = \get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true );
 
 		if ( ! empty( $skip_assessment ) ) {
-			add_filter( 'wpseo_previously_used_keyword_active', '__return_false' );
+			\add_filter( 'wpseo_previously_used_keyword_active', '__return_false' );
 		}
 	}
 

--- a/src/class-duplicate-post-user-interface.php
+++ b/src/class-duplicate-post-user-interface.php
@@ -15,7 +15,7 @@ class Duplicate_Post_User_Interface {
 	/**
 	 * Holds the post.
 	 *
-	 * @var WP_Post
+	 * @var \WP_Post
 	 */
 	private $post = null;
 

--- a/src/class-duplicate-post-user-interface.php
+++ b/src/class-duplicate-post-user-interface.php
@@ -13,6 +13,13 @@ namespace Yoast\WP\Duplicate_Post;
 class Duplicate_Post_User_Interface {
 
 	/**
+	 * Holds the post.
+	 *
+	 * @var WP_Post
+	 */
+	private $post = null;
+
+	/**
 	 * Holds the global `$pagenow` variable's value.
 	 *
 	 * @var string
@@ -49,13 +56,11 @@ class Duplicate_Post_User_Interface {
 			return;
 		}
 
-		$post = \get_post();
-
-		if ( ! $post ) {
-			return;
+		if ( ! $this->post ) {
+			$this->post = \get_post();
 		}
 
-		$skip_assessment = \get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true );
+		$skip_assessment = \get_post_meta( $this->post->ID, '_dp_is_rewrite_republish_copy', true );
 
 		if ( ! empty( $skip_assessment ) ) {
 			\add_filter( 'wpseo_previously_used_keyword_active', '__return_false' );
@@ -95,13 +100,16 @@ class Duplicate_Post_User_Interface {
 	 * @return string The permalink. Returns empty if the post hasn't been published yet.
 	 */
 	private function duplicate_post_get_rewrite_republish_permalink() {
-		$post = get_post();
+		if ( ! $this->post ) {
+			$this->post = \get_post();
+		}
+
 		// phpcs:ignore WordPress.PHP.YodaConditions
-		if ( $post->post_status !== 'publish' ) {
+		if ( $this->post->post_status !== 'publish' ) {
 			return '';
 		}
 
-		return \duplicate_post_get_clone_post_link( $post->ID );
+		return \duplicate_post_get_clone_post_link( $this->post->ID );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to allow post duplicated for Rewrite & Republish to share the same keyphrase with the original post without triggering the Previously Used Keyword analysis assessment, which would be misleading for these temporary copies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows previously used keyphrases on duplicated posts intended for Rewrite & Repubish.

## Relevant technical choices:

- needs https://github.com/Yoast/wordpress-seo/pull/16319 which adds a filter to enable / disable the analysis assessment
- triggers the filter to disable the assessment based on a post meta set on the posts intended for Rewrite & Repubish
- this PR _does not_ add the post meta: there's another issue for that, see P3-230

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- activate Yoast SEO, switch it to the `P3-235-allow-duplicate-focus-keyowrds-filter` (note the typo in the branch name, see https://github.com/Yoast/wordpress-seo/pull/16319) branch and build
- activate Duplicate Post, switch it to this branch and build
- check the Previously Used Keyword analysis assessment works for normal copies by:
  - edit a post, set a focus keyphrase for testing, and save
  - from the post overview, click the "Clone" or "New Draft" links
  - edit the duplicated post and see it has the same focus keyphrase
  - open the SEO analysis panel and see there is an assessment that says "Previously used keyphrase ..."
- for now, to test the disabled assessment you need to alter the code by:
  - in the file `duplicate-post-admin.php` add this: `add_post_meta( $new_post_id, '_dp_is_rewrite_republish_copy', $post->ID );` in the function `duplicate_post_create_duplicate()` after `add_post_meta( $new_post_id, '_dp_original', $post->ID );`
  - note: the code that will actually set the post meta should be implemented in P3-230
  - duplicate another post which as a focus keyphrase by clicking the link "Rewrite & Republish"
  - note: right now, all the 3 links (Clone, New draft, Rewrite & Republish) have basically the same effect for this PR
  - inspect the database: check the `wp_postmeta` table contains an entry with `meta_key` that is `_dp_is_rewrite_republish_copy`
  - the `meta_value` is the original post ID
  - edit the duplicated post and see it has the same focus keyphrase
  - open the SEO analysis panel and see _there's no_ assessment that says "Previously used keyphrase ..."
- test with both Classic Editor and Gutenberg
  


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

- N/A as it was decided the Rewrite & Republish feature should be tested as a whole once the implementation is complete

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-235]