### PR TITLE
CS: don't use Yoda conditions

### DIFF
--- a/compat/duplicate-post-gutenberg.php
+++ b/compat/duplicate-post-gutenberg.php
@@ -29,7 +29,7 @@ function duplicate_post_classic_editor_clone_link( $url, $post_id, $context, $dr
 	if ( isset( $_GET['classic-editor'] ) // phpcs:ignore WordPress.Security.NonceVerification
 		|| ( $draft && function_exists( 'gutenberg_post_has_blocks' ) && ! gutenberg_post_has_blocks( $post ) )
 		|| ( $draft && function_exists( 'has_blocks' ) && ! has_blocks( $post ) ) ) {
-		if ( 'display' === $context ) {
+		if ( $context === 'display' ) {
 			$url .= '&amp;classic-editor';
 		} else {
 			$url .= '&classic-editor';

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -136,7 +136,7 @@ function duplicate_post_plugin_upgrade() {
 	add_option( 'duplicate_post_show_link_in', $show_links_in_defaults );
 
 	$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
-	if ( '' === $taxonomies_blacklist ) {
+	if ( $taxonomies_blacklist === '' ) {
 		$taxonomies_blacklist = [];
 	}
 	if ( in_array( 'post_format', $taxonomies_blacklist, true ) ) {
@@ -146,7 +146,7 @@ function duplicate_post_plugin_upgrade() {
 	}
 
 	$meta_blacklist = explode( ',', get_option( 'duplicate_post_blacklist' ) );
-	if ( '' === $meta_blacklist ) {
+	if ( $meta_blacklist === '' ) {
 		$meta_blacklist = [];
 	}
 	$meta_blacklist = array_map( 'trim', $meta_blacklist );
@@ -306,7 +306,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 		}
 
 		$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
-		if ( '' === $taxonomies_blacklist ) {
+		if ( $taxonomies_blacklist === '' ) {
 			$taxonomies_blacklist = [];
 		}
 		if ( intval( get_option( 'duplicate_post_copyformat' ) ) === 0 ) {
@@ -347,7 +347,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 		return;
 	}
 	$meta_blacklist = get_option( 'duplicate_post_blacklist' );
-	if ( '' === $meta_blacklist ) {
+	if ( $meta_blacklist === '' ) {
 		$meta_blacklist = [];
 	} else {
 		$meta_blacklist = explode( ',', $meta_blacklist );
@@ -468,7 +468,7 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 	);
 	// Clone old attachments.
 	foreach ( $children as $child ) {
-		if ( 'attachment' !== $child->post_type ) {
+		if ( $child->post_type !== 'attachment' ) {
 			continue;
 		}
 		$url = wp_get_attachment_url( $child->ID );
@@ -530,7 +530,7 @@ function duplicate_post_copy_children( $new_id, $post, $status = '' ) {
 	);
 
 	foreach ( $children as $child ) {
-		if ( 'attachment' === $child->post_type ) {
+		if ( $child->post_type === 'attachment' ) {
 			continue;
 		}
 		duplicate_post_create_duplicate( $child, $status, $new_id );
@@ -621,7 +621,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 		wp_die( esc_html( __( 'You aren\'t allowed to duplicate this post', 'duplicate-post' ) ) );
 	}
 
-	if ( ! duplicate_post_is_post_type_enabled( $post->post_type ) && 'attachment' !== $post->post_type ) {
+	if ( ! duplicate_post_is_post_type_enabled( $post->post_type ) && $post->post_type !== 'attachment' ) {
 		wp_die(
 			esc_html(
 				__( 'Copy features for this post type are not enabled in options page', 'duplicate-post' ) . ': ' .
@@ -633,7 +633,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	$new_post_status = ( empty( $status ) ) ? $post->post_status : $status;
 	$title           = ' ';
 
-	if ( 'attachment' !== $post->post_type ) {
+	if ( $post->post_type !== 'attachment' ) {
 		$prefix = sanitize_text_field( get_option( 'duplicate_post_title_prefix' ) );
 		$suffix = sanitize_text_field( get_option( 'duplicate_post_title_suffix' ) );
 		if ( intval( get_option( 'duplicate_post_copytitle' ) ) === 1 ) {
@@ -660,7 +660,7 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 		if ( intval( get_option( 'duplicate_post_copystatus' ) ) === 0 ) {
 			$new_post_status = 'draft';
 		} else {
-			if ( 'publish' === $new_post_status || 'future' === $new_post_status ) {
+			if ( $new_post_status === 'publish' || $new_post_status === 'future' ) {
 				// Check if the user has the right capability.
 				if ( is_post_type_hierarchical( $post->post_type ) ) {
 					if ( ! current_user_can( 'publish_pages' ) ) {
@@ -738,9 +738,9 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 
 	// If you have written a plugin which uses non-WP database tables to save
 	// information about a post you can hook this action to dupe that data.
-	if ( 0 !== $new_post_id && ! is_wp_error( $new_post_id ) ) {
+	if ( $new_post_id !== 0 && ! is_wp_error( $new_post_id ) ) {
 
-		if ( 'page' === $post->post_type || is_post_type_hierarchical( $post->post_type ) ) {
+		if ( $post->post_type === 'page' || is_post_type_hierarchical( $post->post_type ) ) {
 			do_action( 'dp_duplicate_page', $new_post_id, $post, $status );
 		} else {
 			do_action( 'dp_duplicate_post', $new_post_id, $post, $status );

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -73,7 +73,7 @@ function duplicate_post_clone_post_link( $link = null, $before = '', $after = ''
 		return;
 	}
 
-	if ( null === $link ) {
+	if ( $link === null ) {
 		$link = esc_html__( 'Copy to a new draft', 'duplicate-post' );
 	}
 

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -59,7 +59,7 @@ class Post_Duplicator {
 
 		$title           = '';
 		$new_post_status = $post->post_status;
-		if ( 'attachment' !== $post->post_type ) {
+		if ( $post->post_type !== 'attachment' ) {
 			$title           = $this->generate_copy_title( $post, $options );
 			$new_post_status = $this->generate_copy_status( $post, $options );
 		}

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -64,7 +64,7 @@ class Check_Changes_Handler {
 		global $wp_version;
 
 		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && 'duplicate_post_check_changes' === $_REQUEST['action'] ) ) ) { // Input var okay.
+			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_check_changes' ) ) ) { // Input var okay.
 			\wp_die(
 				\esc_html__( 'No post has been supplied!', 'duplicate-post' )
 			);
@@ -156,7 +156,7 @@ class Check_Changes_Handler {
 
 							$diff = \wp_text_diff( $content_from, $content_to, $args );
 
-							if ( ! $diff && 'post_title' === $field ) {
+							if ( ! $diff && $field === 'post_title' ) {
 								// It's a better user experience to still show the Title, even if it didn't change.
 								$diff  = '<table class="diff"><colgroup><col class="content diffsplit left"><col class="content diffsplit middle"><col class="content diffsplit right"></colgroup><tbody><tr>';
 								$diff .= '<td>' . \esc_html( $this->original->post_title ) . '</td><td></td><td>' . \esc_html( $this->post->post_title ) . '</td>';

--- a/src/handlers/class-link-handler.php
+++ b/src/handlers/class-link-handler.php
@@ -63,7 +63,7 @@ class Link_Handler {
 		}
 
 		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && 'duplicate_post_new_draft' === $_REQUEST['action'] ) ) ) { // Input var okay.
+			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_new_draft' ) ) ) { // Input var okay.
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
@@ -119,7 +119,7 @@ class Link_Handler {
 		}
 
 		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && 'duplicate_post_clone' === $_REQUEST['action'] ) ) ) { // Input var okay.
+			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_clone' ) ) ) { // Input var okay.
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
@@ -155,7 +155,7 @@ class Link_Handler {
 		$post_type = $post->post_type;
 		$sendback  = \wp_get_referer();
 		if ( ! $sendback || strpos( $sendback, 'post.php' ) !== false || strpos( $sendback, 'post-new.php' ) !== false ) {
-			if ( 'attachment' === $post_type ) {
+			if ( $post_type === 'attachment' ) {
 				$sendback = \admin_url( 'upload.php' );
 			} else {
 				$sendback = \admin_url( 'edit.php' );
@@ -191,7 +191,7 @@ class Link_Handler {
 		}
 
 		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && 'duplicate_post_rewrite' === $_REQUEST['action'] ) ) ) { // Input var okay.
+			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_rewrite' ) ) ) { // Input var okay.
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 

--- a/src/ui/class-column.php
+++ b/src/ui/class-column.php
@@ -83,7 +83,7 @@ class Column {
 	 * @return void
 	 */
 	public function show_original_item( $column_name, $post_id ) {
-		if ( 'duplicate_post_original_item' === $column_name ) {
+		if ( $column_name === 'duplicate_post_original_item' ) {
 			$column_content = '-';
 			$data_attr      = ' data-no-original="1"';
 			$original_item  = Utils::get_original( $post_id );
@@ -110,7 +110,7 @@ class Column {
 	 * @return void
 	 */
 	public function quick_edit_remove_original( $column_name ) {
-		if ( 'duplicate_post_original_item' !== $column_name ) {
+		if ( $column_name !== 'duplicate_post_original_item' ) {
 			return;
 		}
 		\printf(
@@ -153,7 +153,7 @@ class Column {
 	 * @return void
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'edit.php' === $hook ) {
+		if ( $hook === 'edit.php' ) {
 			$this->asset_manager->enqueue_quick_edit_script();
 		}
 	}
@@ -166,7 +166,7 @@ class Column {
 	 * @return void
 	 */
 	public function admin_enqueue_styles( $hook ) {
-		if ( 'edit.php' === $hook ) {
+		if ( $hook === 'edit.php' ) {
 			$this->asset_manager->enqueue_styles();
 		}
 	}

--- a/src/ui/class-link-builder.php
+++ b/src/ui/class-link-builder.php
@@ -77,7 +77,7 @@ class Link_Builder {
 			return '';
 		}
 
-		if ( 'display' === $context ) {
+		if ( $context === 'display' ) {
 			$action = '?action=' . $action_name . '&amp;post=' . $post->ID;
 		} else {
 			$action = '?action=' . $action_name . '&post=' . $post->ID;


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

YoastCS prohibits the use of Yoda conditions as it decreases the readability of code.

There are other sniffs in place to prevent accidentally using an assignment in a condition (which is what Yoda conditions is supposed to prevent).


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.