### PR TITLE
P3-350 Fix options reset bug on upgrade

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -165,8 +165,10 @@ function duplicate_post_plugin_upgrade() {
 		update_site_option( 'duplicate_post_show_notice', 1 );
 	}
 
-	// Migrate the 'Show links in' options to the new array-based structure.
-	duplicate_post_migrate_show_links_in_options( $show_links_in_defaults );
+	if ( version_compare( $installed_version, '4.0.0' ) < 0 ) {
+		// Migrate the 'Show links in' options to the new array-based structure.
+		duplicate_post_migrate_show_links_in_options( $show_links_in_defaults );
+	}
 
 	delete_site_option( 'duplicate_post_version' );
 	update_option( 'duplicate_post_version', duplicate_post_get_current_version() );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In 4.0 we introduced a new format for the "Display links in" option.
Unfortunately the upgrade routine runs at every upgrade, so if you upgrade from a 4.0.* version the old options have been deleted and the default value (links visible everywhere) is then used.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "Show links in" settings were reset to the default value on version upgrade.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Duplicate Post 4.0.2 (or 4.1.1 if you are testing this in 4.2-RC1)
* visit the Settings, third tab "Display", and make sure you disable the displaying of the plugin in some locations: e.g. Admin bar, then Save
* upgrade to this branch
* visit the Settings, third tab "Display", and check that the settings have not changed.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-350]
