### PR TITLE
Ensure R&R doesn't show up in the bulk actions in the drafts posts list.

### DIFF
--- a/src/ui/class-bulk-actions.php
+++ b/src/ui/class-bulk-actions.php
@@ -69,13 +69,13 @@ class Bulk_Actions {
 	 */
 	public function register_bulk_action( $bulk_actions ) {
 		// phpcs:ignore WordPress.Security.NonceVerification
-		$is_trashed = isset( $_REQUEST['post_status'] ) && $_REQUEST['post_status'] === 'trash';
+		$is_draft_or_trash = isset( $_REQUEST['post_status'] ) && in_array( $_REQUEST['post_status'], array( 'draft', 'trash' ), true );
 
 		if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'clone' ) ) === 1 ) {
 			$bulk_actions['duplicate_post_bulk_clone'] = \esc_html__( 'Clone', 'duplicate-post' );
 		}
 
-		if ( ! $is_trashed && \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1 ) {
+		if ( ! $is_draft_or_trash && \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1 ) {
 			$bulk_actions['duplicate_post_bulk_rewrite_republish'] = \esc_html__( 'Rewrite & Republish', 'duplicate-post' );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removes the Republish & Rewrite action from bulk actions, when the user is viewing _draft_ posts, as Republish & Rewrite is only meant for published posts.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Republish & Rewrite bulk action was displayed in the Drafts posts list.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Checkout this branch, run composer install, yarn and grunt build.
- Go to the posts overview.
- Make sure you have at least one draft post and one trashed post.
- In the posts overview, see that the Rewrite & Republish action is available in the bulk actions list in the following posts lists (the links at the top of the list):
  - All
  - Mine (available only if you're author of at least one post)
  - Published
- Go to the Drafts posts list, see that the Rewrite & Republish action is not available in the bulk actions list.
- Go to the Trash posts list, see that the Rewrite & Republish action is not available in the bulk actions list.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

Of course, except switching to this branch and building.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-304]
