### PR TITLE
Docs: remove unsupported `@ignore` tag

### DIFF
--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -115,7 +115,6 @@ class Options_Form_Generator {
 	 * @param \WP_Taxonomy $taxonomy2 Second taxonomy object.
 	 *
 	 * @return bool True when the first taxonomy is public.
-	 * @ignore
 	 */
 	public function sort_taxonomy_objects( $taxonomy1, $taxonomy2 ) {
 		return ( $taxonomy1->public < $taxonomy2->public );


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

The `@ignore` tag is rarely used and only really supported by phpDocumentor. Unless phpDocumentor is used (which it is not for this project at this time), the tag should not be used.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.