### PR TITLE
Fix fatal errors when `get_current_screen` is not available

### DIFF
--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -126,7 +126,7 @@ class Post_List {
 	 * @return bool Whether the filter should be applied.
 	 */
 	protected function should_filter() {
-		if ( ! \is_admin() ) {
+		if ( ! \is_admin() || ! \function_exists( '\get_current_screen' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug which affected some installations (e.g. with WooCommerce)

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the bug
* Be sure that you have WooCommerce disabled
* build and activate Yoast Duplicate Post from `release/4.0`
* see that everything's working fine
* activate WooCommerce
* see that you get a `Fatal error: Uncaught Error: Call to undefined function get_current_screen()`

#### Test the fix
* switch to this branch and build
* reload the page with the Fatal error and see it's gone now
* enable Elementor and see that the change did not affect the hiding of the R&R copies #89 + the recount of the posts #90


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Activate alongside WooCommerce and see that you don't get any errors
* be sure that you are testing #89 and #90 (very low risk of regression for them)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
