### PR TITLE
P3-336 Prevent copying of R&R related meta fields when creating regular copies

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -354,6 +354,8 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	}
 	$meta_blacklist[] = '_edit_lock'; // Edit lock.
 	$meta_blacklist[] = '_edit_last'; // Edit lock.
+	$meta_blacklist[] = '_dp_is_rewrite_republish_copy';
+	$meta_blacklist[] = '_dp_has_rewrite_republish_copy';
 	if ( intval( get_option( 'duplicate_post_copytemplate' ) ) === 0 ) {
 		$meta_blacklist[] = '_wp_page_template';
 	}

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -248,6 +248,8 @@ class Post_Duplicator {
 		$meta_excludelist[] = '_dp_original';
 		$meta_excludelist[] = '_dp_is_rewrite_republish_copy';
 		$meta_excludelist[] = '_dp_has_rewrite_republish_copy';
+		$meta_excludelist[] = '_dp_has_been_republished';
+		$meta_excludelist[] = '_dp_creation_date_gmt';
 		if ( ! $options['copy_template'] ) {
 			$meta_excludelist[] = '_wp_page_template';
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* R&R-related meta fields are copied when creating a regular copy. We should avoid that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where Rewrite & Republish notices would be shown for regular copies.

## Relevant technical choices:

* We filter out not just the `_dp_has_rewrite_republish_copy` which is the one triggering the notice, but also every other Duplicate  Post-related fields (see last commit from #96)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the bug on `develop`

* create a R&R copy of a published post. 
* go back to the post list, and create a regular copy from the same original
* edit this second copy
* see that you see a `A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished.` notice which shouldn't be there.

#### Test the fix

* create a R&R copy of a published post. 
* go back to the post list, and create a regular copy from the same original
* edit this second copy
* see that you don't see any `A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished.` notice. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-336]
