### PR TITLE
P3-359 Add missing filter for post types in legacy code

### DIFF
--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -21,6 +21,8 @@ function duplicate_post_is_post_type_enabled( $post_type ) {
 	if ( ! is_array( $duplicate_post_types_enabled ) ) {
 		$duplicate_post_types_enabled = array( $duplicate_post_types_enabled );
 	}
+	/** This filter is documented in src/class-permissions-helper.php */
+	$duplicate_post_types_enabled = apply_filters( 'duplicate_post_enabled_post_types', $duplicate_post_types_enabled );
 	return in_array( $post_type, $duplicate_post_types_enabled, true );
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The filter introduced in #92 should be used in legacy code as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a post type enabled by filter couldn't be copied.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate WooCommerce
* edit your theme's functions.php and add these lines at the end of the file, then save:
```
 function test_add_product( $post_list ) {
	$post_list[] = 'product';
    return $post_list;
}
add_filter('duplicate_post_enabled_post_types', 'test_add_product');
```
* visit the product list, make sure there is some Product items (if not, create one)
* use the "Clone" or "New Draft" link, or the "Clone" bulk action, to create a copy of a product
  * See that you don't get a `wp_die` with the error "Copy features for this post type are not enabled in options page: product".


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-359]
