### PR TITLE
Enforce missing checks

### DIFF
--- a/src/ui/class-admin-bar.php
+++ b/src/ui/class-admin-bar.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
@@ -159,7 +160,7 @@ class Admin_Bar {
 	 *
 	 * @global \WP_Query $wp_the_query
 	 *
-	 * @return false|\WP_Post The Post object, false if we are not on a post.
+	 * @return false|WP_Post The Post object, false if we are not on a post.
 	 */
 	public function get_current_post() {
 		global $wp_the_query;
@@ -170,7 +171,7 @@ class Admin_Bar {
 			$post = $wp_the_query->get_queried_object();
 		}
 
-		if ( empty( $post ) || ! \is_a( $post, '\WP_Post' ) ) {
+		if ( empty( $post ) || ! $post instanceof WP_Post ) {
 			return false;
 		}
 

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
@@ -70,7 +71,7 @@ class Block_Editor {
 			$post = \get_post();
 
 			if (
-				! \is_null( $post )
+				$post instanceof WP_Post
 				&& (
 					$this->permissions_helper->is_rewrite_and_republish_copy( $post )
 					|| $this->permissions_helper->has_rewrite_and_republish_copy( $post )
@@ -89,7 +90,7 @@ class Block_Editor {
 	public function enqueue_block_editor_scripts() {
 		$post = \get_post();
 
-		if ( ! $post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return;
 		}
 
@@ -121,7 +122,7 @@ class Block_Editor {
 	public function get_new_draft_permalink() {
 		$post = \get_post();
 
-		if ( ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
+		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
 			return '';
 		}
 
@@ -137,7 +138,8 @@ class Block_Editor {
 		$post = \get_post();
 
 		if (
-			$this->permissions_helper->is_rewrite_and_republish_copy( $post )
+			! $post instanceof WP_Post
+			|| $this->permissions_helper->is_rewrite_and_republish_copy( $post )
 			|| $this->permissions_helper->has_rewrite_and_republish_copy( $post )
 			|| ! $this->permissions_helper->should_links_be_displayed( $post )
 			|| $this->permissions_helper->is_elementor_active()
@@ -156,7 +158,7 @@ class Block_Editor {
 	public function get_check_permalink() {
 		$post = \get_post();
 
-		if ( ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			return '';
 		}
 
@@ -171,7 +173,7 @@ class Block_Editor {
 	public function get_original_post_edit_url() {
 		$post = \get_post();
 
-		if ( \is_null( $post ) ) {
+		if ( ! $post instanceof WP_Post ) {
 			return '';
 		}
 

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -128,10 +128,7 @@ class Classic_Editor {
 			}
 		}
 
-		if (
-			! \is_null( $post )
-			&& $this->permissions_helper->should_links_be_displayed( $post )
-		) {
+		if ( $post instanceof WP_Post && $this->permissions_helper->should_links_be_displayed( $post ) ) {
 			?>
 			<div id="duplicate-action">
 				<a class="submitduplicate duplication"

--- a/src/ui/class-column.php
+++ b/src/ui/class-column.php
@@ -68,7 +68,9 @@ class Column {
 	 * @return array The updated array.
 	 */
 	public function add_original_column( $post_columns ) {
-		$post_columns['duplicate_post_original_item'] = \__( 'Original item', 'duplicate-post' );
+		if ( \is_array( $post_columns ) ) {
+			$post_columns['duplicate_post_original_item'] = \__( 'Original item', 'duplicate-post' );
+		}
 		return $post_columns;
 	}
 

--- a/src/ui/class-link-builder.php
+++ b/src/ui/class-link-builder.php
@@ -73,7 +73,7 @@ class Link_Builder {
 	 */
 	public function build_link( $post, $context, $action_name ) {
 		$post = \get_post( $post );
-		if ( ! $post ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return '';
 		}
 

--- a/src/ui/class-metabox.php
+++ b/src/ui/class-metabox.php
@@ -72,7 +72,7 @@ class Metabox {
 	 */
 	public function custom_metabox_html( $post ) {
 		$original_item = Utils::get_original( $post );
-		if ( $original_item ) {
+		if ( $post instanceof \WP_Post && $original_item instanceof \WP_Post ) {
 			if ( ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 				?>
 			<p>

--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -102,11 +102,17 @@ class Post_List {
 	protected function get_copy_ids( $post_type ) {
 		global $wpdb;
 
+		if ( empty( $post_type ) ) {
+			return [];
+		}
+
 		if ( \array_key_exists( $post_type, $this->copy_ids ) ) {
 			return $this->copy_ids[ $post_type ];
 		}
 
-		$this->copy_ids[ $post_type ] = $wpdb->get_results(
+		$this->copy_ids[ $post_type ] = [];
+
+		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				'SELECT post_id, post_status FROM ' . $wpdb->postmeta . ' AS pm ' .
 				'JOIN ' . $wpdb->posts . ' AS p ON pm.post_id = p.ID ' .
@@ -116,6 +122,10 @@ class Post_List {
 			),
 			OBJECT_K
 		);
+
+		if ( is_array( $results ) ) {
+			$this->copy_ids[ $post_type ] = $results;
+		}
 
 		return $this->copy_ids[ $post_type ];
 	}

--- a/src/ui/class-post-list.php
+++ b/src/ui/class-post-list.php
@@ -123,7 +123,7 @@ class Post_List {
 			OBJECT_K
 		);
 
-		if ( is_array( $results ) ) {
+		if ( \is_array( $results ) ) {
 			$this->copy_ids[ $post_type ] = $results;
 		}
 

--- a/src/ui/class-post-states.php
+++ b/src/ui/class-post-states.php
@@ -50,6 +50,11 @@ class Post_States {
 	 * @return array The updated post states array.
 	 */
 	public function show_original_in_post_states( $post_states, $post ) {
+		if ( ! $post instanceof WP_Post
+			|| ! \is_array( $post_states ) ) {
+			return $post_states;
+		}
+
 		$original_item = Utils::get_original( $post );
 
 		if ( ! $original_item ) {

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -76,7 +76,9 @@ class Row_Actions {
 	 * @return array The updated array of actions.
 	 */
 	public function add_clone_action_link( $actions, $post ) {
-		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
+		if ( ! $post instanceof WP_Post
+			|| ! $this->permissions_helper->should_links_be_displayed( $post )
+			|| ! \is_array( $actions ) ) {
 			return $actions;
 		}
 
@@ -101,7 +103,9 @@ class Row_Actions {
 	 * @return array The updated array of actions.
 	 */
 	public function add_new_draft_action_link( $actions, $post ) {
-		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->should_links_be_displayed( $post ) ) {
+		if ( ! $post instanceof WP_Post
+			|| ! $this->permissions_helper->should_links_be_displayed( $post )
+			|| ! \is_array( $actions ) ) {
 			return $actions;
 		}
 
@@ -131,6 +135,7 @@ class Row_Actions {
 			! $post instanceof WP_Post
 			|| ! $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post )
 			|| ! $this->permissions_helper->should_links_be_displayed( $post )
+			|| ! \is_array( $actions )
 		) {
 			return $actions;
 		}

--- a/src/watchers/class-bulk-actions-watcher.php
+++ b/src/watchers/class-bulk-actions-watcher.php
@@ -38,8 +38,10 @@ class Bulk_Actions_Watcher {
 	 * @return array The updated array of query args keys.
 	 */
 	public function add_removable_query_args( $removable_query_args ) {
-		$removable_query_args[] = 'bulk_cloned';
-		$removable_query_args[] = 'bulk_rewriting';
+		if ( \is_array( $removable_query_args ) ) {
+			$removable_query_args[] = 'bulk_cloned';
+			$removable_query_args[] = 'bulk_rewriting';
+		}
 		return $removable_query_args;
 	}
 

--- a/src/watchers/class-copied-post-watcher.php
+++ b/src/watchers/class-copied-post-watcher.php
@@ -88,7 +88,7 @@ class Copied_Post_Watcher {
 
 		$post = \get_post();
 
-		if ( \is_null( $post ) ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return;
 		}
 
@@ -107,7 +107,7 @@ class Copied_Post_Watcher {
 	public function add_block_editor_notice() {
 		$post = \get_post();
 
-		if ( \is_null( $post ) ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return;
 		}
 

--- a/src/watchers/class-link-actions-watcher.php
+++ b/src/watchers/class-link-actions-watcher.php
@@ -52,8 +52,10 @@ class Link_Actions_Watcher {
 	 * @return array The updated array of query args keys.
 	 */
 	public function add_removable_query_args( $removable_query_args ) {
-		$removable_query_args[] = 'cloned';
-		$removable_query_args[] = 'rewriting';
+		if ( \is_array( $removable_query_args ) ) {
+			$removable_query_args[] = 'cloned';
+			$removable_query_args[] = 'rewriting';
+		}
 		return $removable_query_args;
 	}
 

--- a/src/watchers/class-original-post-watcher.php
+++ b/src/watchers/class-original-post-watcher.php
@@ -69,7 +69,7 @@ class Original_Post_Watcher {
 
 		$post = \get_post();
 
-		if ( \is_null( $post ) ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return;
 		}
 
@@ -88,7 +88,7 @@ class Original_Post_Watcher {
 	public function add_block_editor_notice() {
 		$post = \get_post();
 
-		if ( \is_null( $post ) ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return;
 		}
 

--- a/src/watchers/class-republished-post-watcher.php
+++ b/src/watchers/class-republished-post-watcher.php
@@ -52,10 +52,11 @@ class Republished_Post_Watcher {
 	 * @return array The updated array of query args keys.
 	 */
 	public function add_removable_query_args( $removable_query_args ) {
-		$removable_query_args[] = 'dprepublished';
-		$removable_query_args[] = 'dpcopy';
-		$removable_query_args[] = 'dpnonce';
-
+		if ( \is_array( $removable_query_args ) ) {
+			$removable_query_args[] = 'dprepublished';
+			$removable_query_args[] = 'dpcopy';
+			$removable_query_args[] = 'dpnonce';
+		}
 		return $removable_query_args;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We should enforce stricter checks and add missing ones to avoid fatal errors and warnings when parameters from hooks don't match the expected types.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where errors or notices could be triggered when using the plugin with some other plugins or custom code.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the bug:
* checkout and build branch `master`
* edit class-post-list.php at line 82 to add a line like:
```
$post_type = [];
```
or
```
$post_type = new stdClass();
```
or

```
$post_type = false;
```
or whatever is not a string or an integer
* visit the post list (with WP_DEBUG defined) to see warning and notices about that

#### test the fix
* checkout and build PR branch
* edit class-post-list.php at line 104 to add a line like:
```
$post_type = [];
```
or
```
$post_type = new stdClass();
```
or

```
$post_type = false;
```
or whatever is not a string or an integer
* visit the post list (with WP_DEBUG defined) to see there are no warnings or notices anymore

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-319]
