### PR TITLE
P3-278 Display status and link to original for Rewrite & Republish copies.

### DIFF
--- a/src/ui/class-post-states.php
+++ b/src/ui/class-post-states.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use Yoast\WP\Duplicate_Post\Permissions_Helper;
+
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
@@ -15,9 +17,20 @@ use Yoast\WP\Duplicate_Post\Utils;
 class Post_States {
 
 	/**
-	 * Initializes the class.
+	 * Holds the permissions helper.
+	 *
+	 * @var Permissions_Helper
 	 */
-	public function __construct() {
+	protected $permissions_helper;
+
+	/**
+	 * Initializes the class.
+	 *
+	 * @param Permissions_Helper $permissions_helper The Permissions helper object.
+	 */
+	public function __construct( Permissions_Helper $permissions_helper ) {
+		$this->permissions_helper = $permissions_helper;
+
 		$this->register_hooks();
 	}
 
@@ -27,9 +40,7 @@ class Post_States {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( \intval( \get_option( 'duplicate_post_show_original_in_post_states' ) ) === 1 ) {
-			\add_filter( 'display_post_states', [ $this, 'show_original_in_post_states' ], 10, 2 );
-		}
+		\add_filter( 'display_post_states', [ $this, 'show_original_in_post_states' ], 10, 2 );
 	}
 
 	/**
@@ -41,11 +52,24 @@ class Post_States {
 	 * @return array The updated post states array.
 	 */
 	public function show_original_in_post_states( $post_states, $post ) {
-		$original_item = Utils::get_original( $post );
-		if ( $original_item ) {
-			/* translators: Original item link (to view or edit) or title. */
+		$original_item                 = Utils::get_original( $post );
+		$is_rewrite_and_republish_copy = $this->permissions_helper->is_rewrite_and_republish_copy( $post );
+
+		if ( ! $original_item ) {
+			return $post_states;
+		}
+
+		if ( $is_rewrite_and_republish_copy ) {
+			/* translators: %s: Original item link (to view or edit) or title. */
+			$post_states['duplicate_post_original_item'] = \sprintf( \esc_html__( 'Rewrite & Republish of %s', 'duplicate-post' ), Utils::get_edit_or_view_link( $original_item ) );
+			return $post_states;
+		}
+
+		if ( \intval( \get_option( 'duplicate_post_show_original_in_post_states' ) ) === 1 ) {
+			/* translators: %s: Original item link (to view or edit) or title. */
 			$post_states['duplicate_post_original_item'] = \sprintf( __( 'Original: %s', 'duplicate-post' ), Utils::get_edit_or_view_link( $original_item ) );
 		}
+
 		return $post_states;
 	}
 }

--- a/src/ui/class-post-states.php
+++ b/src/ui/class-post-states.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\Duplicate_Post\UI;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
-
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
@@ -52,14 +51,13 @@ class Post_States {
 	 * @return array The updated post states array.
 	 */
 	public function show_original_in_post_states( $post_states, $post ) {
-		$original_item                 = Utils::get_original( $post );
-		$is_rewrite_and_republish_copy = $this->permissions_helper->is_rewrite_and_republish_copy( $post );
+		$original_item = Utils::get_original( $post );
 
 		if ( ! $original_item ) {
 			return $post_states;
 		}
 
-		if ( $is_rewrite_and_republish_copy ) {
+		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			/* translators: %s: Original item link (to view or edit) or title. */
 			$post_states['duplicate_post_original_item'] = \sprintf( \esc_html__( 'Rewrite & Republish of %s', 'duplicate-post' ), Utils::get_edit_or_view_link( $original_item ) );
 			return $post_states;

--- a/src/ui/class-user-interface.php
+++ b/src/ui/class-user-interface.php
@@ -97,7 +97,7 @@ class User_Interface {
 		$this->block_editor       = new Block_Editor( $this->link_builder, $this->permissions_helper );
 		$this->admin_bar          = new Admin_Bar( $this->link_builder, $this->permissions_helper );
 		$this->bulk_actions       = new Bulk_Actions( $this->permissions_helper );
-		$this->post_states        = new Post_States();
+		$this->post_states        = new Post_States( $this->permissions_helper );
 		$this->metabox            = new Metabox( $this->permissions_helper );
 		$this->column             = new Column( $this->permissions_helper );
 

--- a/tests/ui/class-post-states-test.php
+++ b/tests/ui/class-post-states-test.php
@@ -129,8 +129,7 @@ class Post_States_Test extends TestCase {
 
 		$this->permissions_helper
 			->expects( 'is_rewrite_and_republish_copy' )
-			->with( $post )
-			->andReturnFalse();
+			->never();
 
 		Monkey\Functions\expect( '\get_option' )
 			->with( 'duplicate_post_show_original_in_post_states' )
@@ -213,8 +212,7 @@ class Post_States_Test extends TestCase {
 
 		$this->permissions_helper
 			->expects( 'is_rewrite_and_republish_copy' )
-			->with( $post )
-			->andReturnFalse();
+			->never();
 
 		$utils->expects( 'get_edit_or_view_link' )
 			->never();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want users to be able to distinguish the Rewrite & Republish copies from the other posts and display the link to the original post

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Displays the Rewrite & Republish copies status and link to the original in the Posts list.

## Relevant technical choices:

- After conversation with @enricobattocchi we decided to always display the bold text "Rewrite & Republish of {original post title}" regardless of user settings.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- go in the WordPress posts list
- make a clone of a post by clicking the link "Clone"
- make a new draft of the same post by clicking the link "New Draft"
- go back to the posts list
- make a Rewrite & Republish copy of the same post by clicking the "Rewrite & Republish" link
- go back to the posts list
- observe the first 2 copies only display the bold text " — Draft"
- observe the Rewrite & Republish copy displays the bold text " — Draft, Rewrite & Republish of {original post title here}"

Screenshot:

<img width="529" alt="Screenshot 2020-12-14 at 15 50 43" src="https://user-images.githubusercontent.com/1682452/102102301-eb78a400-3e2b-11eb-973a-74afb3bedb12.png">

- gp to Settings > Duplicate Post > Display > Show original item, and check the checkbox "After the title in the Post list"
- go back to the posts list
- observe the first two copies now display the bold text "Original:" and the link to the original
- observe the displaying of the Rewrite & Republish copy is unchanged

Screenshot:

<img width="526" alt="Screenshot 2020-12-14 at 15 51 12" src="https://user-images.githubusercontent.com/1682452/102102676-65109200-3e2c-11eb-88b4-51d90a644bd9.png">



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A: it was decided the Rewrite and Republish feature will be tested as a whole once completed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-278]
