### PR TITLE
P3-281 Remove slug editing from Rewrite & Republish copies

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -10,6 +10,7 @@ import { select, subscribe, dispatch } from "@wordpress/data";
 class DuplicatePost {
 	constructor() {
 		this.renderNotices();
+		this.removeSlugSidebarPanel();
 	}
 
 	/**
@@ -120,6 +121,17 @@ class DuplicatePost {
 					}
 				);
 			}
+		}
+	}
+
+	/**
+	 * Removes the slug panel from the block editor sidebar when the post is a Rewrite & Republish copy.
+	 *
+	 * @returns {void}
+	 */
+	removeSlugSidebarPanel() {
+		if ( parseInt( duplicatePost.rewriting, 10 ) ) {
+			dispatch( 'core/edit-post' ).removeEditorPanel( 'post-link' );
 		}
 	}
 

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -149,7 +149,7 @@ class Post_Duplicator {
 		$options  = [
 			'copy_title'      => true,
 			'copy_date'       => true,
-			'copy_name'       => true,
+			'copy_name'       => false,
 			'copy_content'    => true,
 			'copy_excerpt'    => true,
 			'copy_author'     => true,

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -66,6 +66,8 @@ class Post_Republisher {
 		\add_action( 'wp_insert_post', [ $this, 'republish_after_post_request' ], \PHP_INT_MAX, 2 );
 		// Clean up after the redirect to the original post.
 		\add_action( 'load-post.php', [ $this, 'clean_up_after_redirect' ] );
+		\add_action( 'add_meta_boxes', [ $this, 'remove_slug_meta_box' ], 10, 2 );
+		\add_filter( 'get_sample_permalink_html', [ $this, 'remove_sample_permalink_slug_editor' ], 10, 5 );
 	}
 
 	/**
@@ -334,5 +336,38 @@ class Post_Republisher {
 		}
 
 		return $post_states;
+	}
+
+	/**
+	 * Removes the slug meta box in the Classic Editor when the post is a Rewrite & Republish copy.
+	 *
+	 * @param string   $post_type Post type.
+	 * @param \WP_Post $post      Post object.
+	 *
+	 * @return void
+	 */
+	public function remove_slug_meta_box( $post_type, $post ) {
+		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			\remove_meta_box( 'slugdiv', $post_type, 'normal' );
+		}
+	}
+
+	/**
+	 * Removes the sample permalink slug editor in the Classic Editor when the post is a Rewrite & Republish copy.
+	 *
+	 * @param string   $return    Sample permalink HTML markup.
+	 * @param int      $post_id   Post ID.
+	 * @param string   $new_title New sample permalink title.
+	 * @param string   $new_slug  New sample permalink slug.
+	 * @param \WP_Post $post      Post object.
+	 *
+	 * @return string The filtered HTML of the sample permalink slug editor.
+	 */
+	public function remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) {
+		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			return '';
+		}
+
+		return $return;
 	}
 }

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -71,9 +71,6 @@ class Post_Republisher {
 		\add_action( 'before_delete_post', [ $this, 'clean_up_when_copy_manually_deleted' ] );
 		// Ensure scheduled Rewrite and Republish posts are properly handled.
 		\add_action( 'future_to_publish', [ $this, 'republish_scheduled_post' ] );
-		// Remove slug editing from Classic Editor.
-		\add_action( 'add_meta_boxes', [ $this, 'remove_slug_meta_box' ], 10, 2 );
-		\add_filter( 'get_sample_permalink_html', [ $this, 'remove_sample_permalink_slug_editor' ], 10, 5 );
 	}
 
 	/**
@@ -412,38 +409,5 @@ class Post_Republisher {
 
 		$original_post_id = Utils::get_original_post_id( $post_id );
 		\delete_post_meta( $original_post_id, '_dp_has_rewrite_republish_copy' );
-	}
-
-	/**
-	 * Removes the slug meta box in the Classic Editor when the post is a Rewrite & Republish copy.
-	 *
-	 * @param string   $post_type Post type.
-	 * @param \WP_Post $post      Post object.
-	 *
-	 * @return void
-	 */
-	public function remove_slug_meta_box( $post_type, $post ) {
-		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
-			\remove_meta_box( 'slugdiv', $post_type, 'normal' );
-		}
-	}
-
-	/**
-	 * Removes the sample permalink slug editor in the Classic Editor when the post is a Rewrite & Republish copy.
-	 *
-	 * @param string   $return    Sample permalink HTML markup.
-	 * @param int      $post_id   Post ID.
-	 * @param string   $new_title New sample permalink title.
-	 * @param string   $new_slug  New sample permalink slug.
-	 * @param \WP_Post $post      Post object.
-	 *
-	 * @return string The filtered HTML of the sample permalink slug editor.
-	 */
-	public function remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) {
-		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
-			return '';
-		}
-
-		return $return;
 	}
 }

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -73,6 +73,10 @@ class Classic_Editor {
 
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_scripts' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_styles' ] );
+
+		// Remove slug editing from Classic Editor.
+		\add_action( 'add_meta_boxes', [ $this, 'remove_slug_meta_box' ], 10, 2 );
+		\add_filter( 'get_sample_permalink_html', [ $this, 'remove_sample_permalink_slug_editor' ], 10, 5 );
 	}
 
 	/**
@@ -286,5 +290,38 @@ class Classic_Editor {
 		}
 
 		return $this->permissions_helper->is_rewrite_and_republish_copy( $post );
+	}
+
+	/**
+	 * Removes the slug meta box in the Classic Editor when the post is a Rewrite & Republish copy.
+	 *
+	 * @param string   $post_type Post type.
+	 * @param \WP_Post $post      Post object.
+	 *
+	 * @return void
+	 */
+	public function remove_slug_meta_box( $post_type, $post ) {
+		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			\remove_meta_box( 'slugdiv', $post_type, 'normal' );
+		}
+	}
+
+	/**
+	 * Removes the sample permalink slug editor in the Classic Editor when the post is a Rewrite & Republish copy.
+	 *
+	 * @param string   $return    Sample permalink HTML markup.
+	 * @param int      $post_id   Post ID.
+	 * @param string   $new_title New sample permalink title.
+	 * @param string   $new_slug  New sample permalink slug.
+	 * @param \WP_Post $post      Post object.
+	 *
+	 * @return string The filtered HTML of the sample permalink slug editor.
+	 */
+	public function remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) {
+		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			return '';
+		}
+
+		return $return;
 	}
 }

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Duplicate Post class to manage the post submitbox.
+ * Duplicate Post class to manage the classic editor UI.
  *
  * @package Duplicate_Post
  */
