### PR TITLE
P3-258 Style the copy links in the editors

### DIFF
--- a/duplicate-post.css
+++ b/duplicate-post.css
@@ -4,6 +4,27 @@
 	top: 2px;
 }
 
+/* Copy links in the classic editor. */
+#duplicate-action {
+	margin-bottom: 12px;
+}
+
+#rewrite-republish-action {
+	margin-bottom: -2px;
+}
+
+#rewrite-republish-action + #delete-action {
+	margin-top: 8px;
+}
+
+/* Copy links in the block editor. */
+.components-button.dp-editor-post-copy-to-draft,
+.components-button.dp-editor-post-rewrite-republish {
+	margin-left: -6px;
+	text-decoration: underline;
+}
+
+
 @media screen and (max-width: 782px){
 	#wpadminbar li#wp-admin-bar-new_draft{
 		display: block;
@@ -27,6 +48,10 @@
 		text-align: center;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+	}
+
+	#rewrite-republish-action + #delete-action {
+		margin-top: 0;
 	}
 }
 

--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -17,6 +17,7 @@ const render = () => (
 			<PluginPostStatusInfo>
 				<Button
 					isTertiary={ true }
+					className="dp-editor-post-copy-to-draft"
 					href={ duplicatePost.new_draft_link }
 				>
 					{ __( 'Copy to a new draft', 'duplicate-post' ) }
@@ -27,6 +28,7 @@ const render = () => (
 			<PluginPostStatusInfo>
 				<Button
 					isTertiary={ true }
+					className="dp-editor-post-rewrite-republish"
 					href={ duplicatePost.rewrite_and_republish_link }
 				>
 					{ __( 'Rewrite & Republish', 'duplicate-post' ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to match the design of the copy links in the classic editor and block editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the styling of the copy links in the Classic editor and Block editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Preliminary step:**
- run `grunt build:js` so that the new CSS classes are applied to the links in Gutenberg

**Test in the Classic Editor first:**
- install and activate the Classic Editor plugin
- edit a published post using the Classic Editor 
- observe the publish box in the right sidebar
- compare with [the design](https://www.sketch.com/s/2ec4254a-9529-4616-abe7-f6262c2ed6dd/a/j5b9r7) and make sure that:
  - the 3 links "Copy to a new draft", "Rewrite & Republish", and "Move to trash", are equally spaced vertically
  - "Move to trash" is pushed a bit to the bottom compared to its normal position, to match the design
- test in the responsive view by using your browser's dev tools and emulating a viewport width less than 782 pixels
- check the 3 links are still equally spaced ("Move to trash" is not pushed to the bottom any longer)

**Test in Gutenberg:**
- deactivate the Classic Editor plugin
- edit a published post using Gutenberg
- note: [the provided design](https://www.sketch.com/s/2ec4254a-9529-4616-abe7-f6262c2ed6dd/a/xGK80A) missed the "Copy to a new draft"  button but it can still be used as reference for the desired design, to some extent
- observe the 3 links in the "Document" sidebar
- check they're equally spaced and aligned to the left
- check the "Copy to a new draft" and "Rewrite & Republish" links are underlined
- check in the responsive view
- you will need to click the "Settings" icon (the "cog" icon) at the top to make the Document sidebar appear again
- check the 3 links are still equally spaced and aligned to the left

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

- **N/A: QA will test the full feature later.**

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-258]
