### PR TITLE
CS: use pre-increment/decrement

### DIFF
--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -92,7 +92,7 @@ class Utils {
 		$parent             = \wp_get_post_parent_id( $post->ID );
 		while ( $parent ) {
 			if ( \in_array( $parent, $post_ids, true ) ) {
-				$ancestors_in_array++;
+				++$ancestors_in_array;
 			}
 			$parent = \wp_get_post_parent_id( $parent );
 		}

--- a/src/handlers/class-bulk-handler.php
+++ b/src/handlers/class-bulk-handler.php
@@ -99,7 +99,7 @@ class Bulk_Handler {
 				if ( ! empty( $post ) && $this->permissions_helper->should_rewrite_and_republish_be_allowed( $post ) ) {
 					$new_post_id = $this->post_duplicator->create_duplicate_for_rewrite_and_republish( $post );
 					if ( ! \is_wp_error( $new_post_id ) ) {
-						$counter ++;
+						++$counter;
 					}
 				}
 			}
@@ -131,7 +131,7 @@ class Bulk_Handler {
 						|| ( \is_post_type_hierarchical( $post->post_type ) && ! Utils::has_ancestors_marked( $post, $post_ids ) )
 					) {
 						if ( ! \is_wp_error( \duplicate_post_create_duplicate( $post ) ) ) {
-							$counter ++;
+							++$counter;
 						}
 					}
 				}


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* When using increment/decrement operators, pre-in/decrement should be favoured over post-in/decrement.
    Note: there is a difference in behaviour: the "pre" variant increments and returns, the "post" variant returns and increments after. This is a significant difference and the reason why "pre" should be favoured, though for stand-alone statement there is - in effect - no difference.
* Also: there should be no whitespace between the increment/decrement operator and the variable it applies to.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.