### PR TITLE
P3-299 Disable for WooCommerce products

### DIFF
--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -223,12 +223,12 @@ class Options_Form_Generator {
 	 * @return string The generated post types list.
 	 */
 	public function generate_post_types_list() {
-		$post_types = \get_post_types( [ 'show_ui' => true ], 'objects' );
-		$output     = '';
+		$post_types        = \get_post_types( [ 'show_ui' => true ], 'objects' );
+		$hidden_post_types = $this->get_hidden_post_types();
+		$output            = '';
 
 		foreach ( $post_types as $post_type_object ) {
-			if ( $post_type_object->name === 'attachment'
-				|| $post_type_object->name === 'wp_block' ) {
+			if ( \in_array( $post_type_object->name, $hidden_post_types, true ) ) {
 				continue;
 			}
 
@@ -302,5 +302,23 @@ class Options_Form_Generator {
 			$duplicate_post_types_enabled = [ $duplicate_post_types_enabled ];
 		}
 		return \in_array( $post_type, $duplicate_post_types_enabled, true );
+	}
+
+	/**
+	 * Generates a list of post types that should be hidden from the options page.
+	 *
+	 * @return array The array of names of the post types to hide.
+	 */
+	public function get_hidden_post_types() {
+		$hidden_post_types = [
+			'attachment',
+			'wp_block',
+		];
+
+		if ( Utils::is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			$hidden_post_types[] = 'product';
+		}
+
+		return $hidden_post_types;
 	}
 }

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -275,22 +275,9 @@ class Permissions_Helper {
 	/**
 	 * Determines if the Elementor plugin is active.
 	 *
-	 * We can't use is_plugin_active because this must be working on front end too.
-	 *
 	 * @return bool Whether the Elementor plugin is currently active.
 	 */
 	public function is_elementor_active() {
-		$plugin = 'elementor/elementor.php';
-
-		if ( \in_array( $plugin, (array) \get_option( 'active_plugins', [] ), true ) ) {
-			return true;
-		}
-
-		if ( ! \is_multisite() ) {
-			return false;
-		}
-
-		$plugins = \get_site_option( 'active_sitewide_plugins' );
-		return isset( $plugins[ $plugin ] );
+		return Utils::is_plugin_active( 'elementor/elementor.php' );
 	}
 }

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -19,12 +19,23 @@ class Permissions_Helper {
 	 * @return array The array of post types.
 	 */
 	public function get_enabled_post_types() {
-		$duplicate_post_types_enabled = \get_option( 'duplicate_post_types_enabled', [ 'post', 'page' ] );
-		if ( ! \is_array( $duplicate_post_types_enabled ) ) {
-			$duplicate_post_types_enabled = [ $duplicate_post_types_enabled ];
+		$enabled_post_types = \get_option( 'duplicate_post_types_enabled', [ 'post', 'page' ] );
+		if ( ! \is_array( $enabled_post_types ) ) {
+			$enabled_post_types = [ $enabled_post_types ];
 		}
 
-		return $duplicate_post_types_enabled;
+		if ( Utils::is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			$enabled_post_types = \array_diff( $enabled_post_types, [ 'product' ] );
+		}
+
+		/**
+		 * Filters the list of post types for which the plugin is enabled.
+		 *
+		 * @param array $enabled_post_types The array of post type names for which the plugin is enabled.
+		 *
+		 * @return array The filtered array of post types names.
+		 */
+		return \apply_filters( 'duplicate_post_enabled_post_types', $enabled_post_types );
 	}
 
 	/**

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -195,13 +195,13 @@ class Utils {
 	}
 
 	/**
-	 * Determines if the a plugin is active.
+	 * Determines if a plugin is active.
 	 *
 	 * We can't use is_plugin_active because this must work on the frontend too.
 	 *
 	 * @param string $plugin Path to the plugin file relative to the plugins directory.
 	 *
-	 * @return bool Whether the plugin is currently active.
+	 * @return bool Whether a plugin is currently active.
 	 */
 	public static function is_plugin_active( $plugin ) {
 		if ( \in_array( $plugin, (array) \get_option( 'active_plugins', [] ), true ) ) {

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -197,7 +197,7 @@ class Utils {
 	/**
 	 * Determines if the a plugin is active.
 	 *
-	 * We can't use is_plugin_active because this must be working on front end too.
+	 * We can't use is_plugin_active because this must work on the frontend too.
 	 *
 	 * @param string $plugin Path to the plugin file relative to the plugins directory.
 	 *

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -193,4 +193,26 @@ class Utils {
 
 		return $option[ $key ];
 	}
+
+	/**
+	 * Determines if the a plugin is active.
+	 *
+	 * We can't use is_plugin_active because this must be working on front end too.
+	 *
+	 * @param string $plugin Path to the plugin file relative to the plugins directory.
+	 *
+	 * @return bool Whether the plugin is currently active.
+	 */
+	public static function is_plugin_active( $plugin ) {
+		if ( \in_array( $plugin, (array) \get_option( 'active_plugins', [] ), true ) ) {
+			return true;
+		}
+
+		if ( ! \is_multisite() ) {
+			return false;
+		}
+
+		$plugins = \get_site_option( 'active_sitewide_plugins' );
+		return isset( $plugins[ $plugin ] );
+	}
 }

--- a/tests/admin/class-options-form-generator-test.php
+++ b/tests/admin/class-options-form-generator-test.php
@@ -324,7 +324,7 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_generate_roles_permission_list() {
-		$utils = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$utils
 			->expects( 'get_roles' )
 			->once()
@@ -348,6 +348,16 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator::generate_post_types_list
 	 */
 	public function test_generate_post_types_list() {
+		$this->instance
+			->expects( 'get_hidden_post_types' )
+			->andReturn(
+				[
+					'attachment',
+					'wp_block',
+					'product',
+				]
+			);
+
 		$this->instance
 			->expects( 'is_post_type_enabled' )
 			->with( 'Books' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WooCommerce already has its own duplication feature which can't be disabled and is more suitable (supporting variable products etc). Letting users enable the plugin for WC Products can be misleading and confusing (with multiple links to create copies).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the plugin for WooCommerce products, introduces filter for enabled post types.

## Relevant technical choices:

* The PR adds a filter calles `duplicate_post_enabled_post_types` to allow users to enable/disable post types overriding the options.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure you have WooCommerce active with at least one Product.
* visit Settings->Duplicate Post, second tab "Permissions", and see that the checkbox for Products is missing.
* visit the list of Products and see that the row actions and bulk actions do not display any Duplicate Post command. You will see just the WC command "Duplicate" (check the URL and see that is has a `duplicate_product` action)
* edit a product and see that you can see only one "Copy to a new draft link" instead of two, and it's the WooCommerce one  (check the URL and see that is has a `duplicate_product` action).
* see also that you can't see any "Copy to a new draft" link in the admin bar, neither when editing the product nor while viewing it in the front-end as logged in.
* see that if you enable the plugin for Orders and Coupons the links are visible: WC does not have any duplication command for them and users might want to clone them as usual

#### Test the filter
* edit your theme's `functions.php` and add these lines at the end of the file, then save:
```
function test_add_product( $post_list ) {
	$post_list[] = 'product';
    return $post_list;
}
add_filter('duplicate_post_enabled_post_types', 'test_add_product');
```
* repeat the test above and see that while you still can't see "Product" in the options, now you can see the Duplicate Post links in every place.

#### Test with non-WooCommerce `product` post type
* disable WooCommerce
* comment out (don't remove) the code in `functions.php`
* paste the snippet you can find in the first comment below in this PR into your theme's `functions.php`, to create a custom post type named `product`.
* visit Settings->Duplicate Post, second tab "Permissions", and see that the checkbox for Products is now present. Enable it and save
* visit Products, create one or more items, see that you can see all the links 
* disable the plugin for Products and see that the links are not displayed anymore
* un-comment the four lines of code above in `functions.php` and see that the links are back, overriding the option.

**Note:** you can't see a Rewrite & Republish link even if they are enabled because WC products don't use the `publish` post status.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-299]
