### PR TITLE
Prevent accidental deletion of copy when it's not been republished yet

### DIFF
--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -243,11 +243,7 @@ class Post_Duplicator {
 		if ( ! \is_array( $meta_excludelist ) ) {
 			$meta_excludelist = [];
 		}
-		$meta_excludelist[] = '_edit_lock'; // Edit lock.
-		$meta_excludelist[] = '_edit_last'; // Edit lock.
-		$meta_excludelist[] = '_dp_original';
-		$meta_excludelist[] = '_dp_is_rewrite_republish_copy';
-		$meta_excludelist[] = '_dp_has_rewrite_republish_copy';
+		$meta_excludelist = \array_merge( $meta_excludelist, Utils::get_default_filtered_meta_names() );
 		if ( ! $options['copy_template'] ) {
 			$meta_excludelist[] = '_wp_page_template';
 		}

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -216,7 +216,11 @@ class Post_Republisher {
 
 			\check_admin_referer( 'dp-republish', 'dpnonce' );
 
-			$this->delete_copy( $copy_id, $post_id );
+			if ( \intval( \get_post_meta( $copy_id, '_dp_has_been_republished', true ) ) === 1 ) {
+				$this->delete_copy( $copy_id, $post_id );
+			} else {
+				\wp_die( \esc_html__( 'An error occurred while deleting the Rewrite & Republish copy.', 'duplicate-post' ) );
+			}
 		}
 	}
 
@@ -260,6 +264,9 @@ class Post_Republisher {
 
 		// Republish the post.
 		$this->republish_post_elements( $post, $original_post );
+
+		// Mark the copy as already published.
+		\update_post_meta( $post->ID, '_dp_has_been_republished', '1' );
 
 		// Re-enable the creation of a new revision.
 		\add_action( 'post_updated', 'wp_save_post_revision', 10, 1 );

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -360,12 +360,7 @@ class Post_Republisher {
 		$original_post_id = Utils::get_original_post_id( $post->ID );
 
 		$copy_meta_options = [
-			'meta_excludelist' => [
-				'_edit_lock',
-				'_edit_last',
-				'_dp_original',
-				'_dp_is_rewrite_republish_copy',
-			],
+			'meta_excludelist' => Utils::get_default_filtered_meta_names(),
 			'use_filters'      => false,
 			'copy_thumbnail'   => true,
 			'copy_template'    => true,

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -173,6 +173,23 @@ class Utils {
 	}
 
 	/**
+	 * Gets the default meta field names to be filtered out.
+	 *
+	 * @return array The names of the meta fields to filter out by default.
+	 */
+	public static function get_default_filtered_meta_names() {
+		return [
+			'_edit_lock',
+			'_edit_last',
+			'_dp_original',
+			'_dp_is_rewrite_republish_copy',
+			'_dp_has_rewrite_republish_copy',
+			'_dp_has_been_republished',
+			'_dp_creation_date_gmt',
+		];
+	}
+
+	/**
 	 * Gets a Duplicate Post option from the database.
 	 *
 	 * @param string $option The option to get.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Visiting `duplicatePost.originalEditURL` triggers the deletion of the R&R copy even if it's not been rewritten yet. We should avoid that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents accidentale deletion of a R&R copy via redirect if it's not been republished yet

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Block editor:
* create a R&R copy and edit it on block editor
* using the console, copy the value for `duplicatePost.originalEditURL` and paste it as address for a new browser tab, then visit it
* see that you get a `wp_die` "An error occurred while deleting the Rewrite & Republish copy."
* visit the post list, or reload the tab where you were editing the copy, to see the copy is still there
* republish the copy via Republish button to see everything's fine (the original is overwritten and the copy deleted)

### Classic editor
Basically the Classic editor after rewriting the original triggers a `wp_safe_redirect` to the above URL so nothing is really changing, but you can test this way:
* comment out `$this->republish( $post, $original_post );` in class-post-republisher.php line 144
* activate Classic editor plugin
* create and edit a R&R copy
* republish it via button: since the original won't be rewritten because of the code commetend out, you will be redirected but the check will fail, so you'll get a `wp_die` "An error occurred while deleting the Rewrite & Republish copy."
* visit the post list to see the copy is still there
* remove the comment and republish the copy via Republish button to see everything's fine (the original is overwritten and the copy deleted)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A, this is to prevent some unwanted consequences that can arise with custom code or other plugins. Just testing for regression (you should be able to republish a copy both in Block editor and in Classic editor) is fine.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-322]
