### PR TITLE
CS: various whitespace fixes

### DIFF
--- a/src/admin/class-options-page.php
+++ b/src/admin/class-options-page.php
@@ -14,6 +14,7 @@ use Yoast\WP\Duplicate_Post\Utils;
  * Class Options_Page
  */
 class Options_Page {
+
 	/**
 	 * The Options instance.
 	 *

--- a/src/class-revisions-migrator.php
+++ b/src/class-revisions-migrator.php
@@ -61,7 +61,7 @@ class Revisions_Migrator {
 
 		$revisions = \array_slice( $revisions, 0, $delete );
 
-		for ( $i = 0; isset( $revisions[ $i ] ); $i ++ ) {
+		for ( $i = 0; isset( $revisions[ $i ] ); $i++ ) {
 			if ( \strpos( $revisions[ $i ]->post_name, 'autosave' ) !== false ) {
 				continue;
 			}

--- a/tests/admin/class-options-page-test.php
+++ b/tests/admin/class-options-page-test.php
@@ -57,12 +57,11 @@ class Options_Page_Test extends TestCase {
 		$this->options        = Mockery::mock( Options::class )->makePartial();
 		$this->form_generator = Mockery::mock( Options_Form_Generator::class )->makePartial();
 		$this->asset_manager  = Mockery::mock( Asset_Manager::class );
-		$this->instance       = Mockery::mock(
-			Options_Page::class,
-			[ $this->options, $this->form_generator, $this->asset_manager ]
-		)
-		->makePartial()
-		->shouldAllowMockingProtectedMethods();
+
+		$parameters     = [ $this->options, $this->form_generator, $this->asset_manager ];
+		$this->instance = Mockery::mock( Options_Page::class, $parameters )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 	}
 
 	/**

--- a/tests/class-revisions-migrator-test.php
+++ b/tests/class-revisions-migrator-test.php
@@ -174,5 +174,4 @@ class Revisions_Migrator_Test extends TestCase {
 
 		$this->instance->migrate_revisions( $post_id, $original_id );
 	}
-
 }

--- a/tests/handlers/class-check-changes-handler-test.php
+++ b/tests/handlers/class-check-changes-handler-test.php
@@ -154,7 +154,6 @@ class Check_Changes_Handler_Test extends TestCase {
 		$this->instance->check_changes_action_handler();
 	}
 
-
 	/**
 	 * Tests the check_changes_action_handler function when there is no post.
 	 *

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -448,7 +448,6 @@ class Block_Editor_Test extends TestCase {
 		$this->instance->enqueue_block_editor_scripts();
 	}
 
-
 	/**
 	 * Tests the get_new_draft_permalink function when a link is returned.
 	 *

--- a/tests/ui/class-row-actions-test.php
+++ b/tests/ui/class-row-actions-test.php
@@ -50,7 +50,7 @@ class Row_Actions_Test extends TestCase {
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
 		$this->instance = Mockery::mock( Row_Actions::class, [ $this->link_builder, $this->permissions_helper ] )
-								->makePartial();
+			->makePartial();
 	}
 
 	/**

--- a/tests/watchers/class-bulk-actions-watcher-test.php
+++ b/tests/watchers/class-bulk-actions-watcher-test.php
@@ -54,7 +54,6 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 		$this->assertNotFalse( \has_action( 'admin_notices', [ $this->instance, 'add_bulk_rewrite_and_republish_admin_notice' ] ), 'Does not have expected admin_notices action' );
 	}
 
-
 	/**
 	 * Tests the add_removable_query_args function.
 	 *

--- a/tests/watchers/class-copied-post-watcher-test.php
+++ b/tests/watchers/class-copied-post-watcher-test.php
@@ -189,6 +189,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 
 		$this->expectOutputString( '' );
 	}
+
 	/**
 	 *
 	 * Tests the add_admin_notice function when the post does not have a copy intended for Rewrite & Republish.

--- a/tests/watchers/class-original-post-watcher-test.php
+++ b/tests/watchers/class-original-post-watcher-test.php
@@ -121,6 +121,7 @@ class Original_Post_Watcher_Test extends TestCase {
 
 		$this->expectOutputString( '' );
 	}
+
 	/**
 	 *
 	 * Tests the add_admin_notice function when the original has not changed.


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Variety of whitespace fixes:
* One blank line at the start of a class.
* One blank line between function declarations.
* No blank line at the end of a class.
* No space between an incrementor/decrementor and the variable it applies to.
* Multi-line chained object method calls should be indented one tab from the line containing the start of the statement.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.