### PR TITLE
P3-295 Include edit screen option for block editor

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -129,6 +129,7 @@ class DuplicatePost {
 		const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
 
 		return (
+			( duplicatePost.showLinksIn.submitbox === '1' ) &&
 			<Fragment>
 				{ ( duplicatePost.newDraftLink !== '' && duplicatePost.showLinks.new_draft === '1' ) &&
 					<PluginPostStatusInfo>

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -93,6 +93,7 @@ class Block_Editor {
 			'newDraftLink'            => $this->get_new_draft_permalink(),
 			'rewriteAndRepublishLink' => $this->get_rewrite_republish_permalink(),
 			'showLinks'               => Utils::get_option( 'duplicate_post_show_link' ),
+			'showLinksIn'             => Utils::get_option( 'duplicate_post_show_link_in' ),
 			'rewriting'               => $is_rewrite_and_republish_copy ? 1 : 0,
 			'originalEditURL'         => $this->get_original_post_edit_url(),
 		];

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -207,6 +207,12 @@ class Block_Editor_Test extends TestCase {
 		$original_edit_url          = 'http://fakeu.rl/original';
 
 		$show_links = [
+			'new_draft'         => '1',
+			'clone'             => '1',
+			'rewrite_republish' => '1',
+		];
+
+		$show_links_in = [
 			'row'         => '1',
 			'adminbar'    => '1',
 			'submitbox'   => '1',
@@ -233,6 +239,10 @@ class Block_Editor_Test extends TestCase {
 			->expects( 'get_option' )
 			->andReturn( $show_links );
 
+		$utils
+			->expects( 'get_option' )
+			->andReturn( $show_links_in );
+
 		$this->instance
 			->expects( 'get_original_post_edit_url' )
 			->andReturn( $original_edit_url );
@@ -241,6 +251,7 @@ class Block_Editor_Test extends TestCase {
 			'newDraftLink'            => $new_draft_link,
 			'rewriteAndRepublishLink' => $rewrite_and_republish_link,
 			'showLinks'               => $show_links,
+			'showLinksIn'             => $show_links_in,
 			'rewriting'               => $rewriting,
 			'originalEditURL'         => $original_edit_url,
 		];
@@ -274,6 +285,12 @@ class Block_Editor_Test extends TestCase {
 		$check_link                 = 'http://fakeu.rl/check';
 
 		$show_links = [
+			'new_draft'         => '1',
+			'clone'             => '1',
+			'rewrite_republish' => '1',
+		];
+
+		$show_links_in = [
 			'row'         => '1',
 			'adminbar'    => '1',
 			'submitbox'   => '1',
@@ -300,6 +317,10 @@ class Block_Editor_Test extends TestCase {
 			->expects( 'get_option' )
 			->andReturn( $show_links );
 
+		$utils
+			->expects( 'get_option' )
+			->andReturn( $show_links_in );
+
 		$this->instance
 			->expects( 'get_original_post_edit_url' )
 			->andReturn( $original_edit_url );
@@ -308,6 +329,7 @@ class Block_Editor_Test extends TestCase {
 			'newDraftLink'            => $new_draft_link,
 			'rewriteAndRepublishLink' => $rewrite_and_republish_link,
 			'showLinks'               => $show_links,
+			'showLinksIn'             => $show_links_in,
 			'rewriting'               => $rewriting,
 			'originalEditURL'         => $original_edit_url,
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The block editor class doesn't have a check for the "Edit screen" setting.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Includes the edit screen option in the block editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure all `Show these links` options are enabled (i.e., `New Draft`, `Clone`, `Rewrite & Republish`).
* Go to Settings > Duplicate Post > Display and from `Show links in` disable the `Edit Screen` option. Save your changes.
* In the block editor, edit a published post without a Rewrite & Republish copy.
* See that there is no `Copy to a new draft` or `Rewrite & Republish` link in the sidebar (above the `Move to trash` button).
* Go to Settings > Duplicate Post > Display and from `Show links in` enable the `Edit Screen` option. Save your changes.
* In the block editor, edit a published post without a Rewrite & Republish copy and see the `Copy to a new draft` and `Rewrite & Republish` links are now shown in the sidebar (above the `Move to trash` button). 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not applicable QA will receive full test instructions for the feature with RC.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-295]
