### PR TITLE
Docs: various minor formatting fixes

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -366,6 +366,7 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	}
 
 	$meta_blacklist = apply_filters_deprecated( 'duplicate_post_blacklist_filter', [ $meta_blacklist ], '3.2.5', 'duplicate_post_excludelist_filter' );
+
 	/**
 	 * Filters the meta fields excludelist when copying a post.
 	 *

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -21,6 +21,7 @@ function duplicate_post_is_post_type_enabled( $post_type ) {
 	if ( ! is_array( $duplicate_post_types_enabled ) ) {
 		$duplicate_post_types_enabled = [ $duplicate_post_types_enabled ];
 	}
+
 	/** This filter is documented in src/class-permissions-helper.php */
 	$duplicate_post_types_enabled = apply_filters( 'duplicate_post_enabled_post_types', $duplicate_post_types_enabled );
 	return in_array( $post_type, $duplicate_post_types_enabled, true );

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -1,15 +1,18 @@
 <?php
 /**
- * Plugin Name: Yoast Duplicate Post
- * Plugin URI: https://yoast.com/wordpress/plugins/duplicate-post/
- * Description: The go-to tool for cloning posts and pages, including the powerful Rewrite & Republish feature.
- * Version: 4.1.2-RC1
- * Author: Enrico Battocchi & Team Yoast
- * Author URI: https://yoast.com
- * Text Domain: duplicate-post
+ * Duplicate Post plugin.
  *
  * @package Duplicate Post
  * @since 0.1
+ *
+ * @wordpress-plugin
+ * Plugin Name: Yoast Duplicate Post
+ * Plugin URI:  https://yoast.com/wordpress/plugins/duplicate-post/
+ * Description: The go-to tool for cloning posts and pages, including the powerful Rewrite & Republish feature.
+ * Version:     4.1.2-RC1
+ * Author:      Enrico Battocchi & Team Yoast
+ * Author URI:  https://yoast.com
+ * Text Domain: duplicate-post
  *
  * Copyright 2020 Yoast BV (email : info@yoast.com)
  *

--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -291,10 +291,11 @@ class Options_Form_Generator {
 	/**
 	 * Checks whether or not a post type is enabled.
 	 *
+	 * @codeCoverageIgnore As this is a simple wrapper for a function that is also being used elsewhere, we can skip testing for now.
+	 *
 	 * @param string $post_type The post type.
 	 *
 	 * @return bool Whether or not the post type is enabled.
-	 * @codeCoverageIgnore As this is a simple wrapper for a function that is also being used elsewhere, we can skip testing for now.
 	 */
 	public function is_post_type_enabled( $post_type ) {
 		$duplicate_post_types_enabled = \get_option( 'duplicate_post_types_enabled', [ 'post', 'page' ] );

--- a/src/admin/class-options-inputs.php
+++ b/src/admin/class-options-inputs.php
@@ -15,11 +15,11 @@ class Options_Inputs {
 	/**
 	 * Creates a basic input based on the passed parameters.
 	 *
-	 * @param string $type          The type of input.
-	 * @param string $name          The name of the input.
-	 * @param string $value         The value of the input.
-	 * @param string $id            The ID of the input.
-	 * @param string $attributes    The additional attributes to use. Optional.
+	 * @param string $type       The type of input.
+	 * @param string $name       The name of the input.
+	 * @param string $value      The value of the input.
+	 * @param string $id         The ID of the input.
+	 * @param string $attributes The additional attributes to use. Optional.
 	 *
 	 * @return string The input's HTML output.
 	 */
@@ -37,9 +37,9 @@ class Options_Inputs {
 	/**
 	 * Creates a checkbox input.
 	 *
-	 * @param string $name The name of the checkbox.
-	 * @param string $value The value of the checkbox.
-	 * @param string $id The ID of the checkbox.
+	 * @param string $name    The name of the checkbox.
+	 * @param string $value   The value of the checkbox.
+	 * @param string $id      The ID of the checkbox.
 	 * @param bool   $checked Whether or not the checkbox should be checked.
 	 *
 	 * @return string The checkbox' HTML output.
@@ -53,9 +53,9 @@ class Options_Inputs {
 	/**
 	 * Creates a text field input.
 	 *
-	 * @param string $name The name of the text field.
+	 * @param string $name  The name of the text field.
 	 * @param string $value The value of the text field.
-	 * @param string $id The ID of the text field.
+	 * @param string $id    The ID of the text field.
 	 *
 	 * @return string The text field's HTML output.
 	 */
@@ -66,9 +66,9 @@ class Options_Inputs {
 	/**
 	 * Creates a number input.
 	 *
-	 * @param string $name The name of the number input.
+	 * @param string $name  The name of the number input.
 	 * @param string $value The value of the number input.
-	 * @param string $id The ID of the number input.
+	 * @param string $id    The ID of the number input.
 	 *
 	 * @return string The number input's HTML output.
 	 */

--- a/src/admin/class-options-page.php
+++ b/src/admin/class-options-page.php
@@ -90,11 +90,12 @@ class Options_Page {
 	/**
 	 * Generates the inputs for the specified tab / fieldset.
 	 *
+	 * @codeCoverageIgnore As this is a simple wrapper for two functions that are already tested elsewhere, we can skip testing.
+	 *
 	 * @param string $tab      The tab to get the configuration for.
 	 * @param string $fieldset The fieldset to get the configuration for. Optional.
 	 *
 	 * @return string The HTML output for the controls present on the tab / fieldset.
-	 * @codeCoverageIgnore As this is a simple wrapper for two functions that are already tested elsewhere, we can skip testing.
 	 */
 	public function generate_tab_inputs( $tab, $fieldset = '' ) {
 		$options = $this->options->get_options_for_tab( $tab, $fieldset );
@@ -105,10 +106,11 @@ class Options_Page {
 	/**
 	 * Generates an input for a single option.
 	 *
+	 * @codeCoverageIgnore As this is a simple wrapper for two functions that are already tested elsewhere, we can skip testing.
+	 *
 	 * @param string $option The option configuration to base the input on.
 	 *
 	 * @return string The input HTML.
-	 * @codeCoverageIgnore As this is a simple wrapper for two functions that are already tested elsewhere, we can skip testing.
 	 */
 	public function generate_input( $option ) {
 		return $this->generator->generate_options_input( $this->options->get_option( $option ) );
@@ -144,8 +146,9 @@ class Options_Page {
 	/**
 	 * Generates the options page.
 	 *
-	 * @return void
 	 * @codeCoverageIgnore
+	 *
+	 * @return void
 	 */
 	public function generate_page() {
 		$this->register_capabilities();

--- a/src/admin/class-options.php
+++ b/src/admin/class-options.php
@@ -77,8 +77,9 @@ class Options {
 	/**
 	 * Gets the list of registered options.
 	 *
-	 * @return array The options.
 	 * @codeCoverageIgnore
+	 *
+	 * @return array The options.
 	 */
 	public function get_options() {
 		return [

--- a/src/admin/views/options.php
+++ b/src/admin/views/options.php
@@ -214,7 +214,7 @@ if ( ! defined( 'DUPLICATE_POST_CURRENT_VERSION' ) ) {
 							<br/>
 							<?php
 							\printf(
-							/* translators: 1: Code start tag, 2: Code closing tag, 3: Link start tag to the template tag documentation, 4: Link closing tag. */
+								/* translators: 1: Code start tag, 2: Code closing tag, 3: Link start tag to the template tag documentation, 4: Link closing tag. */
 								\esc_html__( 'You can also use the template tag %1$sduplicate_post_clone_post_link( $link, $before, $after, $id )%2$s. %3$sMore info on the template tag%4$s.', 'duplicate-post' ),
 								'<code>',
 								'</code>',

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -335,7 +335,7 @@ class Post_Duplicator {
 		if ( $options['copy_status'] ) {
 			$new_post_status = $post->post_status;
 			if ( $new_post_status === 'publish' || $new_post_status === 'future' ) {
-				// check if the user has the right capability.
+				// Check if the user has the right capability.
 				if ( \is_post_type_hierarchical( $post->post_type ) ) {
 					if ( ! \current_user_can( 'publish_pages' ) ) {
 						$new_post_status = 'pending';
@@ -363,7 +363,7 @@ class Post_Duplicator {
 		$new_post_author    = \wp_get_current_user();
 		$new_post_author_id = $new_post_author->ID;
 		if ( $options['copy_author'] ) {
-			// check if the user has the right capability.
+			// Check if the user has the right capability.
 			if ( \is_post_type_hierarchical( $post->post_type ) ) {
 				if ( \current_user_can( 'edit_others_pages' ) ) {
 					$new_post_author_id = $post->post_author;

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -279,8 +279,8 @@ class Post_Republisher {
 	/**
 	 * Deletes the copy and associated post meta, if applicable.
 	 *
-	 * @param int      $copy_id The copy's ID.
-	 * @param int|null $post_id The original post's ID. Optional.
+	 * @param int      $copy_id            The copy's ID.
+	 * @param int|null $post_id            The original post's ID. Optional.
 	 * @param bool     $permanently_delete Whether to permanently delete the copy. Defaults to true.
 	 *
 	 * @return void

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -163,8 +163,9 @@ class Utils {
 	/**
 	 * Gets the registered WordPress roles.
 	 *
-	 * @return array The roles.
 	 * @codeCoverageIgnore As this is a simple wrapper method for a built-in WordPress method, we don't have to test it.
+	 *
+	 * @return array The roles.
 	 */
 	public static function get_roles() {
 		global $wp_roles;

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -108,7 +108,7 @@ class Check_Changes_Handler {
 			<h1 class="long-header">
 			<?php
 				echo \sprintf(
-						/* translators: %s: original item link (to view or edit) or title. */
+					/* translators: %s: original item link (to view or edit) or title. */
 					\esc_html__( 'Compare changes of duplicated post with the original (&#8220;%s&#8221;)', 'duplicate-post' ),
 					Utils::get_edit_or_view_link( $this->original ) // phpcs:ignore WordPress.Security.EscapeOutput
 				);
@@ -141,6 +141,7 @@ class Check_Changes_Handler {
 						}
 
 						$post_array = \get_post( $this->post, \ARRAY_A );
+
 						/** This filter is documented in wp-admin/includes/revision.php */
 						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
 						$fields = \apply_filters( '_wp_post_revision_fields', $fields, $post_array );

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -254,7 +254,7 @@ class Classic_Editor {
 
 		if ( $post->post_type === 'post' ) {
 			$messages['post'][9] = \sprintf(
-			/* translators: 1: The post title with a link to the frontend page, 2: The scheduled date and time. */
+				/* translators: 1: The post title with a link to the frontend page, 2: The scheduled date and time. */
 				\esc_html__(
 					'This rewritten post %1$s is now scheduled to replace the original post. It will be published on %2$s.',
 					'duplicate-post'
@@ -267,7 +267,7 @@ class Classic_Editor {
 
 		if ( $post->post_type === 'page' ) {
 			$messages['page'][9] = \sprintf(
-					/* translators: 1: The page title with a link to the frontend page, 2: The scheduled date and time. */
+				/* translators: 1: The page title with a link to the frontend page, 2: The scheduled date and time. */
 				\esc_html__(
 					'This rewritten page %1$s is now scheduled to replace the original page. It will be published on %2$s.',
 					'duplicate-post'

--- a/src/ui/class-link-builder.php
+++ b/src/ui/class-link-builder.php
@@ -17,8 +17,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for duplication action for the Rewrite & Republish feature.
 	 *
-	 * @param int|\WP_Post $post        The post object or ID.
-	 * @param string       $context     The context in which the URL will be used.
+	 * @param int|\WP_Post $post    The post object or ID.
+	 * @param string       $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -29,8 +29,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for the "Clone" action.
 	 *
-	 * @param int|\WP_Post $post        The post object or ID.
-	 * @param string       $context     The context in which the URL will be used.
+	 * @param int|\WP_Post $post    The post object or ID.
+	 * @param string       $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -41,8 +41,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for the "Copy to a new draft" action.
 	 *
-	 * @param int|\WP_Post $post        The post object or ID.
-	 * @param string       $context     The context in which the URL will be used.
+	 * @param int|\WP_Post $post    The post object or ID.
+	 * @param string       $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -53,8 +53,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for the "Check Changes" action.
 	 *
-	 * @param int|\WP_Post $post        The post object or ID.
-	 * @param string       $context     The context in which the URL will be used.
+	 * @param int|\WP_Post $post    The post object or ID.
+	 * @param string       $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -84,16 +84,16 @@ class Link_Builder {
 		}
 
 		return \wp_nonce_url(
-		/**
-		 * Filter on the URL of the clone link
-		 *
-		 * @param string $url           The URL of the clone link.
-		 * @param int    $ID            The ID of the post
-		 * @param string $context       The context in which the URL is used.
-		 * @param string $action_name   The action name.
-		 *
-		 * @return string
-		 */
+			/**
+			 * Filter on the URL of the clone link
+			 *
+			 * @param string $url           The URL of the clone link.
+			 * @param int    $ID            The ID of the post
+			 * @param string $context       The context in which the URL is used.
+			 * @param string $action_name   The action name.
+			 *
+			 * @return string
+			 */
 			\apply_filters( 'duplicate_post_get_clone_post_link', \admin_url( 'admin.php' . $action ), $post->ID, $context, $action_name ),
 			$action_name . '_' . $post->ID
 		);

--- a/src/ui/class-metabox.php
+++ b/src/ui/class-metabox.php
@@ -100,7 +100,7 @@ class Metabox {
 			<?php
 			\printf(
 				\wp_kses(
-				/* translators: %s: post title */
+					/* translators: %s: post title */
 					\__(
 						'The original item this was copied from is: <span class="duplicate_post_original_item_title_span">%s</span>',
 						'duplicate-post'

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -86,7 +86,7 @@ class Row_Actions {
 
 		$actions['clone'] = '<a href="' . $this->link_builder->build_clone_link( $post->ID ) .
 			'" aria-label="' . \esc_attr(
-			/* translators: %s: Post title. */
+				/* translators: %s: Post title. */
 				\sprintf( \__( 'Clone &#8220;%s&#8221;', 'duplicate-post' ), $title )
 			) . '">' .
 			\esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
@@ -113,7 +113,7 @@ class Row_Actions {
 
 		$actions['edit_as_new_draft'] = '<a href="' . $this->link_builder->build_new_draft_link( $post->ID ) .
 			'" aria-label="' . \esc_attr(
-			/* translators: %s: Post title. */
+				/* translators: %s: Post title. */
 				\sprintf( \__( 'New draft of &#8220;%s&#8221;', 'duplicate-post' ), $title )
 			) . '">' .
 			\esc_html__( 'New Draft', 'duplicate-post' ) .
@@ -144,7 +144,7 @@ class Row_Actions {
 
 		$actions['rewrite'] = '<a href="' . $this->link_builder->build_rewrite_and_republish_link( $post->ID ) .
 			'" aria-label="' . \esc_attr(
-			/* translators: %s: Post title. */
+				/* translators: %s: Post title. */
 				\sprintf( \__( 'Rewrite & Republish &#8220;%s&#8221;', 'duplicate-post' ), $title )
 			) . '">' .
 			\esc_html_x( 'Rewrite & Republish', 'verb', 'duplicate-post' ) . '</a>';

--- a/src/watchers/class-bulk-actions-watcher.php
+++ b/src/watchers/class-bulk-actions-watcher.php
@@ -56,7 +56,7 @@ class Bulk_Actions_Watcher {
 			\printf(
 				'<div id="message" class="notice notice-success fade"><p>' .
 				\esc_html(
-				/* translators: %s: Number of posts copied. */
+					/* translators: %s: Number of posts copied. */
 					\_n(
 						'%s item copied.',
 						'%s items copied.',
@@ -80,7 +80,7 @@ class Bulk_Actions_Watcher {
 			\printf(
 				'<div id="message" class="notice notice-success fade"><p>' .
 				\esc_html(
-				/* translators: %s: Number of posts copied. */
+					/* translators: %s: Number of posts copied. */
 					\_n(
 						'%s post duplicated. You can now start rewriting your post in the duplicate of the original post. Once you choose to republish it your changes will be merged back into the original post.',
 						'%s posts duplicated. You can now start rewriting your posts in the duplicates of the original posts. Once you choose to republish them your changes will be merged back into the original post.',

--- a/src/watchers/class-link-actions-watcher.php
+++ b/src/watchers/class-link-actions-watcher.php
@@ -74,7 +74,7 @@ class Link_Actions_Watcher {
 			\printf(
 				'<div id="message" class="notice notice-success fade"><p>' .
 				\esc_html(
-				/* translators: %s: Number of posts copied. */
+					/* translators: %s: Number of posts copied. */
 					\_n(
 						'%s item copied.',
 						'%s items copied.',

--- a/tests/admin/class-options-form-generator-test.php
+++ b/tests/admin/class-options-form-generator-test.php
@@ -380,10 +380,10 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @dataProvider is_checked_provider
 	 * @covers       \Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator::is_checked
 	 *
-	 * @param string $option The option name.
+	 * @param string $option        The option name.
 	 * @param array  $option_values The option values.
 	 * @param string $parent_option The parent option.
-	 * @param array  $assertion The assumed assertion values.
+	 * @param array  $assertion     The assumed assertion values.
 	 */
 	public function test_is_checked( $option, $option_values, $parent_option, $assertion = [] ) {
 		if ( $assertion['expected'] === false ) {

--- a/tests/watchers/class-copied-post-watcher-test.php
+++ b/tests/watchers/class-copied-post-watcher-test.php
@@ -190,7 +190,6 @@ class Copied_Post_Watcher_Test extends TestCase {
 		$this->expectOutputString( '' );
 	}
 	/**
-	 *
 	 * Tests the add_admin_notice function when the post does not have a copy intended for Rewrite & Republish.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_admin_notice

--- a/tests/watchers/class-original-post-watcher-test.php
+++ b/tests/watchers/class-original-post-watcher-test.php
@@ -122,7 +122,6 @@ class Original_Post_Watcher_Test extends TestCase {
 		$this->expectOutputString( '' );
 	}
 	/**
-	 *
 	 * Tests the add_admin_notice function when the original has not changed.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_admin_notice


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

Variety of formatting fixes to docblocks.

* Blank line before a docblock.
* No blank line at the start of a docblock.
* Alignment of the parameter descriptions.
* Use a capital as the first character of a comment.
* Docblock tag order - the `@param` and `@return` and optionally `@throws` tags should always come last.
* Fix the indentation of a docblock.
* Fix the indentation of numerous translators comments.

Includes fixing up the file docblock of the main plugin file.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.