### PR TITLE
Remove the unsaved changes warning before redirect that happens due t…

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -76,7 +76,7 @@ class DuplicatePost {
 	 * @return bool Whether the Rewrite & Republish copy can be republished.
 	 */
 	isCopyAllowedToBeRepublished() {
-		const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+		const currentPostStatus = select( 'core/editor' ).getCurrentPostAttribute( 'status' );
 
 		if ( currentPostStatus === 'dp-rewrite-republish' || currentPostStatus === 'private' ) {
 			return true;


### PR DESCRIPTION
…o a Gutenberg bug

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Correctly redirect without an unsaved changes warning when a post is republished.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Correctly redirects to the republished post when republishing a post.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the latest version of the Gutenberg plugin
* Rewrite and republish a post.
* Make some changes.
* Click republish.
* You should be redirected to the republished post and see your changes.

This should also be tested without the Gutenberg plugin to be sure.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Clicking on the republish button and on the Save changes and compare button.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
