### PR TITLE
Change link in block editor

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -6,6 +6,8 @@ import { Fragment } from "@wordpress/element";
 import { Button } from '@wordpress/components';
 import { __ } from "@wordpress/i18n";
 import { select, subscribe, dispatch } from "@wordpress/data";
+import { redirectOnSaveCompletion } from "./duplicate-post-functions";
+
 
 class DuplicatePost {
 	constructor() {
@@ -32,32 +34,15 @@ class DuplicatePost {
 		 * @returns {void}
 		 */
 		subscribe( () => {
-			if ( ! this.isSafeRedirectURL( duplicatePost.originalEditURL ) ) {
+			if ( ! this.isSafeRedirectURL( duplicatePost.originalEditURL ) || ! this.isCopyAllowedToBeRepublished() ) {
 				return;
 			}
 
-			const isSavingPost       = select( 'core/editor' ).isSavingPost();
-			const isAutosavingPost   = select( 'core/editor' ).isAutosavingPost();
-			const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
-			const isSavingMetaBoxes  = select( 'core/edit-post' ).isSavingMetaBoxes();
+			const completed = redirectOnSaveCompletion( duplicatePost.originalEditURL, { wasSavingPost, wasSavingMetaboxes, wasAutoSavingPost } );
 
-			if ( ! this.isCopyAllowedToBeRepublished() ) {
-				return;
-			}
-
-			// When there are custom meta boxes, redirect after they're saved.
-			if ( hasActiveMetaBoxes && ! isSavingMetaBoxes && wasSavingMetaboxes ) {
-				window.location.assign( duplicatePost.originalEditURL );
-			}
-
-			// When there are no custom meta boxes, redirect after the post is saved.
-			if ( ! hasActiveMetaBoxes && ! isSavingPost && wasSavingPost && ! wasAutoSavingPost ) {
-				window.location.assign( duplicatePost.originalEditURL );
-			}
-
-			wasSavingPost      = isSavingPost;
-			wasSavingMetaboxes = isSavingMetaBoxes;
-			wasAutoSavingPost  = isAutosavingPost;
+			wasSavingPost      = completed.isSavingPost;
+			wasSavingMetaboxes = completed.isSavingMetaBoxes;
+			wasAutoSavingPost  = completed.isAutosavingPost;
 		} );
 	}
 

--- a/js/src/duplicate-post-functions.js
+++ b/js/src/duplicate-post-functions.js
@@ -3,26 +3,26 @@ import { select } from "@wordpress/data";
 /**
  * Redirects to url when saving in the block editor has completed.
  *
- * @param {string} url The url to redirect to.
+ * @param {string} url         The url to redirect to.
  * @param {Object} editorState The current editor state regarding saving the post, metaboxes and autosaving.
  *
  * @returns {Object} The updated editor state.
  */
 export const redirectOnSaveCompletion = ( url, editorState ) => {
-    const isSavingPost       = select( 'core/editor' ).isSavingPost();
-    const isAutosavingPost   = select( 'core/editor' ).isAutosavingPost();
-    const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
-    const isSavingMetaBoxes  = select( 'core/edit-post' ).isSavingMetaBoxes();
+	const isSavingPost       = select( 'core/editor' ).isSavingPost();
+	const isAutosavingPost   = select( 'core/editor' ).isAutosavingPost();
+	const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
+	const isSavingMetaBoxes  = select( 'core/edit-post' ).isSavingMetaBoxes();
 
-    // When there are custom meta boxes, redirect after they're saved.
-    if ( hasActiveMetaBoxes && ! isSavingMetaBoxes && editorState.wasSavingMetaboxes ) {
-        window.location.assign( url );
-    }
+	// When there are custom meta boxes, redirect after they're saved.
+	if ( hasActiveMetaBoxes && ! isSavingMetaBoxes && editorState.wasSavingMetaboxes ) {
+		window.location.assign( url );
+	}
 
-    // When there are no custom meta boxes, redirect after the post is saved.
-    if ( ! hasActiveMetaBoxes && ! isSavingPost && editorState.wasSavingPost && ! editorState.wasAutoSavingPost ) {
-        window.location.assign( url );
-    }
+	// When there are no custom meta boxes, redirect after the post is saved.
+	if ( ! hasActiveMetaBoxes && ! isSavingPost && editorState.wasSavingPost && ! editorState.wasAutoSavingPost ) {
+		window.location.assign( url );
+	}
 
-    return { isSavingPost, isSavingMetaBoxes, isAutosavingPost };
+	return { isSavingPost, isSavingMetaBoxes, isAutosavingPost };
 };

--- a/js/src/duplicate-post-functions.js
+++ b/js/src/duplicate-post-functions.js
@@ -1,0 +1,28 @@
+import { select } from "@wordpress/data";
+
+/**
+ * Redirects to url when saving in the block editor has completed.
+ *
+ * @param {string} url The url to redirect to.
+ * @param {Object} editorState The current editor state regarding saving the post, metaboxes and autosaving.
+ *
+ * @returns {Object} The updated editor state.
+ */
+export const redirectOnSaveCompletion = ( url, editorState ) => {
+    const isSavingPost       = select( 'core/editor' ).isSavingPost();
+    const isAutosavingPost   = select( 'core/editor' ).isAutosavingPost();
+    const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
+    const isSavingMetaBoxes  = select( 'core/edit-post' ).isSavingMetaBoxes();
+
+    // When there are custom meta boxes, redirect after they're saved.
+    if ( hasActiveMetaBoxes && ! isSavingMetaBoxes && editorState.wasSavingMetaboxes ) {
+        window.location.assign( url );
+    }
+
+    // When there are no custom meta boxes, redirect after the post is saved.
+    if ( ! hasActiveMetaBoxes && ! isSavingPost && editorState.wasSavingPost && ! editorState.wasAutoSavingPost ) {
+        window.location.assign( url );
+    }
+
+    return { isSavingPost, isSavingMetaBoxes, isAutosavingPost };
+};

--- a/js/src/duplicate-post-strings.js
+++ b/js/src/duplicate-post-strings.js
@@ -1,20 +1,43 @@
 /* global duplicatePostStrings */
 
 import { createInterpolateElement } from "@wordpress/element";
+import { Button } from "@wordpress/components";
 import { __, setLocaleData } from "@wordpress/i18n";
+import {dispatch, subscribe} from "@wordpress/data";
+import { redirectOnSaveCompletion } from "./duplicate-post-functions";
+
+const saveAndCompare = () => {
+	dispatch( 'core/editor' ).savePost();
+
+	let wasSavingPost      = false;
+	let wasSavingMetaboxes = false;
+	let wasAutoSavingPost  = false;
+
+	/**
+	 * Determines when the redirect needs to happen.
+	 *
+	 * @returns {void}
+	 */
+	subscribe( () => {
+		const completed = redirectOnSaveCompletion( duplicatePostStrings.checkLink, { wasSavingPost, wasSavingMetaboxes, wasAutoSavingPost } );
+
+		wasSavingPost      = completed.isSavingPost;
+		wasSavingMetaboxes = completed.isSavingMetaBoxes;
+		wasAutoSavingPost  = completed.isAutosavingPost;
+	} );
+}
 
 const republishStrings = {
 	'Publish'  : __( 'Republish', 'duplicate-post' ),
 	'Publish:' : __( 'Republish:', 'duplicate-post' ),
 
-	'Are you ready to publish?':
-		__( 'Are you ready to republish your post?', 'duplicate-post' ),
+	'Are you ready to publish?'	: __( 'Are you ready to republish your post?', 'duplicate-post' ),
 	'Double-check your settings before publishing.':
 		createInterpolateElement(
-			__( 'After republishing your changes will be merged into the original post and you\'ll be redirected there.<br /><br /><a>Do you want to compare your changes with the original version before merging?</a>',
+			__( 'After republishing your changes will be merged into the original post and you\'ll be redirected there.<br /><br />Do you want to compare your changes with the original version before merging?<br /><br /><button>Save changes and compare</button>',
 				'duplicate-post' ),
 			{
-				a: <a href={ duplicatePostStrings.checkLink } />,
+				button: <Button isSecondary onClick={ saveAndCompare } />,
 				br: <br />
 			}
 		),
@@ -23,14 +46,13 @@ const republishStrings = {
 	'Schedule…' : __( 'Schedule republish…', 'duplicate-post' ),
 	'post action/button label\u0004Schedule' : __( 'Schedule republish', 'duplicate-post' ),
 
-	'Are you ready to schedule?':
-		__( 'Are you ready to schedule the republishing of your post?', 'duplicate-post' ),
+	'Are you ready to schedule?' : __( 'Are you ready to schedule the republishing of your post?', 'duplicate-post' ),
 	'Your work will be published at the specified date and time.':
 		createInterpolateElement(
-			__( 'You\'re about to replace the original with this rewritten post at the specified date and time.<br /><br /><a>Do you want to compare your changes with the original version before merging?</a>',
+			__( 'You\'re about to replace the original with this rewritten post at the specified date and time.<br /><br />Do you want to compare your changes with the original version before merging?<br /><br /><button>Save changes and compare</button>',
 				'duplicate-post' ),
 			{
-				a: <a href={ duplicatePostStrings.checkLink } />,
+				button: <Button isSecondary onClick={ saveAndCompare } />,
 				br: <br />
 			}
 		),

--- a/js/src/duplicate-post-strings.js
+++ b/js/src/duplicate-post-strings.js
@@ -3,7 +3,7 @@
 import { createInterpolateElement } from "@wordpress/element";
 import { Button } from "@wordpress/components";
 import { __, setLocaleData } from "@wordpress/i18n";
-import {dispatch, subscribe} from "@wordpress/data";
+import { dispatch, subscribe } from "@wordpress/data";
 import { redirectOnSaveCompletion } from "./duplicate-post-functions";
 
 const saveAndCompare = () => {

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -188,10 +188,10 @@ class Classic_Editor {
 		if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			?>
 				<div id="check-changes-action">
-					<?php echo \esc_html_e( 'Do you want to compare your changes with the original version before merging? Please save any changes first.', 'duplicate-post' ); ?>
+					<?php \esc_html_e( 'Do you want to compare your changes with the original version before merging? Please save any changes first.', 'duplicate-post' ); ?>
 					<br><br>
 					<a class='button' href=<?php echo \esc_url( $this->link_builder->build_check_link( $post ) ); ?>>
-						<?php echo \esc_html_e( 'Compare', 'duplicate-post' ); ?>
+						<?php \esc_html_e( 'Compare', 'duplicate-post' ); ?>
 					</a>
 				</div>
 				<?php

--- a/src/ui/class-post-submitbox.php
+++ b/src/ui/class-post-submitbox.php
@@ -193,7 +193,10 @@ class Post_Submitbox {
 		if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			?>
 				<div id="check-changes-action">
-					<a href="<?php echo \esc_url( $this->link_builder->build_check_link( $post ) ); ?>"><?php \esc_html_e( 'Do you want to compare your changes with the original version before merging?', 'duplicate-post' ); ?>
+					<?php echo \esc_html_e( 'Do you want to compare your changes with the original version before merging? Please save any changes first.', 'duplicate-post' ); ?>
+					<br><br>
+					<a class='button' href=<?php echo \esc_url( $this->link_builder->build_check_link( $post ) ); ?>>
+						<?php echo \esc_html_e( 'Compare', 'duplicate-post' ); ?>
 					</a>
 				</div>
 				<?php


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

In P3-273, the changes overview page was created. In order for this to work, the post (draft) has to be saved first, before clicking the "Do you want to compare your changes ..." link . If the post is not saved, a “Leave site?” pop-up appears. As this might be confusing for users, since they need to cancel the pop-up, then cancel the pre-publish screen, then save the draft and then eventually go back to click the link again. [See this loom for clarification of the problem.](https://www.loom.com/share/5fb1697e52854ab79cfa9994e7b1b252)

So product decided for the link to become normal text and to add a "Save and compare" button under it, which saves the post and sends you to the changes overview screen. 

[Design block editor.](https://www.sketch.com/s/2ec4254a-9529-4616-abe7-f6262c2ed6dd/a/O7bp3k/play)
~~[Design classic editor.](https://www.sketch.com/s/2ec4254a-9529-4616-abe7-f6262c2ed6dd/a/rKGAbd/play)~~ (outdated, see screenshot in test instructions)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces the compare-changes link with normal text and a button to save a Rewrite & Republish post and redirect to the changes overview.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

_Block editor_
* Make sure the Classic Editor is disabled.
* Create a new Rewrite & Republish post. 
* Change something in the title and/or content and click the `Republish` button in the top right corner (make sure NOT to manually save the draft in between). 
* Check that the pre-publish sidebar matches the [design](https://www.sketch.com/s/2ec4254a-9529-4616-abe7-f6262c2ed6dd/a/O7bp3k/play).
* Click the `Save and compare` button and see you are redirected to the changes-overview page without seeing a pop-up to check whether you want to reload the page. Also make sure all changes are still included.
  <img width="416" alt="Screenshot 2020-12-28 at 13 32 27" src="https://user-images.githubusercontent.com/43582255/103214600-22ad8180-4911-11eb-8e01-fc0daa9c217f.png"> 

_Classic editor_
* Make sure the Classic Editor is enabled.
* Create a new Rewrite & Republish post. 
* Change something in the title and/or content and click the `Save draft` button.
* Check that the submitbox matches the design 
<img width="253" alt="Screenshot 2020-12-28 at 15 36 08" src="https://user-images.githubusercontent.com/15989132/103267075-49bb9000-49b1-11eb-8ea0-aa71b9a212c4.png">
* Click the `Compare` button and see you are redirected to the changes-overview page. Also make sure all changes are still included.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A It was decided the Rewrite & Republish feature should be tested as a whole once completed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-293]