@@ -11,9 +11,9 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Post_Submitbox class.
+ * Represents the Classic_Editor class.
  */
-class Post_Submitbox {
+class Classic_Editor {
 
 	/**
 	 * Holds the object to create the action link to duplicate.

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -57,16 +57,14 @@ class Classic_Editor {
 	public function register_hooks() {
 		\add_action( 'post_submitbox_misc_actions', [ $this, 'add_check_changes_link' ], 90 );
 
-		if ( \intval( Utils::get_option( 'duplicate_post_show_link_in', 'submitbox' ) ) === 0 ) {
-			return;
-		}
+		if ( \intval( Utils::get_option( 'duplicate_post_show_link_in', 'submitbox' ) ) === 1 ) {
+			if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'new_draft' ) ) === 1 ) {
+				\add_action( 'post_submitbox_start', [ $this, 'add_new_draft_post_button' ] );
+			}
 
-		if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'new_draft' ) ) === 1 ) {
-			\add_action( 'post_submitbox_start', [ $this, 'add_new_draft_post_button' ] );
-		}
-
-		if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1 ) {
-			\add_action( 'post_submitbox_start', [ $this, 'add_rewrite_and_republish_post_button' ] );
+			if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1 ) {
+				\add_action( 'post_submitbox_start', [ $this, 'add_rewrite_and_republish_post_button' ] );
+			}
 		}
 
 		\add_filter( 'gettext', [ $this, 'change_republish_strings_classic_editor' ], 10, 2 );

--- a/src/ui/class-user-interface.php
+++ b/src/ui/class-user-interface.php
@@ -29,14 +29,14 @@ class User_Interface {
 	protected $row_actions;
 
 	/**
-	 * Holds the object to manage the post submitbox links.
+	 * Holds the object to manage the classic editor UI.
 	 *
-	 * @var Post_Submitbox
+	 * @var Classic_Editor
 	 */
-	protected $post_submitbox;
+	protected $classic_editor;
 
 	/**
-	 * Holds the object to manage the block editor links.
+	 * Holds the object to manage the block editor UI.
 	 *
 	 * @var Block_Editor
 	 */
@@ -108,7 +108,7 @@ class User_Interface {
 		$this->column         = new Column( $this->permissions_helper, $this->asset_manager );
 		$this->metabox        = new Metabox( $this->permissions_helper );
 		$this->post_states    = new Post_States( $this->permissions_helper );
-		$this->post_submitbox = new Post_Submitbox( $this->link_builder, $this->permissions_helper, $this->asset_manager );
+		$this->classic_editor = new Classic_Editor( $this->link_builder, $this->permissions_helper, $this->asset_manager );
 		$this->row_actions    = new Row_Actions( $this->link_builder, $this->permissions_helper );
 
 		$this->admin_bar->register_hooks();
@@ -117,7 +117,7 @@ class User_Interface {
 		$this->column->register_hooks();
 		$this->metabox->register_hooks();
 		$this->post_states->register_hooks();
-		$this->post_submitbox->register_hooks();
+		$this->classic_editor->register_hooks();
 		$this->row_actions->register_hooks();
 	}
 }

--- a/tests/ui/class-classic-editor-test.php
+++ b/tests/ui/class-classic-editor-test.php
@@ -12,13 +12,13 @@ use Mockery;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Asset_Manager;
-use Yoast\WP\Duplicate_Post\UI\Post_Submitbox;
+use Yoast\WP\Duplicate_Post\UI\Classic_Editor;
 use Yoast\WP\Duplicate_Post\UI\Link_Builder;
 
 /**
- * Test the Post_Submitbox class.
+ * Test the Classic_Editor class.
  */
-class Post_Submitbox_Test extends TestCase {
+class Classic_Editor_Test extends TestCase {
 
 	/**
 	 * Holds the object to create the action link to duplicate.
@@ -44,7 +44,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * The instance.
 	 *
-	 * @var Post_Submitbox
+	 * @var Classic_Editor
 	 */
 	protected $instance;
 
@@ -59,7 +59,7 @@ class Post_Submitbox_Test extends TestCase {
 		$this->asset_manager      = Mockery::mock( Asset_Manager::class );
 
 		$this->instance = Mockery::mock(
-			Post_Submitbox::class,
+			Classic_Editor::class,
 			[
 				$this->link_builder,
 				$this->permissions_helper,
@@ -71,7 +71,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests if the needed attributes are set correctly.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::__construct
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::__construct
 	 */
 	public function test_constructor() {
 		$this->assertAttributeInstanceOf( Link_Builder::class, 'link_builder', $this->instance );
@@ -81,7 +81,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the registration of the hooks.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::register_hooks
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::register_hooks
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
@@ -120,7 +120,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the successful enqueue_classic_editor_scripts function.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::enqueue_classic_editor_scripts
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::enqueue_classic_editor_scripts
 	 */
 	public function test_enqueue_classic_editor_scripts() {
 		$_GET['post'] = '123';
@@ -147,7 +147,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the successful enqueue_classic_editor_scripts function.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::enqueue_classic_editor_styles
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::enqueue_classic_editor_styles
 	 */
 	public function test_enqueue_classic_editor_styles() {
 		$_GET['post'] = '123';
@@ -173,7 +173,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_new_draft_post_button function when a button is displayed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_new_draft_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_successful() {
 		$post            = Mockery::mock( \WP_Post::class );
@@ -205,7 +205,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_new_draft_post_button function when a button is displayed and the post ID comes from $_GET.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_new_draft_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_successful_post_from_GET() {
 		$_GET['post']    = '123';
@@ -238,7 +238,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_new_draft_post_button function when no post could be retrieved
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_new_draft_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_unsuccessful_no_post() {
 		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Intended, to be able to test the method.
@@ -266,7 +266,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_new_draft_post_button function when the link cannot be displayed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_new_draft_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_unsuccessful_no_link_allowed() {
 		$post            = Mockery::mock( \WP_Post::class );
@@ -296,7 +296,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_rewrite_and_republish_post_button function when a button is displayed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_rewrite_and_republish_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_successful() {
 		$post              = Mockery::mock( \WP_Post::class );
@@ -334,7 +334,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_rewrite_and_republish_post_button function when a button is displayed and the post ID comes from $_GET.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_rewrite_and_republish_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_post_from_GET() {
 		$_GET['post']      = '123';
@@ -373,7 +373,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_rewrite_and_republish_post_button function when no post could be retrieved.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_rewrite_and_republish_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_no_post() {
 		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Intended, to be able to test the method.
@@ -401,7 +401,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_rewrite_and_republish_post_button function when the link cannot be displayed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_rewrite_and_republish_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_unsuccessful_is_for_rewrite_and_republish() {
 		$post              = Mockery::mock( \WP_Post::class );
@@ -437,7 +437,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the add_rewrite_and_republish_post_button function when the post is not published.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::add_rewrite_and_republish_post_button
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_not_publish() {
 		$post              = Mockery::mock( \WP_Post::class );
@@ -467,7 +467,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the change_republish_strings_classic_editor function when the copy should be changed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_republish_strings_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_republish_strings_classic_editor
 	 */
 	public function test_should_change_republish_strings() {
 		$text = 'Publish';
@@ -490,7 +490,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the change_republish_strings_classic_editor function when the copy should not be changed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_republish_strings_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_republish_strings_classic_editor
 	 */
 	public function test_should_not_change_republish_strings() {
 		$text        = 'Publish';
@@ -515,7 +515,7 @@ class Post_Submitbox_Test extends TestCase {
 	 * Tests the change_republish_strings_classic_editor function when the copy should not be changed,
 	 * because the copy is not 'Publish'.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_republish_strings_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_republish_strings_classic_editor
 	 */
 	public function test_should_not_change_republish_strings_other_text() {
 		$text        = 'Test';
@@ -539,7 +539,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the change_schedule_strings_classic_editor function when the copy should be changed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_schedule_strings_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_schedule_strings_classic_editor
 	 */
 	public function test_should_change_schedule_strings() {
 		$text = 'Schedule';
@@ -562,7 +562,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the change_schedule_strings_classic_editor function when the copy should not be changed.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_schedule_strings_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_schedule_strings_classic_editor
 	 */
 	public function test_should_not_change_schedule_strings() {
 		$text        = 'Schedule';
@@ -587,7 +587,7 @@ class Post_Submitbox_Test extends TestCase {
 	 * Tests the change_republish_strings_classic_editor function when the copy should not be changed,
 	 * because the copy is not 'Schedule'.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_schedule_strings_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_schedule_strings_classic_editor
 	 */
 	public function test_should_not_change_schedule_strings_other_text() {
 		$text        = 'Test';
@@ -611,7 +611,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the change_scheduled_notice_classic_editor function when the copy should be changed for a post.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_scheduled_notice_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
 	 */
 	public function test_should_change_scheduled_notice_post() {
 		$post             = Mockery::mock( \WP_Post::class );
@@ -721,7 +721,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the change_scheduled_notice_classic_editor function when the copy should be changed for a page.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::change_scheduled_notice_classic_editor
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
 	 */
 	public function test_should_change_scheduled_notice_page() {
 		$post             = Mockery::mock( \WP_Post::class );
@@ -831,7 +831,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the should_change_rewrite_republish_copy function when it should return true for a post.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::should_change_rewrite_republish_copy
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::should_change_rewrite_republish_copy
 	 */
 	public function test_should_change_rewrite_republish_copy_post() {
 		global $pagenow;
@@ -851,7 +851,7 @@ class Post_Submitbox_Test extends TestCase {
 	/**
 	 * Tests the should_change_rewrite_republish_copy function when it should return true for a new post.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::should_change_rewrite_republish_copy
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::should_change_rewrite_republish_copy
 	 */
 	public function test_should_change_rewrite_republish_copy_new_post() {
 		global $pagenow;
@@ -872,7 +872,7 @@ class Post_Submitbox_Test extends TestCase {
 	 * Tests the should_change_rewrite_republish_copy function when it should return false,
 	 * because the current page is not a post edit screen.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::should_change_rewrite_republish_copy
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::should_change_rewrite_republish_copy
 	 */
 	public function test_should_not_change_rewrite_republish_copy_not_post_edit_screen() {
 		global $pagenow;
@@ -888,7 +888,7 @@ class Post_Submitbox_Test extends TestCase {
 	 * Tests the should_change_rewrite_republish_copy function when it should return false,
 	 * because the current post is null.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::should_change_rewrite_republish_copy
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::should_change_rewrite_republish_copy
 	 */
 	public function test_should_not_change_rewrite_republish_copy_post_is_null() {
 		global $pagenow;
@@ -901,7 +901,7 @@ class Post_Submitbox_Test extends TestCase {
 	 * Tests the should_change_rewrite_republish_copy function when it should return false,
 	 * because the current post is not a Rewrite & Republish post.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_Submitbox::should_change_rewrite_republish_copy
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::should_change_rewrite_republish_copy
 	 */
 	public function test_should_not_change_rewrite_republish_copy_not_republish_copy() {
 		global $pagenow;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove the ability for users to edit the slug for the Rewrite & Republish copies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes slug editing ability from the user interface for the Rewrite & Republish copies.

## Relevant technical choices:

- when creating a copy, the post slug (`post_name`) is not NOT copied to the copy
- additionally, the UI to edit the post slug is removed from both classic and block editor

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Build with `composer install && yarn && grunt build:js`

**Gutenberg:**
- edit a Rewrite & Republish copy
- check in the Post sidebar there's no "Permalink" panel
- edit a normal post
- check in the Post sidebar the "Permalink" panel is there

**Classic Editor:**
- activate the Classic Editor plugin
- edit a Rewrite & Republish copy
- check that the permalink sample and edit button aren't displayed below the post title
- check there's no "Slug" meta box
- check in the Screen Options at the top of the page there's no "Slug" checkbox
- edit a normal post
- check the "Slug" meta box is present in the page (assuming the "Slug" checkbox in the Screen Options is checked)
- check in the Screen Options the "Slug" checkbox is present and works as expected

**Database:**
- create a new Rewrite & Republish copy and take note of its ID
- search the copy by its ID in the database > `wp_posts` table
- check the `post_name` is empty


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A It was decided the Rewrite & Republish feature should be tested as a whole once completed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-281]
