### PR TITLE
P3-434 Fix R&R comparison screen in WP 5.7

### DIFF
--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -47,6 +47,8 @@ class Check_Changes_Handler {
 	 * @return void
 	 */
 	public function check_changes_action_handler() {
+		global $wp_version;
+
 		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
 			( isset( $_REQUEST['action'] ) && 'duplicate_post_check_changes' === $_REQUEST['action'] ) ) ) { // Input var okay.
 			\wp_die(
@@ -113,6 +115,17 @@ class Check_Changes_Handler {
 							'post_excerpt' => \__( 'Excerpt', 'default' ),
 						];
 
+						$args = array(
+							'show_split_view' => true,
+							'title_left'      => __( 'Removed', 'default' ),
+							'title_right'     => __( 'Added', 'default' ),
+						);
+
+						if ( \version_compare( $wp_version, '5.7' ) < 0 ) {
+							unset( $args['title_left'] );
+							unset( $args['title_right'] );
+						}
+
 						$post_array = \get_post( $post, \ARRAY_A );
 						/** This filter is documented in wp-admin/includes/revision.php */
 						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
@@ -127,7 +140,7 @@ class Check_Changes_Handler {
 							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
 							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $post->$field, $field, $post, 'to' );
 
-							$diff = \wp_text_diff( $content_from, $content_to );
+							$diff = \wp_text_diff( $content_from, $content_to, $args );
 
 							if ( ! $diff && 'post_title' === $field ) {
 								// It's a better user experience to still show the Title, even if it didn't change.

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -24,6 +24,20 @@ class Check_Changes_Handler {
 	protected $permissions_helper;
 
 	/**
+	 * Holds the current post object.
+	 *
+	 * @var \WP_Post
+	 */
+	private $post;
+
+	/**
+	 * Holds the original post object.
+	 *
+	 * @var \WP_Post
+	 */
+	private $original;
+
+	/**
 	 * Initializes the class.
 	 *
 	 * @param Permissions_Helper $permissions_helper The Permissions Helper object.
@@ -61,9 +75,9 @@ class Check_Changes_Handler {
 
 		\check_admin_referer( 'duplicate_post_check_changes_' . $id ); // Input var okay.
 
-		$post = \get_post( $id );
+		$this->post = \get_post( $id );
 
-		if ( ! $post ) {
+		if ( ! $this->post ) {
 			\wp_die(
 				\esc_html(
 					\sprintf(
@@ -76,9 +90,9 @@ class Check_Changes_Handler {
 			return;
 		}
 
-		$original = Utils::get_original( $post );
+		$this->original = Utils::get_original( $this->post );
 
-		if ( ! $original ) {
+		if ( ! $this->original ) {
 			\wp_die(
 				\esc_html(
 					\__( 'Changes overview failed, could not find original post.', 'duplicate-post' )
@@ -86,7 +100,7 @@ class Check_Changes_Handler {
 			);
 			return;
 		}
-		$post_edit_link = \get_edit_post_link( $post->ID );
+		$post_edit_link = \get_edit_post_link( $this->post->ID );
 
 		$this->require_wordpress_header();
 		?>
@@ -96,7 +110,7 @@ class Check_Changes_Handler {
 				echo \sprintf(
 						/* translators: %s: original item link (to view or edit) or title. */
 					\esc_html__( 'Compare changes of duplicated post with the original (&#8220;%s&#8221;)', 'duplicate-post' ),
-					Utils::get_edit_or_view_link( $original ) // phpcs:ignore WordPress.Security.EscapeOutput
+					Utils::get_edit_or_view_link( $this->original ) // phpcs:ignore WordPress.Security.EscapeOutput
 				);
 			?>
 				</h1>
@@ -126,7 +140,7 @@ class Check_Changes_Handler {
 							unset( $args['title_right'] );
 						}
 
-						$post_array = \get_post( $post, \ARRAY_A );
+						$post_array = \get_post( $this->post, \ARRAY_A );
 						/** This filter is documented in wp-admin/includes/revision.php */
 						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
 						$fields = \apply_filters( '_wp_post_revision_fields', $fields, $post_array );
@@ -134,18 +148,18 @@ class Check_Changes_Handler {
 						foreach ( $fields as $field => $name ) {
 							/** This filter is documented in wp-admin/includes/revision.php */
 							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
-							$content_from = apply_filters( "_wp_post_revision_field_{$field}", $original->$field, $field, $original, 'from' );
+							$content_from = apply_filters( "_wp_post_revision_field_{$field}", $this->original->$field, $field, $this->original, 'from' );
 
 							/** This filter is documented in wp-admin/includes/revision.php */
 							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
-							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $post->$field, $field, $post, 'to' );
+							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $this->post->$field, $field, $this->post, 'to' );
 
 							$diff = \wp_text_diff( $content_from, $content_to, $args );
 
 							if ( ! $diff && 'post_title' === $field ) {
 								// It's a better user experience to still show the Title, even if it didn't change.
 								$diff  = '<table class="diff"><colgroup><col class="content diffsplit left"><col class="content diffsplit middle"><col class="content diffsplit right"></colgroup><tbody><tr>';
-								$diff .= '<td>' . \esc_html( $original->post_title ) . '</td><td></td><td>' . \esc_html( $post->post_title ) . '</td>';
+								$diff .= '<td>' . \esc_html( $this->original->post_title ) . '</td><td></td><td>' . \esc_html( $this->post->post_title ) . '</td>';
 								$diff .= '</tr></tbody>';
 								$diff .= '</table>';
 							}
@@ -176,7 +190,10 @@ class Check_Changes_Handler {
 	 * @return void
 	 */
 	public function require_wordpress_header() {
+		global $post;
 		\set_current_screen( 'revision' );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- The revision screen expects $post to be set.
+		$post = $this->post;
 		require_once ABSPATH . 'wp-admin/admin-header.php';
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WP 5.7 has introduced some changes int its "compare revisions" screen and relative functions. This breaks how we use those functions to mimick its look for the Rewrite & Republish "Compare changes" screen.
* #106 introduce a notice in the comparison screen, this also fixes that (see "Relevant technical choices")

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "Compare changes" screen for the Rewrite & Republish feature displayed a broken layout in WordPress 5.7.

## Relevant technical choices:

* #106 set the `current_screen` object to `revision` to make sure that changes introduced there would be working. This triggered a warning notice:
```
NOTICE: wp-includes/admin-bar.php:708 - Trying to get property 'post_type' of non-object
do_action('admin_action_duplicate_post_check_changes'), WP_Hook->do_action, WP_Hook->apply_filters, Yoast\WP\Duplicate_Post\Handlers\Check_Changes_Handler->check_changes_action_handler, Yoast\WP\Duplicate_Post\Handlers\Check_Changes_Handler->require_wordpress_header, require_once('wp-admin/admin-header.php'), do_action('in_admin_header'), WP_Hook->do_action, WP_Hook->apply_filters, wp_admin_bar_render, do_action_ref_array('admin_bar_menu'), WP_Hook->do_action, WP_Hook->apply_filters, wp_admin_bar_edit_menu
```
because the $post object is expected to be set. This PR sets it to the current R&R copy (this also makes the "View Post" appear in the admin bar)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure you have WP 5.7
* make sure you have WP_DEBUG `true` and possibly also Debug Bar and Query Monitor active
* install and activate this branch
* create a Rewrite & Republish copy of a post
* do some changes in the title and/or in the content and/or in the excerpt
* click "Republish", then in the pre-publish column click on "Save and compare changes"
* see that the comparison screen looks ok:
![Screenshot_2021-03-12 ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/110958277-d5a44d80-834c-11eb-987b-a5bf0640b908.png)
unlike it happens with 4.1.1:
![Screenshot_2021-03-10 ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/110958343-e6ed5a00-834c-11eb-968a-521b17918145.png)
* check also that you don't get any warning notice `Trying to get property 'post_type' of non-object` and that you can see "View Post" in the admin bar
* switch to another WP installation with WP 5.6 
* install and activate this branch (e.g. you can run `grunt artifact` and install the zip, without the need of cloning the repo)
* create a Rewrite & Republish copy of a post
* do some changes in the title and/or in the content and/or in the excerpt
* click "Republish", then in the pre-publish column click on "Save and compare changes"
* see that the comparison screen looks ok as well (note that on WP 5.6 the "headers" on each of the two columns for each section are missing, they've been introduced in WP 5.7)
![Screenshot_2021-03-12 ‹ semrush — WordPress](https://user-images.githubusercontent.com/15989132/110958958-827eca80-834d-11eb-912c-55e297647f0c.png)



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* make sure you have WP 5.7
* make sure you have WP_DEBUG `true` and possibly also Debug Bar and Query Monitor active
* install and activate the RC
* create a Rewrite & Republish copy of a post
* do some changes in the title and/or in the content and/or in the excerpt
* click "Republish", then in the pre-publish column click on "Save and compare changes"
* see that the comparison screen looks ok:
![Screenshot_2021-03-12 ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/110958277-d5a44d80-834c-11eb-987b-a5bf0640b908.png)
unlike it happens with 4.1.1:
![Screenshot_2021-03-10 ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/110958343-e6ed5a00-834c-11eb-968a-521b17918145.png)
* check also that you don't get any warning notice `Trying to get property 'post_type' of non-object` and that you can see "View Post" in the admin bar
* switch to another WP installation with WP 5.6 
* install and activate the RC
* create a Rewrite & Republish copy of a post
* do some changes in the title and/or in the content and/or in the excerpt
* click "Republish", then in the pre-publish column click on "Save and compare changes"
* see that the comparison screen looks ok as well (note that on WP 5.6 the "Added"/"Removed" headers on each of the two columns for each section are missing, they're correctly supported only in 5.7):
![Screenshot_2021-03-12 ‹ semrush — WordPress](https://user-images.githubusercontent.com/15989132/110958958-827eca80-834d-11eb-912c-55e297647f0c.png)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-434]
