### PR TITLE
P3 344 prevent wp die error editing copies

### DIFF
--- a/js/src/duplicate-post-elementor.js
+++ b/js/src/duplicate-post-elementor.js
@@ -51,7 +51,7 @@ function duplicatePostOnElementorInitialize() {
 		 * @returns {void}
 		 */
 		apply( args ) {
-			if ( args.status === "publish" && duplicatePost.originalEditURL ) {
+			if ( args.status === "publish" && duplicatePost.originalEditURL && duplicatePost.rewriting === "1" ) {
 				window.location.assign( duplicatePost.originalEditURL );
 			}
 		}

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -199,7 +199,7 @@ class Block_Editor {
 	public function get_original_post_edit_url() {
 		$post = \get_post();
 
-		if ( ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			return '';
 		}
 

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -706,6 +706,11 @@ class Block_Editor_Test extends TestCase {
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
 
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnTrue();
+
 		$utils
 			->expects( 'get_original_post_id' )
 			->with( $post->ID )
@@ -740,6 +745,34 @@ class Block_Editor_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the unsuccessful get_original_post_edit_url when the post is not a Rewrite & Republish copy.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_original_post_edit_url
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_original_post_edit_url_not_rewrite_and_republish() {
+		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$post        = Mockery::mock( \WP_Post::class );
+		$post->ID    = 128;
+		$original_id = 64;
+		$nonce       = '12345678';
+
+		Monkey\Functions\expect( '\get_post' )
+			->andReturn( $post );
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->assertSame(
+			'',
+			$this->instance->get_original_post_edit_url()
+		);
+	}
+
+	/**
 	 * Tests the get_original_post_edit_url when there is no post.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_original_post_edit_url
@@ -769,6 +802,11 @@ class Block_Editor_Test extends TestCase {
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnTrue();
 
 		$utils
 			->expects( 'get_original_post_id' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Saving changes of regular copies in Elementor triggers the redirect that should be reserved to R&R copies, so Duplicate Post tries to delete the post but it's prevente to do so and displays a `wp_die` message

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where editing posts with Elementor could trigger a fatal error.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the bug

* Install and activate Elementor
* Install and activate Duplicate Post 4.1
* Create a regular copy of a post/page, and edit it with Elementor
* make some changes, then hit "Publish" or "Update" (depending if it's already published)
* see that you are redirected and you see "An error occurred while deleting the Rewrite & Republish copy."

#### Test the fix
* Switch to this branch and build
* Create a regular copy of a post/page, and edit it with Elementor
* make some changes, then hit "Publish" or "Update" (depending if it's already published)
* see that you are not redirected, you don't see any error in the console and the changes have been saved
* Test against regression: create a R&R copy, do some changes with Elementor, and "Publish" it.
  * you should be redirected to the rewritten original, while the copy has been deleted
* Test against regression: edit a post which is not a copy, do some changes with Elementor, and "Publish"/"Update" it.
  * you should NOT be redirected, and the changes should be saved. 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-344]
