### PR TITLE
Patch typehinting fatal error

### DIFF
--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -18,6 +18,7 @@ module.exports = {
 					"duplicate-post-admin.php",
 					"duplicate-post-common.php",
 					"duplicate-post-options.php",
+					"duplicate_post_yoast_icon-125x125.png",
 					"!vendor/bin/**",
 					"!vendor/composer/installed.json",
 					"!vendor/composer/installers/**",

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -161,7 +161,7 @@ function duplicate_post_plugin_upgrade() {
 	update_option( 'duplicate_post_blacklist', implode( ',', $meta_blacklist ) );
 
 	delete_option( 'duplicate_post_show_notice' );
-	if ( version_compare( $installed_version, '3.2.5' ) < 0 ) {
+	if ( version_compare( $installed_version, '4.0.0' ) < 0 ) {
 		update_site_option( 'duplicate_post_show_notice', 1 );
 	}
 

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -54,10 +54,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the post is a copy intended for Rewrite & Republish.
 	 */
-	public function is_rewrite_and_republish_copy( $post ) {
-		if ( $post instanceof \WP_Post === false ) {
-			return false;
-		}
+	public function is_rewrite_and_republish_copy( \WP_Post $post ) {
 		return ( \intval( \get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true ) ) === 1 );
 	}
 
@@ -68,7 +65,7 @@ class Permissions_Helper {
 	 *
 	 * @return int The Rewrite & Republish copy ID.
 	 */
-	public function get_rewrite_and_republish_copy_id( $post ) {
+	public function get_rewrite_and_republish_copy_id( \WP_Post $post ) {
 		return \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true );
 	}
 
@@ -79,7 +76,7 @@ class Permissions_Helper {
 	 *
 	 * @return \WP_Post|null The copy's post object or null if it doesn't exist.
 	 */
-	public function get_rewrite_and_republish_copy( $post ) {
+	public function get_rewrite_and_republish_copy( \WP_Post $post ) {
 		$copy_id = $this->get_rewrite_and_republish_copy_id( $post );
 
 		if ( empty( $copy_id ) ) {
@@ -96,7 +93,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the post has a copy intended for Rewrite & Republish.
 	 */
-	public function has_rewrite_and_republish_copy( $post ) {
+	public function has_rewrite_and_republish_copy( \WP_Post $post ) {
 		return ( ! empty( $this->get_rewrite_and_republish_copy_id( $post ) ) );
 	}
 
@@ -107,7 +104,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool|\WP_Post The scheduled copy if present, false if the post has no scheduled copy.
 	 */
-	public function has_scheduled_rewrite_and_republish_copy( $post ) {
+	public function has_scheduled_rewrite_and_republish_copy( \WP_Post $post ) {
 		$copy = $this->get_rewrite_and_republish_copy( $post );
 
 		if ( ! empty( $copy ) && $copy->post_status === 'future' ) {
@@ -172,7 +169,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the original post has changed since the creation of the copy.
 	 */
-	public function has_original_changed( $post ) {
+	public function has_original_changed( \WP_Post $post ) {
 		if ( ! $this->is_rewrite_and_republish_copy( $post ) ) {
 			return false;
 		}
@@ -196,11 +193,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the links can be displayed.
 	 */
-	public function should_links_be_displayed( $post ) {
-		if ( $post instanceof \WP_Post === false ) {
-			return false;
-		}
-
+	public function should_links_be_displayed( \WP_Post $post ) {
 		/**
 		 * Filter allowing displaying duplicate post links for current post.
 		 *
@@ -221,11 +214,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the links should be displayed.
 	 */
-	public function should_rewrite_and_republish_be_allowed( $post ) {
-		if ( $post instanceof \WP_Post === false ) {
-			return false;
-		}
-
+	public function should_rewrite_and_republish_be_allowed( \WP_Post $post ) {
 		return $post->post_status === 'publish'
 			&& ! $this->is_rewrite_and_republish_copy( $post )
 			&& ! $this->has_rewrite_and_republish_copy( $post )
@@ -256,7 +245,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the Rewrite & Republish copy can be republished.
 	 */
-	public function is_copy_allowed_to_be_republished( $post ) {
+	public function is_copy_allowed_to_be_republished( \WP_Post $post ) {
 		return \in_array( $post->post_status, [ 'dp-rewrite-republish', 'private' ], true );
 	}
 
@@ -267,7 +256,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the post has a trashed copy intended for Rewrite & Republish.
 	 */
-	public function has_trashed_rewrite_and_republish_copy( $post ) {
+	public function has_trashed_rewrite_and_republish_copy( \WP_Post $post ) {
 		$copy_id = \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true );
 
 		if ( ! $copy_id ) {

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -55,6 +55,9 @@ class Permissions_Helper {
 	 * @return bool Whether the post is a copy intended for Rewrite & Republish.
 	 */
 	public function is_rewrite_and_republish_copy( $post ) {
+		if ( $post instanceof \WP_Post === false ) {
+			return false;
+		}
 		return ( \intval( \get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true ) ) === 1 );
 	}
 
@@ -194,6 +197,10 @@ class Permissions_Helper {
 	 * @return bool Whether the links can be displayed.
 	 */
 	public function should_links_be_displayed( $post ) {
+		if ( $post instanceof \WP_Post === false ) {
+			return false;
+		}
+
 		/**
 		 * Filter allowing displaying duplicate post links for current post.
 		 *
@@ -215,6 +222,10 @@ class Permissions_Helper {
 	 * @return bool Whether the links should be displayed.
 	 */
 	public function should_rewrite_and_republish_be_allowed( $post ) {
+		if ( $post instanceof \WP_Post === false ) {
+			return false;
+		}
+
 		return $post->post_status === 'publish'
 			&& ! $this->is_rewrite_and_republish_copy( $post )
 			&& ! $this->has_rewrite_and_republish_copy( $post )

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -54,7 +54,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the post is a copy intended for Rewrite & Republish.
 	 */
-	public function is_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function is_rewrite_and_republish_copy( $post ) {
 		return ( \intval( \get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true ) ) === 1 );
 	}
 
@@ -65,7 +65,7 @@ class Permissions_Helper {
 	 *
 	 * @return int The Rewrite & Republish copy ID.
 	 */
-	public function get_rewrite_and_republish_copy_id( \WP_Post $post ) {
+	public function get_rewrite_and_republish_copy_id( $post ) {
 		return \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true );
 	}
 
@@ -76,7 +76,7 @@ class Permissions_Helper {
 	 *
 	 * @return \WP_Post|null The copy's post object or null if it doesn't exist.
 	 */
-	public function get_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function get_rewrite_and_republish_copy( $post ) {
 		$copy_id = $this->get_rewrite_and_republish_copy_id( $post );
 
 		if ( empty( $copy_id ) ) {
@@ -93,7 +93,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the post has a copy intended for Rewrite & Republish.
 	 */
-	public function has_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function has_rewrite_and_republish_copy( $post ) {
 		return ( ! empty( $this->get_rewrite_and_republish_copy_id( $post ) ) );
 	}
 
@@ -104,7 +104,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool|\WP_Post The scheduled copy if present, false if the post has no scheduled copy.
 	 */
-	public function has_scheduled_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function has_scheduled_rewrite_and_republish_copy( $post ) {
 		$copy = $this->get_rewrite_and_republish_copy( $post );
 
 		if ( ! empty( $copy ) && $copy->post_status === 'future' ) {
@@ -169,7 +169,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the original post has changed since the creation of the copy.
 	 */
-	public function has_original_changed( \WP_Post $post ) {
+	public function has_original_changed( $post ) {
 		if ( ! $this->is_rewrite_and_republish_copy( $post ) ) {
 			return false;
 		}
@@ -193,7 +193,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the links can be displayed.
 	 */
-	public function should_links_be_displayed( \WP_Post $post ) {
+	public function should_links_be_displayed( $post ) {
 		/**
 		 * Filter allowing displaying duplicate post links for current post.
 		 *
@@ -214,7 +214,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the links should be displayed.
 	 */
-	public function should_rewrite_and_republish_be_allowed( \WP_Post $post ) {
+	public function should_rewrite_and_republish_be_allowed( $post ) {
 		return $post->post_status === 'publish'
 			&& ! $this->is_rewrite_and_republish_copy( $post )
 			&& ! $this->has_rewrite_and_republish_copy( $post )
@@ -245,7 +245,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the Rewrite & Republish copy can be republished.
 	 */
-	public function is_copy_allowed_to_be_republished( \WP_Post $post ) {
+	public function is_copy_allowed_to_be_republished( $post ) {
 		return \in_array( $post->post_status, [ 'dp-rewrite-republish', 'private' ], true );
 	}
 
@@ -256,7 +256,7 @@ class Permissions_Helper {
 	 *
 	 * @return bool Whether the post has a trashed copy intended for Rewrite & Republish.
 	 */
-	public function has_trashed_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function has_trashed_rewrite_and_republish_copy( $post ) {
 		$copy_id = \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true );
 
 		if ( ! $copy_id ) {

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -8,6 +8,8 @@
 
 namespace Yoast\WP\Duplicate_Post;
 
+use WP_Post;
+
 /**
  * Represents the Post Republisher class.
  */
@@ -126,7 +128,8 @@ class Post_Republisher {
 	 */
 	public function republish_request( $post ) {
 		if (
-			! $this->permissions_helper->is_rewrite_and_republish_copy( $post )
+			! $post instanceof WP_Post
+			|| ! $this->permissions_helper->is_rewrite_and_republish_copy( $post )
 			|| ! $this->permissions_helper->is_copy_allowed_to_be_republished( $post )
 		) {
 			return;
@@ -183,8 +186,8 @@ class Post_Republisher {
 	 *
 	 * @return void
 	 */
-	public function republish_scheduled_post( \WP_Post $copy ) {
-		if ( ! $this->permissions_helper->is_rewrite_and_republish_copy( $copy ) ) {
+	public function republish_scheduled_post( $copy ) {
+		if ( ! $copy instanceof WP_Post || ! $this->permissions_helper->is_rewrite_and_republish_copy( $copy ) ) {
 			return;
 		}
 

--- a/src/handlers/class-bulk-handler.php
+++ b/src/handlers/class-bulk-handler.php
@@ -93,12 +93,14 @@ class Bulk_Handler {
 		}
 
 		$counter = 0;
-		foreach ( $post_ids as $post_id ) {
-			$post = \get_post( $post_id );
-			if ( ! empty( $post ) && $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post ) ) {
-				$new_post_id = $this->post_duplicator->create_duplicate_for_rewrite_and_republish( $post );
-				if ( ! \is_wp_error( $new_post_id ) ) {
-					$counter++;
+		if ( \is_array( $post_ids ) ) {
+			foreach ( $post_ids as $post_id ) {
+				$post = \get_post( $post_id );
+				if ( ! empty( $post ) && $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post ) ) {
+					$new_post_id = $this->post_duplicator->create_duplicate_for_rewrite_and_republish( $post );
+					if ( ! \is_wp_error( $new_post_id ) ) {
+						$counter ++;
+					}
 				}
 			}
 		}

--- a/src/handlers/class-bulk-handler.php
+++ b/src/handlers/class-bulk-handler.php
@@ -122,15 +122,17 @@ class Bulk_Handler {
 		}
 
 		$counter = 0;
-		foreach ( $post_ids as $post_id ) {
-			$post = \get_post( $post_id );
-			if ( ! empty( $post ) && ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
-				if ( \intval( \get_option( 'duplicate_post_copychildren' ) !== 1 )
-					|| ! \is_post_type_hierarchical( $post->post_type )
-					|| ( \is_post_type_hierarchical( $post->post_type ) && ! Utils::has_ancestors_marked( $post, $post_ids ) )
-				) {
-					if ( ! \is_wp_error( \duplicate_post_create_duplicate( $post ) ) ) {
-						$counter++;
+		if ( \is_array( $post_ids ) ) {
+			foreach ( $post_ids as $post_id ) {
+				$post = \get_post( $post_id );
+				if ( ! empty( $post ) && ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+					if ( \intval( \get_option( 'duplicate_post_copychildren' ) !== 1 )
+						|| ! \is_post_type_hierarchical( $post->post_type )
+						|| ( \is_post_type_hierarchical( $post->post_type ) && ! Utils::has_ancestors_marked( $post, $post_ids ) )
+					) {
+						if ( ! \is_wp_error( \duplicate_post_create_duplicate( $post ) ) ) {
+							$counter ++;
+						}
 					}
 				}
 			}

--- a/src/handlers/class-bulk-handler.php
+++ b/src/handlers/class-bulk-handler.php
@@ -73,7 +73,7 @@ class Bulk_Handler {
 	 *
 	 * @return string The URL to redirect to.
 	 */
-	public function bulk_action_handler( $redirect_to, $doaction, array $post_ids ) {
+	public function bulk_action_handler( $redirect_to, $doaction, $post_ids ) {
 		$redirect_to = $this->clone_bulk_action_handler( $redirect_to, $doaction, $post_ids );
 		return $this->rewrite_bulk_action_handler( $redirect_to, $doaction, $post_ids );
 	}
@@ -87,7 +87,7 @@ class Bulk_Handler {
 	 *
 	 * @return string The URL to redirect to.
 	 */
-	public function rewrite_bulk_action_handler( $redirect_to, $doaction, array $post_ids ) {
+	public function rewrite_bulk_action_handler( $redirect_to, $doaction, $post_ids ) {
 		if ( $doaction !== 'duplicate_post_bulk_rewrite_republish' ) {
 			return $redirect_to;
 		}

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -311,7 +311,7 @@ class Classic_Editor {
 	 * @return void
 	 */
 	public function remove_slug_meta_box( $post_type, $post ) {
-		if ( \is_a( $post, '\WP_Post' ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+		if ( $post instanceof \WP_Post && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			\remove_meta_box( 'slugdiv', $post_type, 'normal' );
 		}
 	}

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
@@ -157,7 +158,7 @@ class Classic_Editor {
 		}
 
 		if (
-			! \is_null( $post )
+			$post instanceof WP_Post
 			&& $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post )
 			&& $this->permissions_helper->should_links_be_displayed( $post )
 		) {
@@ -185,7 +186,7 @@ class Classic_Editor {
 			}
 		}
 
-		if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+		if ( $post instanceof WP_Post && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			?>
 				<div id="check-changes-action">
 					<?php \esc_html_e( 'Do you want to compare your changes with the original version before merging? Please save any changes first.', 'duplicate-post' ); ?>
@@ -295,7 +296,7 @@ class Classic_Editor {
 			return false;
 		}
 
-		if ( \is_null( $post ) ) {
+		if ( ! $post instanceof WP_Post ) {
 			return false;
 		}
 
@@ -311,7 +312,7 @@ class Classic_Editor {
 	 * @return void
 	 */
 	public function remove_slug_meta_box( $post_type, $post ) {
-		if ( $post instanceof \WP_Post && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+		if ( $post instanceof WP_Post && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			\remove_meta_box( 'slugdiv', $post_type, 'normal' );
 		}
 	}
@@ -328,6 +329,10 @@ class Classic_Editor {
 	 * @return string The filtered HTML of the sample permalink slug editor.
 	 */
 	public function remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			return $return;
+		}
+
 		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			return '';
 		}

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -311,7 +311,7 @@ class Classic_Editor {
 	 * @return void
 	 */
 	public function remove_slug_meta_box( $post_type, $post ) {
-		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+		if ( \is_a( $post, '\WP_Post' ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			\remove_meta_box( 'slugdiv', $post_type, 'normal' );
 		}
 	}

--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -55,7 +55,7 @@ class Post_List {
 	 * @return \WP_Query The updated post WordPress query.
 	 */
 	public function filter_rewrite_and_republish_copies( $query ) {
-		if ( ! $this->should_filter() ) {
+		if ( ! $this->should_filter() || ( $query instanceof \WP_Query === false ) ) {
 			return $query;
 		}
 

--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -54,7 +54,7 @@ class Post_List {
 	 *
 	 * @return \WP_Query The updated post WordPress query.
 	 */
-	public function filter_rewrite_and_republish_copies( \WP_Query $query ) {
+	public function filter_rewrite_and_republish_copies( $query ) {
 		if ( ! $this->should_filter() ) {
 			return $query;
 		}

--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -132,6 +132,10 @@ class Post_List {
 
 		$current_screen = \get_current_screen();
 
+		if ( \is_null( $current_screen ) ) {
+			return false;
+		}
+
 		return ( $current_screen->base === 'edit' && $this->permissions_helper->is_elementor_active() );
 	}
 }

--- a/src/ui/class-post-states.php
+++ b/src/ui/class-post-states.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -74,7 +74,7 @@ class Row_Actions {
 	 *
 	 * @return array The updated array of actions.
 	 */
-	public function add_clone_action_link( array $actions, \WP_Post $post ) {
+	public function add_clone_action_link( $actions, $post ) {
 		if ( ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
 			return $actions;
 		}
@@ -99,7 +99,7 @@ class Row_Actions {
 	 *
 	 * @return array The updated array of actions.
 	 */
-	public function add_new_draft_action_link( array $actions, \WP_Post $post ) {
+	public function add_new_draft_action_link( $actions, $post ) {
 		if ( ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
 			return $actions;
 		}
@@ -125,7 +125,7 @@ class Row_Actions {
 	 *
 	 * @return array The updated array of actions.
 	 */
-	public function add_rewrite_and_republish_action_link( array $actions, \WP_Post $post ) {
+	public function add_rewrite_and_republish_action_link( $actions, $post ) {
 		if (
 			! $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post )
 			|| ! $this->permissions_helper->should_links_be_displayed( $post )

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
@@ -75,7 +76,7 @@ class Row_Actions {
 	 * @return array The updated array of actions.
 	 */
 	public function add_clone_action_link( $actions, $post ) {
-		if ( ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
+		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
 			return $actions;
 		}
 
@@ -100,7 +101,7 @@ class Row_Actions {
 	 * @return array The updated array of actions.
 	 */
 	public function add_new_draft_action_link( $actions, $post ) {
-		if ( ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
+		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
 			return $actions;
 		}
 
@@ -127,7 +128,8 @@ class Row_Actions {
 	 */
 	public function add_rewrite_and_republish_action_link( $actions, $post ) {
 		if (
-			! $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post )
+			! $post instanceof WP_Post
+			|| ! $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post )
 			|| ! $this->permissions_helper->should_links_be_displayed( $post )
 		) {
 			return $actions;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We should avoid typehinting in functions which are hooked (directly or indirectly) to WP filters, because they can lead to fatal errors

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug that caused a fatal error when used with some plugins

## Relevant technical choices:

* Fixed also a bug that prevented the upgrade notice to be displayed to users upgrading from versions 3.2.5 and 3.2.6
* Added a check to avoid a notice when current_screen is not set yet
* Cherry-picked from `develop` a fix in the creation of artifact (missing logo in upgrade notice)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test the fix
* install and activate the `Members` plugin
* visit "Members"->"Roles" and edit a role
* see that you don't get a fatal error

#### Test against regression
* install and activate the `Classic editor` plugin
* edit a Rewrite & Republish copy and see the UI for editing the slug is correctly missing

#### Test the upgrade notice fix
* inspect the DB and change in `wp_options` the value for `duplicate_post_version` to `3.2.6` (for QA: upgrade from version 3.2.6)
* visit the WP Dashboard or the Plugins page and see that you can see the upgrade notice

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
