### PR TITLE
P3-310 disable Rewrite & Republish when Elementor is active

### DIFF
--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -217,7 +217,8 @@ class Permissions_Helper {
 	public function should_rewrite_and_republish_be_allowed( \WP_Post $post ) {
 		return $post->post_status === 'publish'
 			&& ! $this->is_rewrite_and_republish_copy( $post )
-			&& ! $this->has_rewrite_and_republish_copy( $post );
+			&& ! $this->has_rewrite_and_republish_copy( $post )
+			&& ! $this->is_elementor_active();
 	}
 
 	/**
@@ -265,6 +266,32 @@ class Permissions_Helper {
 		$copy = \get_post( $copy_id );
 
 		if ( $copy && $copy->post_status === 'trash' ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determines if the Elementor plugin is active.
+	 *
+	 * We can't use is_plugin_active because this must be working on front end too.
+	 *
+	 * @return bool
+	 */
+	public function is_elementor_active() {
+		$plugin = 'elementor/elementor.php';
+
+		if ( \in_array( $plugin, (array) \get_option( 'active_plugins', [] ), true ) ) {
+			return true;
+		}
+
+		if ( ! \is_multisite() ) {
+			return false;
+		}
+
+		$plugins = \get_site_option( 'active_sitewide_plugins' );
+		if ( isset( $plugins[ $plugin ] ) ) {
 			return true;
 		}
 

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -277,7 +277,7 @@ class Permissions_Helper {
 	 *
 	 * We can't use is_plugin_active because this must be working on front end too.
 	 *
-	 * @return bool
+	 * @return bool Whether the Elementor plugin is currently active.
 	 */
 	public function is_elementor_active() {
 		$plugin = 'elementor/elementor.php';
@@ -291,10 +291,6 @@ class Permissions_Helper {
 		}
 
 		$plugins = \get_site_option( 'active_sitewide_plugins' );
-		if ( isset( $plugins[ $plugin ] ) ) {
-			return true;
-		}
-
-		return false;
+		return isset( $plugins[ $plugin ] );
 	}
 }

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -140,6 +140,7 @@ class Block_Editor {
 			$this->permissions_helper->is_rewrite_and_republish_copy( $post )
 			|| $this->permissions_helper->has_rewrite_and_republish_copy( $post )
 			|| ! $this->permissions_helper->should_links_be_displayed( $post )
+			|| $this->permissions_helper->is_elementor_active()
 		) {
 			return '';
 		}

--- a/src/ui/class-bulk-actions.php
+++ b/src/ui/class-bulk-actions.php
@@ -75,7 +75,9 @@ class Bulk_Actions {
 			$bulk_actions['duplicate_post_bulk_clone'] = \esc_html__( 'Clone', 'duplicate-post' );
 		}
 
-		if ( ! $is_draft_or_trash && \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1 ) {
+		if ( ! $is_draft_or_trash
+			&& \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1
+			&& ! $this->permissions_helper->is_elementor_active() ) {
 			$bulk_actions['duplicate_post_bulk_rewrite_republish'] = \esc_html__( 'Rewrite & Republish', 'duplicate-post' );
 		}
 

--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Duplicate Post class to manage the post list.
+ *
+ * @package Duplicate_Post
+ */
+
+namespace Yoast\WP\Duplicate_Post\UI;
+
+use Yoast\WP\Duplicate_Post\Permissions_Helper;
+
+/**
+ * Represents the Post_List class.
+ */
+class Post_List {
+
+	/**
+	 * Holds the permissions helper.
+	 *
+	 * @var Permissions_Helper
+	 */
+	protected $permissions_helper;
+
+	/**
+	 * Initializes the class.
+	 *
+	 * @param Permissions_Helper $permissions_helper The Permissions helper object.
+	 */
+	public function __construct( Permissions_Helper $permissions_helper ) {
+		$this->permissions_helper = $permissions_helper;
+	}
+
+	/**
+	 * Adds hooks to integrate with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'parse_query', [ $this, 'filter_rewrite_and_republish_copies' ], 10 );
+	}
+
+	/**
+	 * Filters out Rewrite & Republish copies from the post list when Elementor is active.
+	 *
+	 * @param \WP_Query $query The current WordPress query.
+	 *
+	 * @return \WP_Query The updated post WordPress query.
+	 */
+	public function filter_rewrite_and_republish_copies( \WP_Query $query ) {
+		if ( ! \is_admin() ) {
+			return $query;
+		}
+
+		$current_screen = \get_current_screen();
+		if ( $current_screen->base !== 'edit' ) {
+			return $query;
+		}
+
+		if ( $this->permissions_helper->is_elementor_active() ) {
+			$query->set(
+				'meta_query',
+				[
+					[
+						'key'     => '_dp_is_rewrite_republish_copy',
+						'compare' => 'NOT EXISTS',
+					],
+				]
+			);
+		}
+		return $query;
+	}
+}

--- a/src/ui/class-user-interface.php
+++ b/src/ui/class-user-interface.php
@@ -78,6 +78,13 @@ class User_Interface {
 	protected $column;
 
 	/**
+	 * Post_List object.
+	 *
+	 * @var Post_List
+	 */
+	protected $post_list;
+
+	/**
 	 * Holds the object to create the action link to duplicate.
 	 *
 	 * @var Link_Builder
@@ -108,6 +115,7 @@ class User_Interface {
 		$this->column         = new Column( $this->permissions_helper, $this->asset_manager );
 		$this->metabox        = new Metabox( $this->permissions_helper );
 		$this->post_states    = new Post_States( $this->permissions_helper );
+		$this->post_list      = new Post_List( $this->permissions_helper );
 		$this->classic_editor = new Classic_Editor( $this->link_builder, $this->permissions_helper, $this->asset_manager );
 		$this->row_actions    = new Row_Actions( $this->link_builder, $this->permissions_helper );
 
@@ -117,6 +125,7 @@ class User_Interface {
 		$this->column->register_hooks();
 		$this->metabox->register_hooks();
 		$this->post_states->register_hooks();
+		$this->post_list->register_hooks();
 		$this->classic_editor->register_hooks();
 		$this->row_actions->register_hooks();
 	}

--- a/tests/class-permissions-helper-test.php
+++ b/tests/class-permissions-helper-test.php
@@ -657,6 +657,11 @@ class Permissions_Helper_Test extends TestCase {
 			->with( $post )
 			->andReturn( $original['has_rewrite_and_republish_copy'] );
 
+		$this->instance
+			->allows( 'is_elementor_active' )
+			->times( $original['is_elementor_active_times_called'] )
+			->andReturn( $original['is_elementor_active'] );
+
 		$this->assertEquals( $expected, $this->instance->should_rewrite_and_republish_be_allowed( $post ) );
 	}
 
@@ -669,41 +674,61 @@ class Permissions_Helper_Test extends TestCase {
 		return [
 			[
 				'original' => [
-					'post_status'                    => 'publish',
-					'is_rewrite_and_republish_copy'  => false,
+					'post_status'                      => 'publish',
+					'is_rewrite_and_republish_copy'    => false,
 					'is_rewrite_and_republish_copy_times_called' => 1,
-					'has_rewrite_and_republish_copy' => false,
+					'has_rewrite_and_republish_copy'   => false,
 					'has_rewrite_and_republish_copy_times_called' => 1,
+					'is_elementor_active'              => false,
+					'is_elementor_active_times_called' => 1,
 				],
 				'expected' => true,
 			],
 			[
 				'original' => [
-					'post_status'                    => 'draft',
-					'is_rewrite_and_republish_copy'  => false,
+					'post_status'                      => 'draft',
+					'is_rewrite_and_republish_copy'    => false,
 					'is_rewrite_and_republish_copy_times_called' => 0,
-					'has_rewrite_and_republish_copy' => false,
+					'has_rewrite_and_republish_copy'   => false,
 					'has_rewrite_and_republish_copy_times_called' => 0,
+					'is_elementor_active'              => false,
+					'is_elementor_active_times_called' => 0,
 				],
 				'expected' => false,
 			],
 			[
 				'original' => [
-					'post_status'                    => 'publish',
-					'is_rewrite_and_republish_copy'  => true,
+					'post_status'                      => 'publish',
+					'is_rewrite_and_republish_copy'    => true,
 					'is_rewrite_and_republish_copy_times_called' => 1,
-					'has_rewrite_and_republish_copy' => false,
+					'has_rewrite_and_republish_copy'   => false,
 					'has_rewrite_and_republish_copy_times_called' => 0,
+					'is_elementor_active'              => false,
+					'is_elementor_active_times_called' => 0,
 				],
 				'expected' => false,
 			],
 			[
 				'original' => [
-					'post_status'                    => 'publish',
-					'is_rewrite_and_republish_copy'  => false,
+					'post_status'                      => 'publish',
+					'is_rewrite_and_republish_copy'    => false,
 					'is_rewrite_and_republish_copy_times_called' => 1,
-					'has_rewrite_and_republish_copy' => true,
+					'has_rewrite_and_republish_copy'   => true,
 					'has_rewrite_and_republish_copy_times_called' => 1,
+					'is_elementor_active'              => false,
+					'is_elementor_active_times_called' => 0,
+				],
+				'expected' => false,
+			],
+			[
+				'original' => [
+					'post_status'                      => 'publish',
+					'is_rewrite_and_republish_copy'    => false,
+					'is_rewrite_and_republish_copy_times_called' => 1,
+					'has_rewrite_and_republish_copy'   => false,
+					'has_rewrite_and_republish_copy_times_called' => 1,
+					'is_elementor_active'              => true,
+					'is_elementor_active_times_called' => 1,
 				],
 				'expected' => false,
 			],

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -491,6 +491,10 @@ class Block_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturnTrue();
 
+		$this->permissions_helper
+			->expects( 'is_elementor_active' )
+			->andReturnFalse();
+
 		$this->link_builder
 			->expects( 'build_rewrite_and_republish_link' )
 			->with( $post )

--- a/tests/ui/class-bulk-actions-test.php
+++ b/tests/ui/class-bulk-actions-test.php
@@ -11,7 +11,6 @@ use Brain\Monkey;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Bulk_Actions;
-use Yoast\WP\Duplicate_Post\Utils;
 
 /**
  * Test the Bulk_Actions class.
@@ -155,6 +154,10 @@ class Bulk_Actions_Test extends TestCase {
 			->with( 'duplicate_post_show_link', 'rewrite_republish' )
 			->once()
 			->andReturn( '1' );
+
+		$this->permissions_helper
+			->expects( 'is_elementor_active' )
+			->andReturnFalse();
 
 		$array = [
 			'edit'  => 'Edit',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Rewrite & Republish has some issueS when working with Elementor. We decided to disable the new feature when Elementor is active while we work to make it compatible.
We need to:

1. prevent the creation of new Rewrite & Republish copies by disabling all the occurrences of the R&R command
2. hide existing R&R copies so users can't edit and republish them

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the Rewrite & Republish feature when Elementor is active.

## Relevant technical choices:

* We adapted the existing tests but didn't add new ones for time constraints.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Elementor, do not activate it yet
* create a number of R&R copies from existing posts, do not republish them
* see that you can see them in the post list
* Activate Elementor
* see that you can't find anywhere a Rewrite&Republish command:
  * in the quick actions in the post list
  * in the bulk actions in the post list
  * in the admin bar when you edit or view (as logged in user) a published post
  * in the publishing section of the edit screen for a published post
* see that you can't see any Rewrite & Republish copy in the post list.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-310]
