### PR TITLE
P3-302 Disable duplicate focus keyphrase assessment on Rewrite and Republish original post

### DIFF
--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -60,7 +60,7 @@ class Block_Editor {
 	}
 
 	/**
-	 * Disables the Yoast SEO PreviouslyUsedKeyword assessment for posts duplicated for Rewrite & Republish.
+	 * Disables the Yoast SEO PreviouslyUsedKeyword assessment for Rewrite & Republish original and duplicate posts.
 	 *
 	 * @return void
 	 */
@@ -69,7 +69,13 @@ class Block_Editor {
 
 			$post = \get_post();
 
-			if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			if (
+				! \is_null( $post )
+				&& (
+					$this->permissions_helper->is_rewrite_and_republish_copy( $post )
+					|| $this->permissions_helper->has_rewrite_and_republish_copy( $post )
+				)
+			) {
 				\add_filter( 'wpseo_previously_used_keyword_active', '__return_false' );
 			}
 		}

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -136,6 +136,11 @@ class Block_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $original['is_rewrite_and_republish_copy'] );
 
+		$this->permissions_helper
+			->allows( 'has_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturn( $original['has_rewrite_and_republish_copy'] );
+
 		$this->instance->should_previously_used_keyword_assessment_run();
 		$this->assertSame( $expected, \has_filter( 'wpseo_previously_used_keyword_active' ) );
 	}
@@ -149,41 +154,55 @@ class Block_Editor_Test extends TestCase {
 		return [
 			[
 				'original' => [
-					'is_edit_post_screen'           => true,
-					'is_new_post_screen'            => false,
-					'is_rewrite_and_republish_copy' => true,
+					'is_edit_post_screen'            => true,
+					'is_new_post_screen'             => false,
+					'is_rewrite_and_republish_copy'  => true,
+					'has_rewrite_and_republish_copy' => false,
 				],
 				'expected' => true,
 			],
 			[
 				'original' => [
-					'is_edit_post_screen'           => false,
-					'is_new_post_screen'            => true,
-					'is_rewrite_and_republish_copy' => true,
+					'is_edit_post_screen'            => false,
+					'is_new_post_screen'             => true,
+					'is_rewrite_and_republish_copy'  => true,
+					'has_rewrite_and_republish_copy' => false,
 				],
 				'expected' => true,
 			],
 			[
 				'original' => [
-					'is_edit_post_screen'           => false,
-					'is_new_post_screen'            => false,
-					'is_rewrite_and_republish_copy' => null,
+					'is_edit_post_screen'            => true,
+					'is_new_post_screen'             => false,
+					'is_rewrite_and_republish_copy'  => false,
+					'has_rewrite_and_republish_copy' => true,
+				],
+				'expected' => true,
+			],
+			[
+				'original' => [
+					'is_edit_post_screen'            => false,
+					'is_new_post_screen'             => false,
+					'is_rewrite_and_republish_copy'  => false,
+					'has_rewrite_and_republish_copy' => false,
 				],
 				'expected' => false,
 			],
 			[
 				'original' => [
-					'is_edit_post_screen'           => true,
-					'is_new_post_screen'            => false,
-					'is_rewrite_and_republish_copy' => false,
+					'is_edit_post_screen'            => true,
+					'is_new_post_screen'             => false,
+					'is_rewrite_and_republish_copy'  => false,
+					'has_rewrite_and_republish_copy' => false,
 				],
 				'expected' => false,
 			],
 			[
 				'original' => [
-					'is_edit_post_screen'           => false,
-					'is_new_post_screen'            => true,
-					'is_rewrite_and_republish_copy' => false,
+					'is_edit_post_screen'            => false,
+					'is_new_post_screen'             => true,
+					'is_rewrite_and_republish_copy'  => false,
+					'has_rewrite_and_republish_copy' => false,
 				],
 				'expected' => false,
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the SEO analysis results to not give potentially confusing feedback for the Rewrite and Republish original and duplicate posts.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the duplicate focus keyphrase SEO analysis assessment for the Rewrite & Republish original posts.

## Relevant technical choices:

* In https://github.com/Yoast/duplicate-post/pull/56 we disabled the duplicate focus keyphrase assessment for the R&R duplicate posts, following what was specified in https://yoast.atlassian.net/browse/P3-235
* This PR uses the same approach to disable the assessment also for the R&R original posts, i.e. the ones that are published and have a copy meant for R&R .

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Activate Yoast SEO and Yoast Duplicate Post
- Edit a published post 
- Enter a focus keyphrase and update the post 
- Create a Rewrite & Republish copy of the post 
- Check the copy has the same focus keyphrase of the original (it should be copied by default)
- In the Yoast SEO metabox > SEO analysis, check there's no assessment that says "Previously used keyphrase: You've used this keyphrase ..."
- Open the original post 
- In the Yoast SEO metabox > SEO analysis, check there's no assessment that says "Previously used keyphrase: You've used this keyphrase ..."
- Deactivate Yoast Duplicate Post 
- Open both posts and check the "Previously used keyphrase" assessment is now present in the metabox > SEO analysis



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-302]
