### PR TITLE
Update upgrade notice for version 4.0

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -203,8 +203,6 @@ function duplicate_post_migrate_show_links_in_options( $defaults ) {
  * @global string $wp_version The WordPress version string.
  */
 function duplicate_post_show_update_notice() {
-	global $wp_version;
-
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
@@ -220,27 +218,29 @@ function duplicate_post_show_update_notice() {
 
 	$class   = 'notice is-dismissible';
 	$message = '<p><strong>' . sprintf(
-		/* translators: %s: Duplicate Post version. */
-		__( "What's new in Duplicate Post version %s:", 'duplicate-post' ),
+		/* translators: %s: Yoast Duplicate Post version. */
+		__( "What's new in Yoast Duplicate Post version %s:", 'duplicate-post' ),
 		DUPLICATE_POST_CURRENT_VERSION
-	) . '</strong></p>';
+	) . '</strong> ';
+	$message .= __( 'Meet the Rewrite & Republish feature! It makes it easy as ABC to update a post/page without taking it offline or having to take extra steps!', 'duplicate-post' )
+		. ' ';
+
+	$message .= '<a href="https://yoa.st/duplicate-post-4-0">'
+				. sprintf(
+					/* translators: %s: Yoast Duplicate Post version. */
+					__( 'Read more about what’s new in Yoast Duplicate Post %s!', 'duplicate-post' ),
+					DUPLICATE_POST_CURRENT_VERSION
+				)
+				. '</a></p>';
 
 	$message .= '<p>%%SIGNUP_FORM%%</p>';
 
-	$message .= '<p>' . __( 'Serving the WordPress community since November 2007.', 'duplicate-post' ) . '</p>';
-
-	if ( version_compare( $wp_version, '4.2' ) < 0 ) {
-		$message .= ' | <a id="duplicate-post-dismiss-notice" href="javascript:duplicate_post_dismiss_notice();">' .
-			__( 'Dismiss this notice.', 'default' ) . '</a>';
-	}
 	$allowed_tags = array(
 		'a'      => array(
 			'href'  => array(),
-			'title' => array(),
 		),
 		'br'     => array(),
 		'p'      => array(),
-		'em'     => array(),
 		'strong' => array(),
 	);
 
@@ -782,7 +782,7 @@ function duplicate_post_newsletter_signup_form() {
 	$copy = sprintf(
 		/* translators: 1: Yoast */
 		__(
-			'If you want to stay up to date about all the exciting developments around duplicate post, subscribe to the %1$s newsletter!',
+			'If you want to stay up to date about all the exciting developments around Duplicate Post, subscribe to the %1$s newsletter!',
 			'duplicate-post'
 		),
 		'Yoast'


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We have to upgrade the plugin notice for version 4.0

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the upgrade notice for version 4.0

## Relevant technical choices:

* We have removed some outdated code which was needed to ensure compatibility with WP < 4.7

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit the WP Dashboard or the Plugins page
  * If you already tested a 4.0-RCx version and dismissed the notice, you'll have to visit Settings→Duplicate Post, third tab "Display", tick the "Show upgrade notice" checkbox and save.
* Observe that the notice matches the design:
![Screenshot_2021-01-11 Dashboard ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/104190997-354dad80-541d-11eb-8141-f17237e814e6.png)
* click on the link to see you arrive to the page about Duplicate Post on the yoast.com website.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-311]
