### PR TITLE
P3-288 migrate revisions

### DIFF
--- a/src/class-duplicate-post.php
+++ b/src/class-duplicate-post.php
@@ -53,6 +53,13 @@ class Duplicate_Post {
 	protected $post_republisher;
 
 	/**
+	 * Revisions_Migrator object.
+	 *
+	 * @var Revisions_Migrator
+	 */
+	protected $revisions_migrator;
+
+	/**
 	 * Watchers object.
 	 *
 	 * @var Watchers
@@ -68,6 +75,10 @@ class Duplicate_Post {
 		$this->post_duplicator    = new Post_Duplicator();
 		$this->handler            = new Handler( $this->post_duplicator, $this->permissions_helper );
 		$this->post_republisher   = new Post_Republisher( $this->post_duplicator, $this->permissions_helper );
+		$this->revisions_migrator = new Revisions_Migrator();
 		$this->watchers           = new Watchers( $this->permissions_helper );
+
+		$this->post_republisher->register_hooks();
+		$this->revisions_migrator->register_hooks();
 	}
 }

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -36,8 +36,6 @@ class Post_Republisher {
 	public function __construct( Post_Duplicator $post_duplicator, Permissions_Helper $permissions_helper ) {
 		$this->post_duplicator    = $post_duplicator;
 		$this->permissions_helper = $permissions_helper;
-
-		$this->register_hooks();
 	}
 
 	/**
@@ -141,8 +139,6 @@ class Post_Republisher {
 		}
 
 		$this->republish( $post, $original_post );
-
-		\do_action( 'duplicate_post_after_rewriting', $post, $original_post );
 
 		// Trigger the redirect in the Classic Editor.
 		if ( $this->is_classic_editor_post_request() ) {
@@ -264,12 +260,20 @@ class Post_Republisher {
 	 * Deletes the copy and associated post meta, if applicable.
 	 *
 	 * @param int      $copy_id The copy's ID.
-	 * @param int|null $post_id The post's ID. Optional.
+	 * @param int|null $post_id The original post's ID. Optional.
 	 * @param bool     $permanently_delete Whether to permanently delete the copy. Defaults to true.
 	 *
 	 * @return void
 	 */
 	public function delete_copy( $copy_id, $post_id = null, $permanently_delete = true ) {
+		/**
+		 * Fires before deleting a Rewrite & Republish copy.
+		 *
+		 * @param int $copy_id The copy's ID.
+		 * @param int $post_id The original post's ID..
+		 */
+		\do_action( 'duplicate_post_after_rewriting', $copy_id, $post_id );
+
 		// Delete the copy bypassing the trash so it also deletes the copy post meta.
 		\wp_delete_post( $copy_id, $permanently_delete );
 

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -248,12 +248,18 @@ class Post_Republisher {
 	 * @return void
 	 */
 	public function republish( \WP_Post $post, $original_post ) {
+		// Remove WordPress default filter so a new revision is not created on republish.
+		\remove_action( 'post_updated', 'wp_save_post_revision', 10 );
+
 		// Republish taxonomies and meta.
 		$this->republish_post_taxonomies( $post );
 		$this->republish_post_meta( $post );
 
 		// Republish the post.
 		$this->republish_post_elements( $post, $original_post );
+
+		// Re-enable the creation of a new revision.
+		\add_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
 	}
 
 	/**

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -320,7 +320,7 @@ class Post_Republisher {
 	 * Adds the default post display states used in the posts list table.
 	 *
 	 * @param string[] $post_states An array of post display states.
-	 * @param \WP_Post  $post        The current post object.
+	 * @param \WP_Post $post        The current post object.
 	 *
 	 * @return string[] An array of filtered display post states.
 	 */

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -8,10 +8,6 @@
 
 namespace Yoast\WP\Duplicate_Post;
 
-use Yoast\WP\Duplicate_Post\Permissions_Helper;
-use Yoast\WP\Duplicate_Post\Post_Duplicator;
-use Yoast\WP\Duplicate_Post\Utils;
-
 /**
  * Represents the Post Republisher class.
  */
@@ -40,8 +36,6 @@ class Post_Republisher {
 	public function __construct( Post_Duplicator $post_duplicator, Permissions_Helper $permissions_helper ) {
 		$this->post_duplicator    = $post_duplicator;
 		$this->permissions_helper = $permissions_helper;
-
-		$this->register_hooks();
 	}
 
 	/**
@@ -144,9 +138,9 @@ class Post_Republisher {
 			return;
 		}
 
-		$original_post_id = Utils::get_original_post_id( $post->ID );
+		$original_post = Utils::get_original( $post );
 
-		if ( ! $original_post_id ) {
+		if ( ! $original_post ) {
 			return;
 		}
 
@@ -155,11 +149,13 @@ class Post_Republisher {
 		$this->republish_post_meta( $post );
 
 		// Republish the post.
-		$this->republish_post_elements( $post, $original_post_id );
+		$this->republish_post_elements( $post, $original_post->ID );
+
+		\do_action( 'duplicate_post_after_rewriting', $post, $original_post );
 
 		// Trigger the redirect in the Classic Editor.
 		if ( $this->is_classic_editor_post_request() ) {
-			$this->redirect( $original_post_id, $post->ID );
+			$this->redirect( $original_post->ID, $post->ID );
 		}
 	}
 
@@ -324,7 +320,7 @@ class Post_Republisher {
 	 * Adds the default post display states used in the posts list table.
 	 *
 	 * @param string[] $post_states An array of post display states.
-	 * @param WP_Post  $post        The current post object.
+	 * @param \WP_Post  $post        The current post object.
 	 *
 	 * @return string[] An array of filtered display post states.
 	 */

--- a/src/class-revisions-migrator.php
+++ b/src/class-revisions-migrator.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Duplicate Post class to migrate revisions from the Rewrite & Republish copy to the original post.
+ *
+ * @package Duplicate_Post
+ * @since 4.0
+ */
+
+namespace Yoast\WP\Duplicate_Post;
+
+/**
+ * Represents the Revisions Migrator class.
+ */
+class Revisions_Migrator {
+
+	/**
+	 * Adds hooks to integrate with the Post Republisher class.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'duplicate_post_after_rewriting', [ $this, 'migrate_revisions' ], 10, 2 );
+	}
+
+	/**
+	 * Updates the revisions of the Rewrite & Republish copy to make them revisions of the original.
+	 *
+	 * It mimics the behaviour of wp_save_post_revision() in wp-includes/revision.php
+	 * by deleting the revisions (except autosaves) exceeding the maximum allowed number.
+	 *
+	 * @param \WP_Post $post          The Rewrite & Republish copy.
+	 * @param \WP_Post $original_post The original post which has been rewritten.
+	 *
+	 * @return void
+	 */
+	public function migrate_revisions( $post, $original_post ) {
+		if ( ! \wp_revisions_enabled( $original_post ) ) {
+			return;
+		}
+
+		$copy_revisions = \wp_get_post_revisions( $post );
+		foreach ( $copy_revisions as $revision ) {
+			$revision->post_parent = $original_post->ID;
+			$revision->post_name   = "$original_post->ID-revision-v1";
+			\wp_update_post( $revision );
+		}
+
+		$revisions_to_keep = \wp_revisions_to_keep( $original_post );
+		if ( $revisions_to_keep < 0 ) {
+			return;
+		}
+
+		$revisions = \wp_get_post_revisions( $original_post, [ 'order' => 'ASC' ] );
+		$delete    = \count( $revisions ) - $revisions_to_keep;
+		if ( $delete < 1 ) {
+			return;
+		}
+
+		$revisions = \array_slice( $revisions, 0, $delete );
+
+		for ( $i = 0; isset( $revisions[ $i ] ); $i ++ ) {
+			if ( \strpos( $revisions[ $i ]->post_name, 'autosave' ) !== false ) {
+				continue;
+			}
+			\wp_delete_post_revision( $revisions[ $i ]->ID );
+		}
+	}
+}

--- a/src/class-revisions-migrator.php
+++ b/src/class-revisions-migrator.php
@@ -37,11 +37,7 @@ class Revisions_Migrator {
 		$copy          = \get_post( $copy_id );
 		$original_post = \get_post( $original_id );
 
-		if ( \is_null( $copy ) || \is_null( $original_post ) ) {
-			return;
-		}
-
-		if ( ! \wp_revisions_enabled( $original_post ) ) {
+		if ( \is_null( $copy ) || \is_null( $original_post ) || ! \wp_revisions_enabled( $original_post ) ) {
 			return;
 		}
 

--- a/src/class-revisions-migrator.php
+++ b/src/class-revisions-migrator.php
@@ -28,17 +28,24 @@ class Revisions_Migrator {
 	 * It mimics the behaviour of wp_save_post_revision() in wp-includes/revision.php
 	 * by deleting the revisions (except autosaves) exceeding the maximum allowed number.
 	 *
-	 * @param \WP_Post $post          The Rewrite & Republish copy.
-	 * @param \WP_Post $original_post The original post which has been rewritten.
+	 * @param int $copy_id     The copy's ID.
+	 * @param int $original_id The post's ID.
 	 *
 	 * @return void
 	 */
-	public function migrate_revisions( $post, $original_post ) {
+	public function migrate_revisions( $copy_id, $original_id ) {
+		$copy          = \get_post( $copy_id );
+		$original_post = \get_post( $original_id );
+
+		if ( \is_null( $copy ) || \is_null( $original_post ) ) {
+			return;
+		}
+
 		if ( ! \wp_revisions_enabled( $original_post ) ) {
 			return;
 		}
 
-		$copy_revisions = \wp_get_post_revisions( $post );
+		$copy_revisions = \wp_get_post_revisions( $copy );
 		foreach ( $copy_revisions as $revision ) {
 			$revision->post_parent = $original_post->ID;
 			$revision->post_name   = "$original_post->ID-revision-v1";

--- a/tests/class-post-republisher-test.php
+++ b/tests/class-post-republisher-test.php
@@ -9,7 +9,6 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey;
 use Mockery;
-use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\Post_Republisher;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
@@ -50,16 +49,9 @@ class Post_Republisher_Test extends TestCase {
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
 		$this->instance = Mockery::mock(
-			Post_Republisher::class
+			Post_Republisher::class,
+			[ $this->post_duplicator, $this->permissions_helper ]
 		)->makePartial();
-
-		$enabled_post_types = [ 'post', 'page' ];
-
-		$this->permissions_helper
-			->expects( 'get_enabled_post_types' )
-			->andReturn( $enabled_post_types );
-
-		$this->instance->__construct( $this->post_duplicator, $this->permissions_helper );
 	}
 
 	/**
@@ -70,9 +62,6 @@ class Post_Republisher_Test extends TestCase {
 	public function test_constructor() {
 		$this->assertAttributeInstanceOf( Post_Duplicator::class, 'post_duplicator', $this->instance );
 		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
-
-		$this->instance->expects( 'register_hooks' )->once();
-		$this->instance->__construct( $this->post_duplicator, $this->permissions_helper );
 	}
 
 	/**

--- a/tests/class-revisions-migrator-test.php
+++ b/tests/class-revisions-migrator-test.php
@@ -50,15 +50,20 @@ class Revisions_Migrator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::migrate_revisions
 	 */
 	public function test_migrate_revisions_unlimited() {
+		$post_id           = 128;
+		$original_id       = 64;
 		$post              = Mockery::mock( \WP_Post::class );
 		$original_post     = Mockery::mock( \WP_Post::class );
-		$original_post->ID = 64;
+		$original_post->ID = $original_id;
 		$revisions         = [
 			Mockery::mock( \WP_Post::class ),
 			Mockery::mock( \WP_Post::class ),
 			Mockery::mock( \WP_Post::class ),
 			Mockery::mock( \WP_Post::class ),
 		];
+
+		Monkey\Functions\expect( '\get_post' )
+			->andReturn( $post, $original_post );
 
 		Monkey\Functions\expect( '\wp_revisions_enabled' )
 			->with( $original_post )
@@ -78,7 +83,7 @@ class Revisions_Migrator_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_delete_post_revision' )
 			->never();
 
-		$this->instance->migrate_revisions( $post, $original_post );
+		$this->instance->migrate_revisions( $post_id, $original_id );
 	}
 
 	/**
@@ -87,12 +92,14 @@ class Revisions_Migrator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::migrate_revisions
 	 */
 	public function test_migrate_revisions_limited() {
+		$post_id             = 128;
+		$original_id         = 64;
 		$post                = Mockery::mock( \WP_Post::class );
 		$revision            = Mockery::mock( \WP_Post::class );
 		$revision->ID        = 123;
 		$revision->post_name = 'revision';
 		$original_post       = Mockery::mock( \WP_Post::class );
-		$original_post->ID   = 64;
+		$original_post->ID   = $original_id;
 		$revisions           = [
 			$revision,
 			$revision,
@@ -112,6 +119,9 @@ class Revisions_Migrator_Test extends TestCase {
 		];
 		$revisions_to_keep   = 6;
 
+		Monkey\Functions\expect( '\get_post' )
+			->andReturn( $post, $original_post );
+
 		Monkey\Functions\expect( '\wp_revisions_enabled' )
 			->with( $original_post )
 			->andReturnTrue();
@@ -129,7 +139,7 @@ class Revisions_Migrator_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_delete_post_revision' )
 			->times( 3 );
 
-		$this->instance->migrate_revisions( $post, $original_post );
+		$this->instance->migrate_revisions( $post_id, $original_id );
 	}
 
 	/**
@@ -138,8 +148,13 @@ class Revisions_Migrator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::migrate_revisions
 	 */
 	public function test_migrate_revisions_none() {
+		$post_id       = 128;
+		$original_id   = 64;
 		$post          = Mockery::mock( \WP_Post::class );
 		$original_post = Mockery::mock( \WP_Post::class );
+
+		Monkey\Functions\expect( '\get_post' )
+			->andReturn( $post, $original_post );
 
 		Monkey\Functions\expect( '\wp_revisions_enabled' )
 			->with( $original_post )
@@ -157,7 +172,7 @@ class Revisions_Migrator_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_delete_post_revision' )
 			->never();
 
-		$this->instance->migrate_revisions( $post, $original_post );
+		$this->instance->migrate_revisions( $post_id, $original_id );
 	}
 
 }

--- a/tests/class-revisions-migrator-test.php
+++ b/tests/class-revisions-migrator-test.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Duplicate Post test file.
+ *
+ * @package Duplicate_Post\Tests
+ */
+
+namespace Yoast\WP\Duplicate_Post\Tests;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\Duplicate_Post\Revisions_Migrator;
+
+/**
+ * Test the Revisions_Migrator class.
+ */
+class Revisions_Migrator_Test extends TestCase {
+
+	/**
+	 * The instance.
+	 *
+	 * @var Revisions_Migrator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets the instance.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new Revisions_Migrator();
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Actions\expectAdded( 'duplicate_post_after_rewriting' )
+			->with( [ $this->instance, 'migrate_revisions' ], 10, 2 );
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests the migrate_revisions function with unlimited revisions allowed
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::migrate_revisions
+	 */
+	public function test_migrate_revisions_unlimited() {
+		$post              = Mockery::mock( \WP_Post::class );
+		$original_post     = Mockery::mock( \WP_Post::class );
+		$original_post->ID = 64;
+		$revisions         = [
+			Mockery::mock( \WP_Post::class ),
+			Mockery::mock( \WP_Post::class ),
+			Mockery::mock( \WP_Post::class ),
+			Mockery::mock( \WP_Post::class ),
+		];
+
+		Monkey\Functions\expect( '\wp_revisions_enabled' )
+			->with( $original_post )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( '\wp_get_post_revisions' )
+			->with( $post )
+			->andReturn( $revisions );
+
+		Monkey\Functions\expect( '\wp_update_post' )
+			->times( 4 );
+
+		Monkey\Functions\expect( '\wp_revisions_to_keep' )
+			->with( $original_post )
+			->andReturn( -1 );
+
+		Monkey\Functions\expect( '\wp_delete_post_revision' )
+			->never();
+
+		$this->instance->migrate_revisions( $post, $original_post );
+	}
+
+	/**
+	 * Tests the migrate_revisions function with limited revisions allowed
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::migrate_revisions
+	 */
+	public function test_migrate_revisions_limited() {
+		$post                = Mockery::mock( \WP_Post::class );
+		$revision            = Mockery::mock( \WP_Post::class );
+		$revision->ID        = 123;
+		$revision->post_name = 'revision';
+		$original_post       = Mockery::mock( \WP_Post::class );
+		$original_post->ID   = 64;
+		$revisions           = [
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+		];
+		$original_revisions  = [
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+			$revision,
+		];
+		$revisions_to_keep   = 6;
+
+		Monkey\Functions\expect( '\wp_revisions_enabled' )
+			->with( $original_post )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( '\wp_get_post_revisions' )
+			->andReturn( $revisions, $original_revisions );
+
+		Monkey\Functions\expect( '\wp_update_post' )
+			->times( 4 );
+
+		Monkey\Functions\expect( '\wp_revisions_to_keep' )
+			->with( $original_post )
+			->andReturn( $revisions_to_keep );
+
+		Monkey\Functions\expect( '\wp_delete_post_revision' )
+			->times( 3 );
+
+		$this->instance->migrate_revisions( $post, $original_post );
+	}
+
+	/**
+	 * Tests the migrate_revisions function with no revisions allowed
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Revisions_Migrator::migrate_revisions
+	 */
+	public function test_migrate_revisions_none() {
+		$post          = Mockery::mock( \WP_Post::class );
+		$original_post = Mockery::mock( \WP_Post::class );
+
+		Monkey\Functions\expect( '\wp_revisions_enabled' )
+			->with( $original_post )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( '\wp_get_post_revisions' )
+			->never();
+
+		Monkey\Functions\expect( '\wp_update_post' )
+			->never();
+
+		Monkey\Functions\expect( '\wp_revisions_to_keep' )
+			->never();
+
+		Monkey\Functions\expect( '\wp_delete_post_revision' )
+			->never();
+
+		$this->instance->migrate_revisions( $post, $original_post );
+	}
+
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a post has been overwritten with the content of a Rewrite & Republish copy, we also want to merge the two revisions history so that the revisions of the copy (which will eventually be deleted) is not lost.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Merges the revision history of a Rewrite & Republish copy into the one of its original.

## Relevant technical choices:

* As it has happened in previous PRs, we also moved some calls to `register_hooks()` method outside the constructors for easier testing.
* Most of the main method from the new `Revisions_Migrator` class come from the `wp_save_post_revision()` function from `wp-includes/revision.php`
* The creation of a new revision on overwriting has been disabled by removing a default WP hooked function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test with unlimited revisions 
* make sure you don't have `define( 'WP_POST_REVISIONS', <something> );` in your `wp-config.php`
* pick a published post and make sure it has a number of revisions.
  * On the Docker environment posts don't have revisions initially: edit a post, make a change and "Update": do it repeatedly to add revisions. 
  * I suggest to write increasing numbers in the Title and in the Content, so to "number" the revisions and see they are differing
  * take notice of the number of revisions (you can see it from the link in the sidebar: "X Revisions")
* create a Rewrite & Republish copy from that post, and do the same (small changes, like continuing the numbering in the Title and in the Content, then "Save Draft") repeatedly. Take note of the number of revisions, let's make it Y.
* Click on "Republish", then confirm if you have the pre-publish checks enabled.
* You will be redirected to the overwritten original
* Check the number of revisions: it should be X from the original, plus Y from the copy.
* You can also try to repeat the process but make some changes on the copy and *not* save them before republish: a new revision will be created before republishing thus adding +1 to the expected revisions count (and it's OK).

#### Test with limited revisions 
* make sure you have `define( 'WP_POST_REVISIONS', 5 );` in your `wp-config.php`
* pick a published post and make sure it has a number of revisions.
  * On the Docker environment posts don't have revisions initially: edit a post, make a change and "Update": do it repeatedly to add revisions. 
  * I suggest to write increasing numbers in the Title and in the Content, so to "number" the revisions and see they are differing
  * take notice of the number of revisions (you can see it from the link in the sidebar: "X Revisions")
  * try to create more than 5 revisions, and see the revisions count stays at 5.
* create a Rewrite & Republish copy from that post, and do the same (small changes, like continuing the numbering in the Title and in the Content, then "Save Draft") repeatedly. Take note of the number of revisions, let's make it Y. Better if they are less than 5.
* Click on "Republish", then confirm if you have the pre-publish checks enabled.
* You will be redirected to the overwritten original
* Check the number of revisions: it should be a total of 5.
  * inspect the DB (table `wp_post`, select the posts having `post_parent` equal to the original ID) and see that the "provenience" of the revisions is what we are expecting: the latest ones from the copy (you'll see that in the `guid` field), the earliest ones from the original, up to a total of 5.

#### Test with no revisions 
* make sure you have `define( 'WP_POST_REVISIONS', 0 );` in your `wp-config.php`
* create and publish a new post, update multiple times and see there is no revision added
* create a Rewrite & Republish copy from that post, and do the same (small changes, like continuing the numbering in the Title and in the Content, then "Save Draft") repeatedly. See there are no revisions.
* Click on "Republish", then confirm if you have the pre-publish checks enabled.
* You will be redirected to the overwritten original
* See that you still don't have any revisions
  * inspect the DB (table `wp_post`, select the posts having `post_parent` equal to the original ID) and see you get no results.
  
**remember to comment out the `define( 'WP_POST_REVISIONS', 0 );` when you have finished** so revisions are working again.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* **Not applicable** QA will have complete test instructions for the new feature

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-288]
