### PR TITLE
P3-321 improve Metabox class

### DIFF
--- a/src/ui/class-metabox.php
+++ b/src/ui/class-metabox.php
@@ -38,28 +38,36 @@ class Metabox {
 	 */
 	public function register_hooks() {
 		if ( \intval( \get_option( 'duplicate_post_show_original_meta_box' ) ) === 1 ) {
-			\add_action( 'add_meta_boxes', [ $this, 'add_custom_metabox' ] );
+			\add_action( 'add_meta_boxes', [ $this, 'add_custom_metabox' ], 10, 2 );
 		}
 	}
 
 	/**
 	 * Adds a metabox to Edit screen.
 	 *
+	 * @param string   $post_type The post type.
+	 * @param \WP_Post $post      The current post object.
+	 *
 	 * @return void
 	 */
-	public function add_custom_metabox() {
-		$screens = $this->permissions_helper->get_enabled_post_types();
-		if ( ! \is_array( $screens ) ) {
-			$screens = [ $screens ];
-		}
-		foreach ( $screens as $screen ) {
-			\add_meta_box(
-				'duplicate_post_show_original',
-				\__( 'Duplicate Post', 'duplicate-post' ),
-				[ $this, 'custom_metabox_html' ],
-				$screen,
-				'side'
-			);
+	public function add_custom_metabox( $post_type, $post ) {
+		$enabled_post_types = $this->permissions_helper->get_enabled_post_types();
+
+		if ( \in_array( $post_type, $enabled_post_types, true )
+			&& $post instanceof \WP_Post ) {
+			$original_item = Utils::get_original( $post );
+
+			if ( $original_item instanceof \WP_Post ) {
+				\add_meta_box(
+					'duplicate_post_show_original',
+					\__( 'Duplicate Post', 'duplicate-post' ),
+					[ $this, 'custom_metabox_html' ],
+					$post_type,
+					'side',
+					'default',
+					[ 'original' => $original_item ]
+				);
+			}
 		}
 	}
 
@@ -67,55 +75,46 @@ class Metabox {
 	 * Outputs the HTML for the metabox.
 	 *
 	 * @param \WP_Post $post The current post.
+	 * @param array    $args The array of arguments from the `add_meta_box()` call.
 	 *
 	 * @return void
 	 */
-	public function custom_metabox_html( $post ) {
-		$original_item = Utils::get_original( $post );
-		if ( $post instanceof \WP_Post && $original_item instanceof \WP_Post ) {
-			if ( ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
-				?>
-			<p>
-				<input type="checkbox"
-					name="duplicate_post_remove_original"
-					id="duplicate-post-remove-original"
-					value="duplicate_post_remove_original"
-					aria-describedby="duplicate-post-remove-original-description">
-				<label for="duplicate-post-remove-original">
-					<?php \esc_html_e( 'Delete reference to original item.', 'duplicate-post' ); ?>
-				</label>
-			</p>
-				<?php
-			}
+	public function custom_metabox_html( $post, $metabox ) {
+		$original_item = $metabox['args']['original'];
+		if ( ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			?>
-			<p id="duplicate-post-remove-original-description">
-				<?php
-				\printf(
-					\wp_kses(
-					/* translators: %s: post title */
-						\__(
-							'The original item this was copied from is: <span class="duplicate_post_original_item_title_span">%s</span>',
-							'duplicate-post'
-						),
-						[
-							'span' => [
-								'class' => [],
-							],
-						]
-					),
-					Utils::get_edit_or_view_link( $original_item )  // phpcs:ignore WordPress.Security.EscapeOutput
-				);
-				?>
-			</p>
-			<?php
-		} else {
-			?>
-			<script>
-				(function(jQuery){
-					jQuery('#duplicate_post_show_original').hide();
-				})(jQuery);
-			</script>
+		<p>
+			<input type="checkbox"
+				name="duplicate_post_remove_original"
+				id="duplicate-post-remove-original"
+				value="duplicate_post_remove_original"
+				aria-describedby="duplicate-post-remove-original-description">
+			<label for="duplicate-post-remove-original">
+				<?php \esc_html_e( 'Delete reference to original item.', 'duplicate-post' ); ?>
+			</label>
+		</p>
 			<?php
 		}
+		?>
+		<p id="duplicate-post-remove-original-description">
+			<?php
+			\printf(
+				\wp_kses(
+				/* translators: %s: post title */
+					\__(
+						'The original item this was copied from is: <span class="duplicate_post_original_item_title_span">%s</span>',
+						'duplicate-post'
+					),
+					[
+						'span' => [
+							'class' => [],
+						],
+					]
+				),
+				Utils::get_edit_or_view_link( $original_item )  // phpcs:ignore WordPress.Security.EscapeOutput
+			);
+			?>
+		</p>
+		<?php
 	}
 }

--- a/src/ui/class-metabox.php
+++ b/src/ui/class-metabox.php
@@ -74,8 +74,8 @@ class Metabox {
 	/**
 	 * Outputs the HTML for the metabox.
 	 *
-	 * @param \WP_Post $post The current post.
-	 * @param array    $args The array of arguments from the `add_meta_box()` call.
+	 * @param \WP_Post $post    The current post.
+	 * @param array    $metabox The array containing the metabox data.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The current implementation of the Metabox class has been copied directly from the legacy code. It uses WP function and hooks in a wrong way and forces to use JS to hide the custom metabox for post that are not copies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the Metabox class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit `Settings` > `Duplicate Post`, third tab `Display`, and make sure the `Show original item:` > `In a metabox in the Edit screen` option is enabled.
* Make sure you have at least:
  * 1 post which is not a copy of anything
  * 1 post which is a R&R copy of another post
  * 2 posts which are regular copy of other posts
  * 1 page which is a regular copy of another page
* **perform the following steps both in Block and Classic editor**
* Edit a post which is not a copy of anything, and see that you don't see any Duplicate Post metabox. Please make sure the metabox is not disabled (Block editor: `Options` > `Preferences` > `Panels`, Classic editor: `Screen options`). **Note by Andrea:** just to clarify these test instructions for future reference:  in this case, there's no setting related to the Duplicate Post meta box under "Block editor: `Options` > `Preferences` > `Panels`, Classic editor: `Screen options`" and that's the expected behavior. The setting is only displayed for posts that do have a copy.
* Edit a post which is a R&R copy of a post, and see that you see a Duplicate Post metabox like this one (Classic editor view, in Block Editor the content will be the same)
![Screenshot_2021-03-15 Edit Post ‹ Basic — WordPress(1)](https://user-images.githubusercontent.com/15989132/111179250-2b2a6580-85ac-11eb-85bc-69a339eedc80.png)
* Edit a post which is a regular copy of a post, and see that you see a Duplicate Post metabox like this one (Classic editor view, in Block Editor the content will be the same):
![Screenshot_2021-03-15 Edit Post ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/111178981-ec94ab00-85ab-11eb-8c8a-a8bef548f306.png)
* tick the checkbox and save the post
   * if you are on Block Editor, reload the page (F5) - on Classic Editor this happens automatically
   * see that the Metabox is not there anymore
* visit `Settings` > `Duplicate Post`, second tab `Permissions`, and disable the plugin for the `Page` type
* edit a page which is a copy of another page and see that you can't see the metabox at all
* visit `Settings` > `Duplicate Post`, third tab `Display`, and make sure the `Show original item:` > `In a metabox in the Edit screen` option is _disabled_.
* edit a post which is a copy of another page and see that you can't see the metabox at all

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-321]
