### PR TITLE
QA: declare static closures as static

### DIFF
--- a/src/admin/class-options.php
+++ b/src/admin/class-options.php
@@ -39,7 +39,7 @@ class Options {
 
 		$options = \array_filter(
 			$options,
-			function ( $option ) use ( $tab ) {
+			static function ( $option ) use ( $tab ) {
 				return \array_key_exists( 'tab', $option ) && $option['tab'] === $tab;
 			}
 		);
@@ -52,7 +52,7 @@ class Options {
 		if ( ! empty( $fieldset ) ) {
 			$options = \array_filter(
 				$options,
-				function ( $option ) use ( $fieldset ) {
+				static function ( $option ) use ( $fieldset ) {
 					return \array_key_exists( 'fieldset', $option ) && $option['fieldset'] === $fieldset;
 				}
 			);

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -267,7 +267,7 @@ class Block_Editor {
 
 		return \array_filter(
 			$suggestions,
-			function( $suggestion ) use ( $original_post_id ) {
+			static function ( $suggestion ) use ( $original_post_id ) {
 				return $suggestion->object_id !== $original_post_id;
 			}
 		);

--- a/tests/admin/class-options-form-generator-test.php
+++ b/tests/admin/class-options-form-generator-test.php
@@ -65,7 +65,7 @@ class Options_Form_Generator_Test extends TestCase {
 		Monkey\Functions\stubs(
 			[
 				'get_post_types'      => [ $post_type1, $post_type2 ],
-				'translate_user_role' => function( $role ) {
+				'translate_user_role' => static function ( $role ) {
 					return $role;
 				},
 			]

--- a/tests/class-post-duplicator-test.php
+++ b/tests/class-post-duplicator-test.php
@@ -173,7 +173,7 @@ class Post_Duplicator_Test extends TestCase {
 		Monkey\Functions\expect( '\is_post_type_hierarchical' )
 			->with( $post->post_type )
 			->andReturnUsing(
-				function( $post_type ) {
+				static function ( $post_type ) {
 					return $post_type !== 'post' && $post_type === 'page';
 				}
 			);
@@ -277,7 +277,7 @@ class Post_Duplicator_Test extends TestCase {
 		Monkey\Functions\expect( '\is_post_type_hierarchical' )
 			->with( $post->post_type )
 			->andReturnUsing(
-				function( $post_type ) {
+				static function ( $post_type ) {
 					return $post_type !== 'post' && $post_type === 'page';
 				}
 			);

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -41,13 +41,13 @@ abstract class TestCase extends BaseTestCase {
 		];
 		$role1->allows(
 			[
-				'has_cap' => function( $cap ) {
+				'has_cap' => static function ( $cap ) {
 					return true;
 				},
-				'add_cap' => function( $cap ) {
+				'add_cap' => static function ( $cap ) {
 					return true;
 				},
-				'remove_cap' => function( $cap ) {
+				'remove_cap' => static function ( $cap ) {
 				},
 			]
 		);
@@ -61,13 +61,13 @@ abstract class TestCase extends BaseTestCase {
 		];
 		$role2->allows(
 			[
-				'has_cap' => function( $cap ) {
+				'has_cap' => static function ( $cap ) {
 					return false;
 				},
-				'add_cap' => function( $cap ) {
+				'add_cap' => static function ( $cap ) {
 					return true;
 				},
-				'remove_cap' => function( $cap ) {
+				'remove_cap' => static function ( $cap ) {
 				},
 			]
 		);
@@ -77,13 +77,13 @@ abstract class TestCase extends BaseTestCase {
 		$role3->capabilities = [];
 		$role3->allows(
 			[
-				'has_cap' => function( $cap ) {
+				'has_cap' => static function ( $cap ) {
 					return false;
 				},
-				'add_cap' => function( $cap ) {
+				'add_cap' => static function ( $cap ) {
 					return true;
 				},
-				'remove_cap' => function( $cap ) {
+				'remove_cap' => static function ( $cap ) {
 				},
 			]
 		);
@@ -103,7 +103,7 @@ abstract class TestCase extends BaseTestCase {
 				'esc_html'       => null,
 				'esc_textarea'   => null,
 				'__'             => null,
-				'_n'             => function( $single, $plural, $number ) {
+				'_n'             => static function ( $single, $plural, $number ) {
 					if ( $number === 1 ) {
 						return $single;
 					}
@@ -121,16 +121,16 @@ abstract class TestCase extends BaseTestCase {
 				'is_multisite'   => false,
 				'site_url'       => 'https://www.example.org',
 				'wp_slash'       => null,
-				'wp_unslash'     => function( $value ) {
+				'wp_unslash'     => static function ( $value ) {
 					return \is_string( $value ) ? \stripslashes( $value ) : $value;
 				},
-				'absint'         => function( $value ) {
+				'absint'         => static function ( $value ) {
 					return \abs( \intval( $value ) );
 				},
-				'wp_parse_args'  => function ( $settings, $defaults ) {
+				'wp_parse_args'  => static function ( $settings, $defaults ) {
 					return \array_merge( $defaults, $settings );
 				},
-				'get_role'       => function( $name ) use ( $role_objects ) {
+				'get_role'       => static function ( $name ) use ( $role_objects ) {
 					return $role_objects[ $name ];
 				},
 			]

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -718,7 +718,7 @@ class Block_Editor_Test extends TestCase {
 
 		Monkey\Functions\expect( '\admin_url' )
 			->andReturnUsing(
-				function ( $string ) {
+				static function ( $string ) {
 					return 'http://basic.wordpress.test/wp-admin/' . $string;
 				}
 			);
@@ -729,7 +729,7 @@ class Block_Editor_Test extends TestCase {
 
 		Monkey\Functions\expect( '\add_query_arg' )
 			->andReturnUsing(
-				function ( $array, $string ) {
+				static function ( $array, $string ) {
 					foreach ( $array as $key => $value ) {
 						$string .= '&' . $key . '=' . $value;
 					}

--- a/tests/ui/class-classic-editor-test.php
+++ b/tests/ui/class-classic-editor-test.php
@@ -201,7 +201,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button( $post );
 	}
 
@@ -234,7 +234,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button();
 	}
 
@@ -261,7 +261,7 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_new_draft_link' )
 			->never();
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
 	}
@@ -292,7 +292,7 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_new_draft_link' )
 			->never();
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button( $post );
 	}
 
@@ -330,7 +330,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button( $post );
 	}
 
@@ -369,7 +369,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button();
 	}
 
@@ -396,7 +396,7 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_rewrite_and_republish_link' )
 			->never();
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
 	}
@@ -433,7 +433,7 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_rewrite_and_republish_link' )
 			->never();
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button( $post );
 	}
 
@@ -462,7 +462,7 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_rewrite_and_republish_link' )
 			->never();
 
-		$this->setOutputCallback( function() {} );
+		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
 	}

--- a/tests/ui/class-link-builder-test.php
+++ b/tests/ui/class-link-builder-test.php
@@ -133,7 +133,7 @@ class Link_Builder_Test extends TestCase {
 
 		Monkey\Functions\expect( '\admin_url' )
 			->andReturnUsing(
-				function ( $string ) {
+				static function ( $string ) {
 					return 'http://basic.wordpress.test/wp-admin/' . $string;
 				}
 			);
@@ -164,7 +164,7 @@ class Link_Builder_Test extends TestCase {
 
 		Monkey\Functions\expect( '\admin_url' )
 			->andReturnUsing(
-				function ( $string ) {
+				static function ( $string ) {
 					return 'http://basic.wordpress.test/wp-admin/' . $string;
 				}
 			);

--- a/tests/ui/class-row-actions-test.php
+++ b/tests/ui/class-row-actions-test.php
@@ -129,7 +129,7 @@ class Row_Actions_Test extends TestCase {
 		Monkey\Functions\expect( '\_draft_or_post_title' )
 			->with( $post )
 			->andReturnUsing(
-				function ( $post ) {
+				static function ( $post ) {
 					return $post->post_title;
 				}
 			);
@@ -214,7 +214,7 @@ class Row_Actions_Test extends TestCase {
 		Monkey\Functions\expect( '\_draft_or_post_title' )
 			->with( $post )
 			->andReturnUsing(
-				function ( $post ) {
+				static function ( $post ) {
 					return $post->post_title;
 				}
 			);
@@ -305,7 +305,7 @@ class Row_Actions_Test extends TestCase {
 		Monkey\Functions\expect( '\_draft_or_post_title' )
 			->with( $post )
 			->andReturnUsing(
-				function ( $post ) {
+				static function ( $post ) {
 					return $post->post_title;
 				}
 			);


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Closures not using `$this` should be declared as `static`.

Includes minor whitespace fixes for the space between the `function` keyword and the opening parenthesis.


### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
