### PR TITLE
Modernize: use __DIR__ instead of dirname( __FILE__ )

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -10,10 +10,10 @@ if ( ! is_admin() ) {
 	return;
 }
 
-require_once dirname( __FILE__ ) . '/duplicate-post-options.php';
+require_once __DIR__ . '/duplicate-post-options.php';
 
-require_once dirname( __FILE__ ) . '/compat/duplicate-post-wpml.php';
-require_once dirname( __FILE__ ) . '/compat/duplicate-post-jetpack.php';
+require_once __DIR__ . '/compat/duplicate-post-wpml.php';
+require_once __DIR__ . '/compat/duplicate-post-jetpack.php';
 
 /**
  * Wrapper for the option 'duplicate_post_version'.
@@ -771,7 +771,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
  * @return array
  */
 function duplicate_post_add_plugin_links( $links, $file ) {
-	if ( plugin_basename( dirname( __FILE__ ) . '/duplicate-post.php' ) === $file ) {
+	if ( plugin_basename( __DIR__ . '/duplicate-post.php' ) === $file ) {
 		$links[] = '<a href="https://yoast.com/wordpress/plugins/duplicate-post">' . esc_html__( 'Documentation', 'duplicate-post' ) . '</a>';
 	}
 	return $links;

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -67,7 +67,7 @@ function __duplicate_post_main() {
  * Initialises the internationalisation domain.
  */
 function duplicate_post_load_plugin_textdomain() {
-	load_plugin_textdomain( 'duplicate-post', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+	load_plugin_textdomain( 'duplicate-post', false, basename( __DIR__ ) . '/languages/' );
 }
 add_action( 'plugins_loaded', 'duplicate_post_load_plugin_textdomain' );
 
@@ -96,8 +96,8 @@ function duplicate_post_plugin_actions( $actions ) {
 	return $actions;
 }
 
-require_once dirname( __FILE__ ) . '/duplicate-post-common.php';
+require_once __DIR__ . '/duplicate-post-common.php';
 
 if ( is_admin() ) {
-	include_once dirname( __FILE__ ) . '/duplicate-post-admin.php';
+	include_once __DIR__ . '/duplicate-post-admin.php';
 }


### PR DESCRIPTION
## Context

* Code modernization

## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

Now support for PHP < 5.6 has been dropped, the `__DIR__` constant can be safely used.


### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.