### PR TITLE
CS: use parentheses around arithmetic operations

### DIFF
--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -92,7 +92,7 @@ function duplicate_post_plugin_actions( $actions ) {
 		),
 	];
 
-	$actions = $settings_action + $actions;
+	$actions = ( $settings_action + $actions );
 	return $actions;
 }
 

--- a/src/class-revisions-migrator.php
+++ b/src/class-revisions-migrator.php
@@ -54,7 +54,7 @@ class Revisions_Migrator {
 		}
 
 		$revisions = \wp_get_post_revisions( $original_post, [ 'order' => 'ASC' ] );
-		$delete    = \count( $revisions ) - $revisions_to_keep;
+		$delete    = ( \count( $revisions ) - $revisions_to_keep );
 		if ( $delete < 1 ) {
 			return;
 		}


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Always use parentheses around arithmetic operations to prevent potential issues with operator precedence.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.