### PR TITLE
CS: use short arrays

### DIFF
--- a/compat/duplicate-post-wpml.php
+++ b/compat/duplicate-post-wpml.php
@@ -22,7 +22,7 @@ function duplicate_post_wpml_init() {
 }
 
 global $duplicated_posts;    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-$duplicated_posts = array(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+$duplicated_posts = []; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 /**
  * Copy post translations.
@@ -84,7 +84,7 @@ function duplicate_wpml_string_packages() { // phpcs:ignore WordPress.NamingConv
 		$new_string_packages      = apply_filters( 'wpml_st_get_post_string_packages', false, $duplicate_post_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 		if ( is_array( $original_string_packages ) ) {
 			foreach ( $original_string_packages as $original_string_package ) {
-				$translated_original_strings = $original_string_package->get_translated_strings( array() );
+				$translated_original_strings = $original_string_package->get_translated_strings( [] );
 
 				foreach ( $new_string_packages as $new_string_package ) {
 					$cache = new WPML_WP_Cache( 'WPML_Package' );

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -82,12 +82,12 @@ function duplicate_post_plugin_upgrade() {
 
 	if ( empty( $installed_version ) ) {
 		// Get default roles.
-		$default_roles = array(
+		$default_roles = [
 			'editor',
 			'administrator',
 			'wpseo_manager',
 			'wpseo_editor',
-		);
+		];
 
 		foreach ( $default_roles as $name ) {
 			$role = get_role( $name );
@@ -119,9 +119,9 @@ function duplicate_post_plugin_upgrade() {
 	add_option( 'duplicate_post_copychildren', '0' );
 	add_option( 'duplicate_post_copycomments', '0' );
 	add_option( 'duplicate_post_copymenuorder', '1' );
-	add_option( 'duplicate_post_taxonomies_blacklist', array() );
+	add_option( 'duplicate_post_taxonomies_blacklist', [] );
 	add_option( 'duplicate_post_blacklist', '' );
-	add_option( 'duplicate_post_types_enabled', array( 'post', 'page' ) );
+	add_option( 'duplicate_post_types_enabled', [ 'post', 'page' ] );
 	add_option( 'duplicate_post_show_original_column', '0' );
 	add_option( 'duplicate_post_show_original_in_post_states', '0' );
 	add_option( 'duplicate_post_show_original_meta_box', '0' );
@@ -137,26 +137,26 @@ function duplicate_post_plugin_upgrade() {
 
 	$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
 	if ( '' === $taxonomies_blacklist ) {
-		$taxonomies_blacklist = array();
+		$taxonomies_blacklist = [];
 	}
 	if ( in_array( 'post_format', $taxonomies_blacklist, true ) ) {
 		update_option( 'duplicate_post_copyformat', 0 );
-		$taxonomies_blacklist = array_diff( $taxonomies_blacklist, array( 'post_format' ) );
+		$taxonomies_blacklist = array_diff( $taxonomies_blacklist, [ 'post_format' ] );
 		update_option( 'duplicate_post_taxonomies_blacklist', $taxonomies_blacklist );
 	}
 
 	$meta_blacklist = explode( ',', get_option( 'duplicate_post_blacklist' ) );
 	if ( '' === $meta_blacklist ) {
-		$meta_blacklist = array();
+		$meta_blacklist = [];
 	}
 	$meta_blacklist = array_map( 'trim', $meta_blacklist );
 	if ( in_array( '_wp_page_template', $meta_blacklist, true ) ) {
 		update_option( 'duplicate_post_copytemplate', 0 );
-		$meta_blacklist = array_diff( $meta_blacklist, array( '_wp_page_template' ) );
+		$meta_blacklist = array_diff( $meta_blacklist, [ '_wp_page_template' ] );
 	}
 	if ( in_array( '_thumbnail_id', $meta_blacklist, true ) ) {
 		update_option( 'duplicate_post_copythumbnail', 0 );
-		$meta_blacklist = array_diff( $meta_blacklist, array( '_thumbnail_id' ) );
+		$meta_blacklist = array_diff( $meta_blacklist, [ '_thumbnail_id' ] );
 	}
 	update_option( 'duplicate_post_blacklist', implode( ',', $meta_blacklist ) );
 
@@ -237,14 +237,14 @@ function duplicate_post_show_update_notice() {
 
 	$message .= '<p>%%SIGNUP_FORM%%</p>';
 
-	$allowed_tags = array(
-		'a'      => array(
-			'href'  => array(),
-		),
-		'br'     => array(),
-		'p'      => array(),
-		'strong' => array(),
-	);
+	$allowed_tags = [
+		'a'      => [
+			'href'  => [],
+		],
+		'br'     => [],
+		'p'      => [],
+		'strong' => [],
+	];
 
 	$sanitized_message = wp_kses( $message, $allowed_tags );
 	$sanitized_message = str_replace( '%%SIGNUP_FORM%%', duplicate_post_newsletter_signup_form(), $sanitized_message );
@@ -307,7 +307,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 
 		$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
 		if ( '' === $taxonomies_blacklist ) {
-			$taxonomies_blacklist = array();
+			$taxonomies_blacklist = [];
 		}
 		if ( intval( get_option( 'duplicate_post_copyformat' ) ) === 0 ) {
 			$taxonomies_blacklist[] = 'post_format';
@@ -324,8 +324,8 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 
 		$taxonomies = array_diff( $post_taxonomies, $taxonomies_blacklist );
 		foreach ( $taxonomies as $taxonomy ) {
-			$post_terms = wp_get_object_terms( $post->ID, $taxonomy, array( 'orderby' => 'term_order' ) );
-			$terms      = array();
+			$post_terms = wp_get_object_terms( $post->ID, $taxonomy, [ 'orderby' => 'term_order' ] );
+			$terms      = [];
 			$num_terms  = count( $post_terms );
 			for ( $i = 0; $i < $num_terms; $i++ ) {
 				$terms[] = $post_terms[ $i ]->slug;
@@ -348,7 +348,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	}
 	$meta_blacklist = get_option( 'duplicate_post_blacklist' );
 	if ( '' === $meta_blacklist ) {
-		$meta_blacklist = array();
+		$meta_blacklist = [];
 	} else {
 		$meta_blacklist = explode( ',', $meta_blacklist );
 		$meta_blacklist = array_filter( $meta_blacklist );
@@ -365,7 +365,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 		$meta_blacklist[] = '_thumbnail_id';
 	}
 
-	$meta_blacklist = apply_filters_deprecated( 'duplicate_post_blacklist_filter', array( $meta_blacklist ), '3.2.5', 'duplicate_post_excludelist_filter' );
+	$meta_blacklist = apply_filters_deprecated( 'duplicate_post_blacklist_filter', [ $meta_blacklist ], '3.2.5', 'duplicate_post_excludelist_filter' );
 	/**
 	 * Filters the meta fields excludelist when copying a post.
 	 *
@@ -377,9 +377,9 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 
 	$meta_blacklist_string = '(' . implode( ')|(', $meta_blacklist ) . ')';
 	if ( strpos( $meta_blacklist_string, '*' ) !== false ) {
-		$meta_blacklist_string = str_replace( array( '*' ), array( '[a-zA-Z0-9_]*' ), $meta_blacklist_string );
+		$meta_blacklist_string = str_replace( [ '*' ], [ '[a-zA-Z0-9_]*' ], $meta_blacklist_string );
 
-		$meta_keys = array();
+		$meta_keys = [];
 		foreach ( $post_meta_keys as $meta_key ) {
 			if ( ! preg_match( '#^' . $meta_blacklist_string . '$#', $meta_key ) ) {
 				$meta_keys[] = $meta_key;
@@ -459,12 +459,12 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 	$old_thumbnail_id = get_post_thumbnail_id( $post->ID );
 	// Get children.
 	$children = get_posts(
-		array(
+		[
 			'post_type'   => 'any',
 			'numberposts' => -1,
 			'post_status' => 'any',
 			'post_parent' => $post->ID,
-		)
+		]
 	);
 	// Clone old attachments.
 	foreach ( $children as $child ) {
@@ -480,7 +480,7 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 
 		$desc = wp_slash( $child->post_content );
 
-		$file_array             = array();
+		$file_array             = [];
 		$file_array['name']     = basename( $url );
 		$file_array['tmp_name'] = $tmp;
 		// "Upload" to the media collection
@@ -491,12 +491,12 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 			continue;
 		}
 		$new_post_author = wp_get_current_user();
-		$cloned_child    = array(
+		$cloned_child    = [
 			'ID'           => $new_attachment_id,
 			'post_title'   => $child->post_title,
 			'post_exceprt' => $child->post_title,
 			'post_author'  => $new_post_author->ID,
-		);
+		];
 		wp_update_post( wp_slash( $cloned_child ) );
 
 		$alt_title = get_post_meta( $child->ID, '_wp_attachment_image_alt', true );
@@ -521,12 +521,12 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 function duplicate_post_copy_children( $new_id, $post, $status = '' ) {
 	// Get children.
 	$children = get_posts(
-		array(
+		[
 			'post_type'   => 'any',
 			'numberposts' => -1,
 			'post_status' => 'any',
 			'post_parent' => $post->ID,
-		)
+		]
 	);
 
 	foreach ( $children as $child ) {
@@ -545,21 +545,21 @@ function duplicate_post_copy_children( $new_id, $post, $status = '' ) {
  */
 function duplicate_post_copy_comments( $new_id, $post ) {
 	$comments = get_comments(
-		array(
+		[
 			'post_id' => $post->ID,
 			'order'   => 'ASC',
 			'orderby' => 'comment_date_gmt',
-		)
+		]
 	);
 
-	$old_id_to_new = array();
+	$old_id_to_new = [];
 	foreach ( $comments as $comment ) {
 		// Do not copy pingbacks or trackbacks.
 		if ( $comment->comment_type === 'pingback' || $comment->comment_type === 'trackback' ) {
 			continue;
 		}
 		$parent      = ( $comment->comment_parent && $old_id_to_new[ $comment->comment_parent ] ) ? $old_id_to_new[ $comment->comment_parent ] : 0;
-		$commentdata = array(
+		$commentdata = [
 			'comment_post_ID'      => $new_id,
 			'comment_author'       => $comment->comment_author,
 			'comment_author_email' => $comment->comment_author_email,
@@ -572,7 +572,7 @@ function duplicate_post_copy_comments( $new_id, $post ) {
 			'comment_agent'        => $comment->comment_agent,
 			'comment_karma'        => $comment->comment_karma,
 			'comment_approved'     => $comment->comment_approved,
-		);
+		];
 		if ( intval( get_option( 'duplicate_post_copydate' ) ) === 1 ) {
 			$commentdata['comment_date']     = $comment->comment_date;
 			$commentdata['comment_date_gmt'] = get_gmt_from_date( $comment->comment_date );
@@ -702,7 +702,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	}
 	$new_post_parent = empty( $parent_id ) ? $post->post_parent : $parent_id;
 
-	$new_post = array(
+	$new_post = [
 		'menu_order'            => $menu_order,
 		'comment_status'        => $post->comment_status,
 		'ping_status'           => $post->ping_status,
@@ -717,7 +717,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 		'post_title'            => $title,
 		'post_type'             => $post->post_type,
 		'post_name'             => $post_name,
-	);
+	];
 
 	if ( intval( get_option( 'duplicate_post_copydate' ) ) === 1 ) {
 		$new_post_date             = $post->post_date;

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -17,9 +17,9 @@ use Yoast\WP\Duplicate_Post\Utils;
  * @return bool
  */
 function duplicate_post_is_post_type_enabled( $post_type ) {
-	$duplicate_post_types_enabled = get_option( 'duplicate_post_types_enabled', array( 'post', 'page' ) );
+	$duplicate_post_types_enabled = get_option( 'duplicate_post_types_enabled', [ 'post', 'page' ] );
 	if ( ! is_array( $duplicate_post_types_enabled ) ) {
-		$duplicate_post_types_enabled = array( $duplicate_post_types_enabled );
+		$duplicate_post_types_enabled = [ $duplicate_post_types_enabled ];
 	}
 	/** This filter is documented in src/class-permissions-helper.php */
 	$duplicate_post_types_enabled = apply_filters( 'duplicate_post_enabled_post_types', $duplicate_post_types_enabled );

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -83,14 +83,14 @@ add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'duplicate_pos
  * @return array
  */
 function duplicate_post_plugin_actions( $actions ) {
-	$settings_action = array(
+	$settings_action = [
 		'settings' => sprintf(
 			'<a href="%1$s" %2$s>%3$s</a>',
 			menu_page_url( 'duplicatepost', false ),
 			'aria-label="' . __( 'Settings for Duplicate Post', 'duplicate-post' ) . '"',
 			esc_html__( 'Settings', 'default' )
 		),
-	);
+	];
 
 	$actions = $settings_action + $actions;
 	return $actions;

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -129,11 +129,11 @@ class Check_Changes_Handler {
 							'post_excerpt' => \__( 'Excerpt', 'default' ),
 						];
 
-						$args = array(
+						$args = [
 							'show_split_view' => true,
 							'title_left'      => __( 'Removed', 'default' ),
 							'title_right'     => __( 'Added', 'default' ),
-						);
+						];
 
 						if ( \version_compare( $wp_version, '5.7' ) < 0 ) {
 							unset( $args['title_left'] );

--- a/src/ui/class-bulk-actions.php
+++ b/src/ui/class-bulk-actions.php
@@ -69,7 +69,7 @@ class Bulk_Actions {
 	 */
 	public function register_bulk_action( $bulk_actions ) {
 		// phpcs:ignore WordPress.Security.NonceVerification
-		$is_draft_or_trash = isset( $_REQUEST['post_status'] ) && in_array( $_REQUEST['post_status'], array( 'draft', 'trash' ), true );
+		$is_draft_or_trash = isset( $_REQUEST['post_status'] ) && in_array( $_REQUEST['post_status'], [ 'draft', 'trash' ], true );
 
 		if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'clone' ) ) === 1 ) {
 			$bulk_actions['duplicate_post_bulk_clone'] = \esc_html__( 'Clone', 'duplicate-post' );


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

YoastCS enforces the use of short arrays.

This plugin was using a mixture of both long as well as short arrays. This has now been fixed up to always use short arrays.


### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.