### PR TITLE
P3-337 Hide the post status changer in Elementor instead of removing it

### DIFF
--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
-use Elementor\Core\Base\Document;
 use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
@@ -57,7 +56,7 @@ class Block_Editor {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'elementor/documents/register_controls', [ $this, 'remove_elementor_post_status' ] );
+		\add_action( 'elementor/editor/after_enqueue_styles', [ $this, 'hide_elementor_post_status' ] );
 		\add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_elementor_script' ], 9 );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'should_previously_used_keyword_assessment_run' ], 9 );
 		\add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_scripts' ] );
@@ -81,20 +80,20 @@ class Block_Editor {
 	}
 
 	/**
-	 * Removes the post status control if we're working on a Rewrite and Republish post.
-	 *
-	 * @param Document $document The document to remove the control from.
+	 * Hides the post status control if we're working on a Rewrite and Republish post.
 	 *
 	 * @return void
 	 */
-	public function remove_elementor_post_status( $document ) {
+	public function hide_elementor_post_status() {
 		$post = \get_post();
 
 		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			return;
 		}
-
-		$document->remove_control( 'post_status' );
+		\wp_add_inline_style(
+			'elementor-editor',
+			'.elementor-control-post_status { display: none !important; }'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* #100 prevented status changes in Elementor for R&R copies by removing the control. This triggers some problems because Yoast SEO can't detect the post_status and so editing the Yoast SEO data triggers an unexpected warning (intended for published posts, while R&R are drafts). We should hide the control using CSS instead of removing it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the post status changer in Elementor for Rewrite & Republish copies instead of removing it

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate Yoast SEO and Elementor
* build Duplicate Post from the PR branch and activate
* create a R&R copy from a published post and edit it with Elementor
* open the Elementor settings (with the cog icon in the bottom left corner of the screen) and see that there is no section "Status" with a `<select>` to change the post status
* switch to the Yoast SEO panel and change the focus keyphrase
  * check that no warning is displayed
* open the JS console and type `window.elementor.settings.page.model.get( "post_status" )`, see that you get "draft" as a return value.
* navigate back to the WP backend, choose a published post and edit it with Elementor
* open the Elementor settings (with the cog icon in the bottom left corner of the screen) and see that there is a section "Status" with a `<select>` to change the post status 
* switch to the Yoast SEO panel and change the focus keyphrase
  * see that you get a warning like the one in the image
![Screenshot_2021-01-22 Elementor Videos](https://user-images.githubusercontent.com/15989132/105498270-42418b00-5cc0-11eb-8305-e4e9bd3f26df.png)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* install and activate Yoast SEO, Elementor, Duplicate Post 
* create a R&R copy from a published post and edit it with Elementor
* open the Elementor settings (with the cog icon in the bottom left corner of the screen) and see that there is no section "Status" with a `<select>` to change the post status
* switch to the Yoast SEO panel and change the focus keyphrase
  * check that no warning is displayed
* navigate back to the WP backend, choose a published post and edit it with Elementor
* open the Elementor settings (with the cog icon in the bottom left corner of the screen) and see that there is a section "Status" with a `<select>` to change the post status 
* switch to the Yoast SEO panel and change the focus keyphrase
  * see that you get a warning like the one in the image
![Screenshot_2021-01-22 Elementor Videos](https://user-images.githubusercontent.com/15989132/105498270-42418b00-5cc0-11eb-8305-e4e9bd3f26df.png)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-337]
