### PR TITLE
P3-342 Show ACF fields in comparison

### DIFF
--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -108,12 +108,15 @@ class Check_Changes_Handler {
 						<div class="diff">
 						<?php
 						$fields = [
-							\__( 'Title', 'default' )   => 'post_title',
-							\__( 'Content', 'default' ) => 'post_content',
-							\__( 'Excerpt', 'default' ) => 'post_excerpt',
+							'post_title'   => \__( 'Title', 'default' ),
+							'post_content' => \__( 'Content', 'default' ),
+							'post_excerpt' => \__( 'Excerpt', 'default' ),
 						];
 
-						foreach ( $fields as $name => $field ) {
+						$post_array = \get_post( $post, \ARRAY_A );
+						$fields     = \apply_filters( '_wp_post_revision_fields', $fields, $post_array ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+						foreach ( $fields as $field => $name ) {
 							$diff = \wp_text_diff( $original->$field, $post->$field );
 
 							if ( ! $diff && 'post_title' === $field ) {
@@ -150,6 +153,7 @@ class Check_Changes_Handler {
 	 * @return void
 	 */
 	public function require_wordpress_header() {
+		\set_current_screen( 'revision' );
 		require_once ABSPATH . 'wp-admin/admin-header.php';
 	}
 

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -114,14 +114,18 @@ class Check_Changes_Handler {
 						];
 
 						$post_array = \get_post( $post, \ARRAY_A );
-						$fields     = \apply_filters( '_wp_post_revision_fields', $fields, $post_array ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+						/** This filter is documented in wp-admin/includes/revision.php */
+						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
+						$fields = \apply_filters( '_wp_post_revision_fields', $fields, $post_array );
 
 						foreach ( $fields as $field => $name ) {
 							/** This filter is documented in wp-admin/includes/revision.php */
-							$content_from = $original ? \apply_filters( "_wp_post_revision_field_{$field}", $original->$field, $field, $original, 'from' ) : '';  // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
+							$content_from = apply_filters( "_wp_post_revision_field_{$field}", $original->$field, $field, $original, 'from' );
 
 							/** This filter is documented in wp-admin/includes/revision.php */
-							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $post->$field, $field, $post, 'to' );  // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
+							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $post->$field, $field, $post, 'to' );
 
 							$diff = \wp_text_diff( $content_from, $content_to );
 

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -117,7 +117,13 @@ class Check_Changes_Handler {
 						$fields     = \apply_filters( '_wp_post_revision_fields', $fields, $post_array ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 						foreach ( $fields as $field => $name ) {
-							$diff = \wp_text_diff( $original->$field, $post->$field );
+							/** This filter is documented in wp-admin/includes/revision.php */
+							$content_from = $original ? \apply_filters( "_wp_post_revision_field_{$field}", $original->$field, $field, $original, 'from' ) : '';  // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+							/** This filter is documented in wp-admin/includes/revision.php */
+							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $post->$field, $field, $post, 'to' );  // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+							$diff = \wp_text_diff( $content_from, $content_to );
 
 							if ( ! $diff && 'post_title' === $field ) {
 								// It's a better user experience to still show the Title, even if it didn't change.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,10 @@
 \define( 'MONTH_IN_SECONDS', 2592000 );
 \define( 'YEAR_IN_SECONDS', 31536000 );
 
+\define( 'OBJECT', 'OBJECT' );
+\define( 'ARRAY_A', 'ARRAY_A' );
+\define( 'ARRAY_N', 'ARRAY_N' );
+
 \define( 'DUPLICATE_POST_FILE', '/var/www/html/wp-content/plugins/duplicate-post/duplicate-post.php' );
 \define( 'DUPLICATE_POST_CURRENT_VERSION', '4.0' );
 // phpcs:enable

--- a/tests/handlers/class-check-changes-handler-test.php
+++ b/tests/handlers/class-check-changes-handler-test.php
@@ -107,6 +107,9 @@ class Check_Changes_Handler_Test extends TestCase {
 
 		$this->instance->expects( 'require_wordpress_header' );
 
+		Monkey\Functions\expect( '\get_post' )
+			->with( $post, \ARRAY_A );
+
 		Monkey\Functions\expect( '\wp_text_diff' )
 			->with( $original->post_title, $post->post_title )
 			->andReturn( null, 'diff-content', 'diff-excerpt' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* ACF fields are displayed in the standard WP revisions comparison screen. Since we are mimicking that to compare the R&R copy to its original, we should make sure it happens there as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows plugins such as ACF to add fields to the "Compare changes" screen for Rewrite & Republish

## Relevant technical choices:

* The comparison screen ID is set to `revision` to make sure that some checks from ACF pass
* Added the `OBJECT`, `ARRAY_A` and `ARRAY_N` defines to the tests bootstrap

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate ACF. If possible, use ACF PRO (ping me if you need it)
* Define some custom fields, or import this set of fields
[acf-export-for-PRO.json.zip](https://github.com/Yoast/duplicate-post/files/5972845/acf-export-for-PRO.json.zip)
* Create a post, set values for the ACF fields and publish
* _plus:_ change some of the ACF fields and save again; then visit the revisions screen and see how the fields you changed are displayed
* create a R&R copy from that post, change the values of most of the ACF fields (leave at least one untouched to see how it behaves)
* Visit the comparison screen (in Block Editor, hit "Republish" and then "Save changes and compare"; in Classic editor, save the changes and visit the link in the Publish metabox)
* see that you can see the changes between the original and the copy, and they include the ACF fields that you changed while the ones that you left untouched are not displayed.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #105 
Fixes [P3-342]
