### PR TITLE
P3-263 update R&R link in block editor

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -141,6 +141,8 @@ class DuplicatePost {
 	 * @returns {JSX.Element} The rendered links.
 	 */
 	render() {
+		const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+
 		return (
 			<Fragment>
 				{ ( duplicatePost.newDraftLink !== '' && duplicatePost.showLinks.new_draft === '1' ) &&
@@ -154,7 +156,7 @@ class DuplicatePost {
 						</Button>
 					</PluginPostStatusInfo>
 				}
-				{ ( duplicatePost.rewriteAndRepublishLink !== '' && duplicatePost.showLinks.rewrite_republish === '1' ) &&
+				{ ( currentPostStatus === 'publish' && duplicatePost.rewriteAndRepublishLink !== '' && duplicatePost.showLinks.rewrite_republish === '1' ) &&
 					<PluginPostStatusInfo>
 						<Button
 							isTertiary={ true }

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -130,7 +130,8 @@ class Block_Editor {
 		$post = \get_post();
 
 		if (
-			! $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post )
+			$this->permissions_helper->is_rewrite_and_republish_copy( $post )
+			|| $this->permissions_helper->has_rewrite_and_republish_copy( $post )
 			|| ! $this->permissions_helper->should_links_be_displayed( $post )
 		) {
 			return '';

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -86,14 +86,32 @@ class Block_Editor_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertNotFalse( \has_action( 'admin_enqueue_scripts', [ $this->instance, 'should_previously_used_keyword_assessment_run' ] ), 'Does not have expected admin_enqueue_scripts action' );
-		$this->assertNotFalse( \has_action( 'enqueue_block_editor_assets', [ $this->instance, 'enqueue_block_editor_scripts' ] ), 'Does not have expected enqueue_block_editor_assets action' );
+		$this->assertNotFalse(
+			\has_action(
+				'admin_enqueue_scripts',
+				[
+					$this->instance,
+					'should_previously_used_keyword_assessment_run',
+				]
+			),
+			'Does not have expected admin_enqueue_scripts action'
+		);
+		$this->assertNotFalse(
+			\has_action(
+				'enqueue_block_editor_assets',
+				[
+					$this->instance,
+					'enqueue_block_editor_scripts',
+				]
+			),
+			'Does not have expected enqueue_block_editor_assets action'
+		);
 	}
 
 	/**
 	 * Tests the should_previously_used_keyword_assessment_run function.
 	 *
-	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::should_previously_used_keyword_assessment_run
+	 * @covers       \Yoast\WP\Duplicate_Post\UI\Block_Editor::should_previously_used_keyword_assessment_run
 	 * @dataProvider should_previously_used_keyword_assessment_run_provider
 	 *
 	 * @param mixed $original Input value.
@@ -173,7 +191,8 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the enqueueing of the scripts on a post that is not a Rewrite & Republish copy.
+	 * Tests the enqueueing of the scripts on a post that is not a Rewrite &
+	 * Republish copy.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::enqueue_block_editor_scripts
 	 * @runInSeparateProcess
@@ -210,7 +229,8 @@ class Block_Editor_Test extends TestCase {
 			->expects( 'get_rewrite_republish_permalink' )
 			->andReturn( $rewrite_and_republish_link );
 
-		$utils->expects( 'get_option' )
+		$utils
+			->expects( 'get_option' )
 			->andReturn( $show_links );
 
 		$this->instance
@@ -237,7 +257,8 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the enqueueing of the scripts on a post that is a Rewrite & Republish copy.
+	 * Tests the enqueueing of the scripts on a post that is a Rewrite &
+	 * Republish copy.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::enqueue_block_editor_scripts
 	 * @runInSeparateProcess
@@ -351,11 +372,11 @@ class Block_Editor_Test extends TestCase {
 	}
 
 
-		/**
-		 * Tests the get_new_draft_permalink function when a link is returned.
-		 *
-		 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_new_draft_permalink
-		 */
+	/**
+	 * Tests the get_new_draft_permalink function when a link is returned.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_new_draft_permalink
+	 */
 	public function test_get_new_draft_permalink_successful() {
 		$post = Mockery::mock( \WP_Post::class );
 		$url  = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_new_draft&post=201&_wpnonce=94038b7dee';
@@ -363,11 +384,13 @@ class Block_Editor_Test extends TestCase {
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'should_links_be_displayed' )
+		$this->permissions_helper
+			->expects( 'should_links_be_displayed' )
 			->with( $post )
 			->andReturnTrue();
 
-		$this->link_builder->expects( 'build_new_draft_link' )
+		$this->link_builder
+			->expects( 'build_new_draft_link' )
 			->with( $post )
 			->andReturn( $url );
 
@@ -375,7 +398,8 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get_new_draft_permalink function when a link should not be displayed.
+	 * Tests the get_new_draft_permalink function when a link should not be
+	 * displayed.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_new_draft_permalink
 	 */
@@ -385,11 +409,13 @@ class Block_Editor_Test extends TestCase {
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'should_links_be_displayed' )
+		$this->permissions_helper
+			->expects( 'should_links_be_displayed' )
 			->with( $post )
 			->andReturnFalse();
 
-		$this->link_builder->expects( 'build_new_draft_link' )
+		$this->link_builder
+			->expects( 'build_new_draft_link' )
 			->with( $post )
 			->never();
 
@@ -397,27 +423,35 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get_rewrite_republish_permalink function when a link is returned.
+	 * Tests the get_rewrite_republish_permalink function when a link is
+	 * returned.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
 	public function test_get_rewrite_republish_permalink_successful() {
-		$post              = Mockery::mock( \WP_Post::class );
-		$post->post_status = 'publish';
-		$url               = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_rewrite&post=201&_wpnonce=5e7abf68c9';
+		$post = Mockery::mock( \WP_Post::class );
+		$url  = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_rewrite&post=201&_wpnonce=5e7abf68c9';
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'should_links_be_displayed' )
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->permissions_helper
+			->expects( 'has_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->permissions_helper
+			->expects( 'should_links_be_displayed' )
 			->with( $post )
 			->andReturnTrue();
 
-		$this->permissions_helper->expects( 'should_rewrite_and_republish_be_allowed' )
-			->with( $post )
-			->andReturnTrue();
-
-		$this->link_builder->expects( 'build_rewrite_and_republish_link' )
+		$this->link_builder
+			->expects( 'build_rewrite_and_republish_link' )
 			->with( $post )
 			->andReturn( $url );
 
@@ -425,26 +459,33 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get_rewrite_republish_permalink function when the post is not published.
+	 * Tests the get_rewrite_republish_permalink function when the post is a Rewrite & Republish copy.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
-	public function test_get_rewrite_republish_permalink_unsuccessful_not_published() {
-		$post              = Mockery::mock( \WP_Post::class );
-		$post->post_status = 'draft';
+	public function test_get_rewrite_republish_permalink_unsuccessful_is_rewrite_and_republish() {
+		$post = Mockery::mock( \WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'should_links_be_displayed' )
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'has_rewrite_and_republish_copy' )
 			->with( $post )
 			->never();
 
-		$this->permissions_helper->expects( 'should_rewrite_and_republish_be_allowed' )
+		$this->permissions_helper
+			->expects( 'should_links_be_displayed' )
 			->with( $post )
-			->andReturnFalse();
+			->never();
 
-		$this->link_builder->expects( 'build_rewrite_and_republish_link' )
+		$this->link_builder
+			->expects( 'build_rewrite_and_republish_link' )
 			->with( $post )
 			->never();
 
@@ -453,26 +494,33 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get_rewrite_republish_permalink function when the link should not be displayed.
+	 * Tests the get_rewrite_republish_permalink function when the post has a Rewrite & Republish copy.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
-	public function test_get_rewrite_republish_permalink_unsuccessful_link_should_not_be_displayed() {
-		$post              = Mockery::mock( \WP_Post::class );
-		$post->post_status = 'publish';
+	public function test_get_rewrite_republish_permalink_unsuccessful_has_a_rewrite_and_republish() {
+		$post = Mockery::mock( \WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'should_links_be_displayed' )
-			->with( $post )
-			->never();
-
-		$this->permissions_helper->expects( 'should_rewrite_and_republish_be_allowed' )
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
 			->with( $post )
 			->andReturnFalse();
 
-		$this->link_builder->expects( 'build_rewrite_and_republish_link' )
+		$this->permissions_helper
+			->expects( 'has_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'should_links_be_displayed' )
+			->with( $post )
+			->never();
+
+		$this->link_builder
+			->expects( 'build_rewrite_and_republish_link' )
 			->with( $post )
 			->never();
 
@@ -480,26 +528,34 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get_rewrite_republish_permalink function when duplicate link should be displayed except the Rewrite & Republish one.
+	 * Tests the get_rewrite_republish_permalink function when the links should not be displayed.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
-	public function test_get_rewrite_republish_permalink_unsuccessful_rewrite_and_republish_link_should_not_be_displayed() {
+	public function test_get_rewrite_republish_permalink_unsuccessful_links_should_not_be_displayed() {
 		$post              = Mockery::mock( \WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'should_links_be_displayed' )
-			->with( $post )
-			->never();
-
-		$this->permissions_helper->expects( 'should_rewrite_and_republish_be_allowed' )
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
 			->with( $post )
 			->andReturnFalse();
 
-		$this->link_builder->expects( 'build_rewrite_and_republish_link' )
+		$this->permissions_helper
+			->expects( 'has_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->permissions_helper
+			->expects( 'should_links_be_displayed' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->link_builder
+			->expects( 'build_rewrite_and_republish_link' )
 			->with( $post )
 			->never();
 
@@ -532,7 +588,8 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get_check_permalink function when the post is not intended for Rewrite & Republish.
+	 * Tests the get_check_permalink function when the post is not intended for
+	 * Rewrite & Republish.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_check_permalink
 	 */
@@ -572,7 +629,8 @@ class Block_Editor_Test extends TestCase {
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
-		$utils->expects( 'get_original_post_id' )
+		$utils
+			->expects( 'get_original_post_id' )
 			->with( $post->ID )
 			->andReturn( $original_id );
 
@@ -593,6 +651,7 @@ class Block_Editor_Test extends TestCase {
 					foreach ( $array as $key => $value ) {
 						$string .= '&' . $key . '=' . $value;
 					}
+
 					return $string;
 				}
 			);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a post is published in the block editor, the status update does not trigger a page reload. The R&R link is then hidden until you hit F5, or exit the edit screen and open it again. We should fix this

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows the Rewrite & Republish link in the Block editor immediately after the post has been published.

## Relevant technical choices:

* The link wasn't display on publish because it wasn't created in the first place on the server side. We changed the link creation so it's created and passed to JS, but displayed only when the current post status is `publish`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure you have the Rewrite & Republish link enabled in the settings (third tab)
* create a new post with block editor, do not publish it
* see that you can see only "Copy to a new draft" in the sidebar
* publish the post
* see that the page is not reloded, but now there is a "Rewrite & Republish" link in the sidebar, and it has a full URL for R&R
* switch to draft and see the R&R link disappears
* open an existing post which is in draft and see the R&R link is not visible
* open a R&R copy and see that you can't find none of the links in the sidebar
* open a post which has a R&R copy and see that you can't find the R&R link in the sidebar
  * completely delete (not just trash) the R&R copy and visit the original again to see the R&R link back in the sidebar


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* **Not applicable** QA will receive full test instructions for the feature with RC

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-263]
