### PR TITLE
P3-280 Handle the cases when a copy is saved as draft, pending, private, etc.

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -41,6 +41,10 @@ class DuplicatePost {
 			const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
 			const isSavingMetaBoxes  = select( 'core/edit-post' ).isSavingMetaBoxes();
 
+			if ( ! this.is_copy_allowed_to_be_republished() ) {
+				return;
+			}
+
 			// When there are custom meta boxes, redirect after they're saved.
 			if ( hasActiveMetaBoxes && ! isSavingMetaBoxes && wasSavingMetaboxes ) {
 				window.location.assign( duplicatePost.originalEditURL );
@@ -74,6 +78,21 @@ class DuplicatePost {
 			/\/wp-admin\/post\.php$/.test( parser.pathname ) &&
 			/\?action=edit&post=[0-9]+&dprepublished=1&dpcopy=[0-9]+&dpnonce=[a-z0-9]+/i.test( parser.search )
 		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determines whether a Rewrite & Republish copy can be republished.
+	 *
+	 * @return bool Whether the Rewrite & Republish copy can be republished.
+	 */
+	is_copy_allowed_to_be_republished() {
+		const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+
+		if ( currentPostStatus === 'dp-rewrite-republish' || currentPostStatus === 'private' ) {
 			return true;
 		}
 

--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -41,7 +41,7 @@ class DuplicatePost {
 			const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
 			const isSavingMetaBoxes  = select( 'core/edit-post' ).isSavingMetaBoxes();
 
-			if ( ! this.is_copy_allowed_to_be_republished() ) {
+			if ( ! this.isCopyAllowedToBeRepublished() ) {
 				return;
 			}
 
@@ -89,7 +89,7 @@ class DuplicatePost {
 	 *
 	 * @return bool Whether the Rewrite & Republish copy can be republished.
 	 */
-	is_copy_allowed_to_be_republished() {
+	isCopyAllowedToBeRepublished() {
 		const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
 
 		if ( currentPostStatus === 'dp-rewrite-republish' || currentPostStatus === 'private' ) {

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -201,10 +201,6 @@ class Permissions_Helper {
 	 * @return bool Whether the Rewrite & Republish copy can be republished.
 	 */
 	public function is_copy_allowed_to_be_republished( \WP_Post $post ) {
-		if ( $post->post_status === 'dp-rewrite-republish' || $post->post_status === 'private' ) {
-			return true;
-		}
-
-		return false;
+		return \in_array( $post->post_status, [ 'dp-rewrite-republish', 'private' ], true );
 	}
 }

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -192,4 +192,19 @@ class Permissions_Helper {
 
 		return $post_type_object->public && $post_type_object->show_in_admin_bar;
 	}
+
+	/**
+	 * Determines whether a Rewrite & Republish copy can be republished.
+	 *
+	 * @param \WP_Post $post The post object.
+	 *
+	 * @return bool Whether the Rewrite & Republish copy can be republished.
+	 */
+	public function is_copy_allowed_to_be_republished( \WP_Post $post ) {
+		if ( $post->post_status === 'dp-rewrite-republish' || $post->post_status === 'private' ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -52,6 +52,7 @@ class Post_Republisher {
 	public function register_hooks() {
 		\add_action( 'init', [ $this, 'register_post_statuses' ] );
 		\add_filter( 'wp_insert_post_data', [ $this, 'change_post_copy_status' ], 1, 2 );
+		\add_filter( 'display_post_states', [ $this, 'add_rewrite_schedule_display_state' ], 9, 2 );
 
 		$enabled_post_types = $this->permissions_helper->get_enabled_post_types();
 		foreach ( $enabled_post_types as $enabled_post_type ) {
@@ -317,5 +318,21 @@ class Post_Republisher {
 		}
 
 		return isset( $_GET['meta-box-loader'] ) === false; // phpcs:ignore WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Adds the default post display states used in the posts list table.
+	 *
+	 * @param string[] $post_states An array of post display states.
+	 * @param WP_Post  $post        The current post object.
+	 *
+	 * @return string[] An array of filtered display post states.
+	 */
+	public function add_rewrite_schedule_display_state( $post_states, $post ) {
+		if ( $post->post_status === 'dp-rewrite-schedule' ) {
+			$post_states['dp-rewrite-schedule'] = \esc_html__( 'Scheduled', 'duplicate-post' );
+		}
+
+		return $post_states;
 	}
 }

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -138,7 +138,7 @@ class Post_Republisher {
 	public function republish_request( $post ) {
 		if (
 			! $this->permissions_helper->is_rewrite_and_republish_copy( $post )
-			|| $post->post_status !== 'dp-rewrite-republish'
+			|| ! $this->permissions_helper->is_copy_allowed_to_be_republished( $post )
 		) {
 			return;
 		}
@@ -203,10 +203,12 @@ class Post_Republisher {
 	protected function republish_post_elements( $post, $original_post_id ) {
 		// Cast to array and not alter the original object.
 		$post_to_be_rewritten = (array) $post;
+		// Determine the new post status.
+		$new_post_status = $post_to_be_rewritten['post_status'] === 'private' ? 'private' : 'publish';
 		// Prepare post data for republishing.
 		$post_to_be_rewritten['ID']          = $original_post_id;
 		$post_to_be_rewritten['post_name']   = \get_post_field( 'post_name', $original_post_id );
-		$post_to_be_rewritten['post_status'] = 'publish';
+		$post_to_be_rewritten['post_status'] = $new_post_status;
 
 		// Yoast SEO and other plugins prevent from accidentally updating another
 		// post's data (e.g. the Yoast SEO metadata) by checking the $_POST data

--- a/tests/class-permissions-helper-test.php
+++ b/tests/class-permissions-helper-test.php
@@ -610,4 +610,42 @@ class Permissions_Helper_Test extends TestCase {
 
 		$this->assertSame( false, $this->instance->post_type_has_admin_bar( $post_type ) );
 	}
+
+	/**
+	 * Tests the is_copy_allowed_to_be_republished function.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::is_copy_allowed_to_be_republished
+	 * @dataProvider is_copy_allowed_to_be_republished_provider
+	 *
+	 * @param mixed $post_status Input value.
+	 * @param mixed $expected    Expected output.
+	 */
+	public function test_is_copy_allowed_to_be_republished( $post_status, $expected ) {
+		$post              = Mockery::mock( \WP_Post::class );
+		$post->post_status = $post_status;
+
+		$this->assertEquals( $expected, $this->instance->is_copy_allowed_to_be_republished( $post ) );
+	}
+
+	/**
+	 * Data provider for test_is_copy_allowed_to_be_republished.
+	 *
+	 * @return array The test parameters.
+	 */
+	public function is_copy_allowed_to_be_republished_provider() {
+		return [
+			[
+				'post_status' => 'dp-rewrite-republish',
+				'expected'    => true,
+			],
+			[
+				'post_status' => 'private',
+				'expected'    => true,
+			],
+			[
+				'post_status' => 'draft',
+				'expected'    => false,
+			],
+		];
+	}
 }

--- a/tests/class-post-republisher-test.php
+++ b/tests/class-post-republisher-test.php
@@ -94,6 +94,9 @@ class Post_Republisher_Test extends TestCase {
 		Monkey\Filters\expectAdded( 'wp_insert_post_data' )
 			->with( [ $this->instance, 'change_post_copy_status' ], 1, 2 );
 
+		Monkey\Filters\expectAdded( 'display_post_states' )
+			->with( [ $this->instance, 'add_rewrite_schedule_display_state' ], 9, 2 );
+
 		Monkey\Actions\expectAdded( 'init' )
 			->with( [ $this->instance, 'register_post_statuses' ] );
 
@@ -240,6 +243,65 @@ class Post_Republisher_Test extends TestCase {
 				[
 					'post_status' => 'dp-rewrite-schedule',
 				],
+			],
+		];
+	}
+
+	/**
+	 * Tests the add_rewrite_schedule_display_state function.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::add_rewrite_schedule_display_state
+	 * @dataProvider add_rewrite_schedule_display_state_provider
+	 *
+	 * @param mixed $post_status        Input value.
+	 * @param mixed $display_post_state Expected output.
+	 */
+	public function test_add_rewrite_schedule_display_state( $post_status, $display_post_state ) {
+		$some_default_display_post_states = [
+			'draft'     => 'Draft',
+			'future'    => 'Scheduled',
+			'pending'   => 'Pending',
+			'private'   => 'Private',
+			'protected' => 'Password protected',
+		];
+
+		$post              = Mockery::mock( \WP_Post::class );
+		$post->post_status = $post_status;
+
+		$returned_post_display_state = $this->instance->add_rewrite_schedule_display_state( $some_default_display_post_states, $post );
+		$this->assertEquals( $display_post_state, $returned_post_display_state[ $post_status ] );
+	}
+
+	/**
+	 * Data provider for test_add_rewrite_schedule_display_state.
+	 *
+	 * @return array
+	 */
+	public function add_rewrite_schedule_display_state_provider() {
+		return [
+			[
+				'post_status'        => 'draft',
+				'display_post_state' => 'Draft',
+			],
+			[
+				'post_status'        => 'future',
+				'display_post_state' => 'Scheduled',
+			],
+			[
+				'post_status'        => 'pending',
+				'display_post_state' => 'Pending',
+			],
+			[
+				'post_status'        => 'private',
+				'display_post_state' => 'Private',
+			],
+			[
+				'post_status'        => 'protected',
+				'display_post_state' => 'Password protected',
+			],
+			[
+				'post_status'        => 'dp-rewrite-schedule',
+				'display_post_state' => 'Scheduled',
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the post saving flow when a post copy for Rewrite & Republish is saved as draft, pending, private, future, etc.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Addresses the cases when a Rewrite & Republish post copy is saved with a status other than `private` and the one for republishing.

## Relevant technical choices:

- when users click the button to publish the post, we want to allow only posts with a status of `dp-rewrite-republish` or `private` to overwrite the original
- worth reminding in WordPress `private` posts can only be published
- all Rewrite & Republish post copies with other statuses should follow the normal WordPress flow e.g. be saved as draft, pending, future, etc.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

In Gutenberg:
- in all the following cases, the copy should _not_ overwrite the original:
- create a copy for Rewrite & Republish and save it as draft
- check it doesn't overwrite the original and there is no redirect to the original
- go back to the posts list and verify the copy displays a status "Draft" in the title column 
- repeat saving the copy as pending review and at the end verify the displayed status is "Pending"
- repeat saving the copy as draft and password protected and at the end verify the displayed status is "Password protected, Draft"
- repeat saving the copy as pending review and password protected and at the end verify the displayed status is "Password protected, Pending" 
- repeat saving the copy as scheduled and at the end verify the displayed status is "Scheduled"
Note: The `future` status will be fully handled in P3-232.

Special case:
- save the copy as private 
- in this case, Gutenberg will ask you if you want to privately publish the post
- press OK and publish
- observe you're redirected to the original post and the original is overwritten with the changes from the copy
- go back to the posts list and observe the copy has been deleted 
- check the original is now published as "Private"

Repeat the steps above with the Classic Editor.
The only difference should be that when saving as private, WordPress will not as for a confirmation. However, in the publish box the only available action will be to press the "Update" button and that will publish the post.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

- N/A: it was decided the whole Rewrite & Republish feature should be tested as a whole once completed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-280]
