### PR TITLE
Travis: lint files against PHP 8 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
     - '7.2'
     - '7.3'
     - '7.4'
+    - "nightly"
 
 matrix:
   include:
@@ -24,10 +25,13 @@ matrix:
     - php: '7.4'
       env: SNIFF=1
 
+  allow_failures:
+    - php: "nightly"
+
 before_install:
   - if [[ "$SNIFF" == "1" ]]; then composer install; fi
 
 script:
-  - find -L . compat/ -maxdepth 1 -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+  - find -L . ./compat/ ./src/ -maxdepth 1 -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
   - if [[ "$SNIFF" == "1" ]]; then composer check-vip; fi


### PR DESCRIPTION
## Context

* Improve QA/CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve QA/CI

## Relevant technical choices:

Lint files against PHP 8 as well and lint the new `src` directory too.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check the Travis output: has the additional build been added ? And does the linting of the files run correctly ?
    Note: until PHP 8 is released, the build will be allowed to fail.

