### PR TITLE
P3-298 Fix "Publish on" strings

### DIFF
--- a/js/src/duplicate-post-strings.js
+++ b/js/src/duplicate-post-strings.js
@@ -30,6 +30,7 @@ const saveAndCompare = () => {
 const republishStrings = {
 	'Publish'  : __( 'Republish', 'duplicate-post' ),
 	'Publish:' : __( 'Republish:', 'duplicate-post' ),
+	'Publish on:' : __( 'Republish on:', 'duplicate-post' ),
 
 	'Are you ready to publish?'	: __( 'Are you ready to republish your post?', 'duplicate-post' ),
 	'Double-check your settings before publishing.':

--- a/src/ui/class-asset-manager.php
+++ b/src/ui/class-asset-manager.php
@@ -46,7 +46,7 @@ class Asset_Manager {
 			'duplicate_post_edit_script',
 			\plugins_url( \sprintf( 'js/dist/duplicate-post-edit-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
 			[
-				'wp-blocks',
+				'wp-components',
 				'wp-element',
 				'wp-i18n',
 			],
@@ -58,6 +58,7 @@ class Asset_Manager {
 			'duplicate_post_strings',
 			\plugins_url( \sprintf( 'js/dist/duplicate-post-strings-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
 			[
+				'wp-components',
 				'wp-element',
 				'wp-i18n',
 			],

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -207,8 +207,15 @@ class Classic_Editor {
 	 * @return string The to-be-used copy of the text.
 	 */
 	public function change_republish_strings_classic_editor( $translation, $text ) {
-		if ( $this->should_change_rewrite_republish_copy( \get_post() ) && $text === 'Publish' ) {
-			return \__( 'Republish', 'duplicate-post' );
+		if ( $this->should_change_rewrite_republish_copy( \get_post() ) ) {
+			if ( $text === 'Publish' ) {
+				return \__( 'Republish', 'duplicate-post' );
+			}
+
+			if ( $text === 'Publish on: %s' ) {
+				/* translators: %s: Date on which the post is to be republished. */
+				return \__( 'Republish on: %s', 'duplicate-post' );
+			}
 		}
 
 		return $translation;

--- a/tests/ui/class-asset-manager-test.php
+++ b/tests/ui/class-asset-manager-test.php
@@ -104,7 +104,7 @@ class Asset_Manager_Test extends TestCase {
 				'duplicate_post_edit_script',
 				$edit_script_url,
 				[
-					'wp-blocks',
+					'wp-components',
 					'wp-element',
 					'wp-i18n',
 				],
@@ -117,6 +117,7 @@ class Asset_Manager_Test extends TestCase {
 				'duplicate_post_strings',
 				$strings_script_url,
 				[
+					'wp-components',
 					'wp-element',
 					'wp-i18n',
 				],

--- a/tests/ui/class-classic-editor-test.php
+++ b/tests/ui/class-classic-editor-test.php
@@ -86,7 +86,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_register_hooks() {
-		$utils = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 
 		$utils->expects( 'get_option' )
 			->with( 'duplicate_post_show_link_in', 'submitbox' )
@@ -465,6 +465,29 @@ class Classic_Editor_Test extends TestCase {
 		$this->setOutputCallback( function() {} );
 		$this->instance->add_rewrite_and_republish_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
+	}
+
+	/**
+	 * Tests the change_republish_strings_classic_editor function when the copy should be changed in the case of the date label.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_republish_strings_classic_editor
+	 */
+	public function test_should_change_republish_strings_date_label() {
+		$text = 'Publish on: %s';
+
+		$post            = Mockery::mock( \WP_Post::class );
+		$post->post_type = 'post';
+
+		Monkey\Functions\expect( '\get_post' )
+			->once()
+			->andReturn( $post );
+
+		$this->instance->expects( 'should_change_rewrite_republish_copy' )
+			->with( $post )
+			->once()
+			->andReturnTrue();
+
+		$this->assertEquals( $this->instance->change_republish_strings_classic_editor( '', $text ), 'Republish on: %s' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently on Classic editor the label for choosing the date is "Publish on:", For Rewrite & Republish copies it should become "Republish on:" as it happens on Block editor

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the label for the date choser in Classic editor for Rewrite & Republish copies.

## Relevant technical choices:

* Also fixes a dependency error, and changes the dependency list for the Block Editor script

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Classic editor, disable Yoast SEO if you have it (and any other plugin if possible)
* edit a Rewrite & Republish copy
* see that the label for the date shows "Republish on:" (this comes from PHP)
* change the date to a future one so that the label changes to "Schedule for:"
* change the date back to a past date and see that the label is again "Republish on:" (this comes from JS)
* edit a non-R&R copy to check this doesn't happen


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Block editor integration: we changed the dependency list to make it more consistent, it should be checked for any regressions.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-298]
