### PR TITLE
CS: else(if) must be on new line

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -54,6 +54,9 @@
 
 		<!-- Demanding Yoda conditions is stupid. -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
+
+		<!-- YoastCS demands else on new line. -->
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 	</rule>
 
 	<config name="testVersion" value="5.5-"/>

--- a/compat/duplicate-post-gutenberg.php
+++ b/compat/duplicate-post-gutenberg.php
@@ -31,7 +31,8 @@ function duplicate_post_classic_editor_clone_link( $url, $post_id, $context, $dr
 		|| ( $draft && function_exists( 'has_blocks' ) && ! has_blocks( $post ) ) ) {
 		if ( $context === 'display' ) {
 			$url .= '&amp;classic-editor';
-		} else {
+		}
+		else {
 			$url .= '&classic-editor';
 		}
 	}

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -40,7 +40,8 @@ function duplicate_post_admin_init() {
 	if ( intval( get_site_option( 'duplicate_post_show_notice' ) ) === 1 ) {
 		if ( is_multisite() ) {
 			add_action( 'network_admin_notices', 'duplicate_post_show_update_notice' );
-		} else {
+		}
+		else {
 			add_action( 'admin_notices', 'duplicate_post_show_update_notice' );
 		}
 		add_action( 'wp_ajax_duplicate_post_dismiss_notice', 'duplicate_post_dismiss_notice' );
@@ -349,7 +350,8 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 	$meta_blacklist = get_option( 'duplicate_post_blacklist' );
 	if ( $meta_blacklist === '' ) {
 		$meta_blacklist = [];
-	} else {
+	}
+	else {
 		$meta_blacklist = explode( ',', $meta_blacklist );
 		$meta_blacklist = array_filter( $meta_blacklist );
 		$meta_blacklist = array_map( 'trim', $meta_blacklist );
@@ -386,7 +388,8 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 				$meta_keys[] = $meta_key;
 			}
 		}
-	} else {
+	}
+	else {
 		$meta_keys = array_diff( $post_meta_keys, $meta_blacklist );
 	}
 
@@ -420,7 +423,8 @@ function duplicate_post_copy_post_meta_info( $new_id, $post ) {
 function duplicate_post_addslashes_deep( $value ) {
 	if ( function_exists( 'map_deep' ) ) {
 		return map_deep( $value, 'duplicate_post_addslashes_to_strings_only' );
-	} else {
+	}
+	else {
 		return wp_slash( $value );
 	}
 }
@@ -645,7 +649,8 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 			if ( ! empty( $suffix ) ) {
 				$suffix = ' ' . $suffix;
 			}
-		} else {
+		}
+		else {
 			$title = ' ';
 		}
 		$title = trim( $prefix . $title . $suffix );
@@ -660,14 +665,16 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 
 		if ( intval( get_option( 'duplicate_post_copystatus' ) ) === 0 ) {
 			$new_post_status = 'draft';
-		} else {
+		}
+		else {
 			if ( $new_post_status === 'publish' || $new_post_status === 'future' ) {
 				// Check if the user has the right capability.
 				if ( is_post_type_hierarchical( $post->post_type ) ) {
 					if ( ! current_user_can( 'publish_pages' ) ) {
 						$new_post_status = 'pending';
 					}
-				} else {
+				}
+				else {
 					if ( ! current_user_can( 'publish_posts' ) ) {
 						$new_post_status = 'pending';
 					}
@@ -684,7 +691,8 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 			if ( current_user_can( 'edit_others_pages' ) ) {
 				$new_post_author_id = $post->post_author;
 			}
-		} else {
+		}
+		else {
 			if ( current_user_can( 'edit_others_posts' ) ) {
 				$new_post_author_id = $post->post_author;
 			}
@@ -743,7 +751,8 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 
 		if ( $post->post_type === 'page' || is_post_type_hierarchical( $post->post_type ) ) {
 			do_action( 'dp_duplicate_page', $new_post_id, $post, $status );
-		} else {
+		}
+		else {
 			do_action( 'dp_duplicate_post', $new_post_id, $post, $status );
 		}
 

--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -50,7 +50,8 @@ function duplicate_post_get_clone_post_link( $id = 0, $context = 'display', $dra
 
 	if ( $draft ) {
 		return $link_builder->build_new_draft_link( $post, $context );
-	} else {
+	}
+	else {
 		return $link_builder->build_clone_link( $post, $context );
 	}
 }

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -272,7 +272,8 @@ class Post_Duplicator {
 					$meta_keys[] = $meta_key;
 				}
 			}
-		} else {
+		}
+		else {
 			$meta_keys = \array_diff( $post_meta_keys, $meta_excludelist );
 		}
 
@@ -315,7 +316,8 @@ class Post_Duplicator {
 			if ( ! empty( $suffix ) ) {
 				$suffix = ' ' . $suffix;
 			}
-		} else {
+		}
+		else {
 			$title = '';
 		}
 		return \trim( $prefix . $title . $suffix );
@@ -340,7 +342,8 @@ class Post_Duplicator {
 					if ( ! \current_user_can( 'publish_pages' ) ) {
 						$new_post_status = 'pending';
 					}
-				} else {
+				}
+				else {
 					if ( ! \current_user_can( 'publish_posts' ) ) {
 						$new_post_status = 'pending';
 					}
@@ -368,7 +371,8 @@ class Post_Duplicator {
 				if ( \current_user_can( 'edit_others_pages' ) ) {
 					$new_post_author_id = $post->post_author;
 				}
-			} else {
+			}
+			else {
 				if ( \current_user_can( 'edit_others_posts' ) ) {
 					$new_post_author_id = $post->post_author;
 				}

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -222,7 +222,8 @@ class Post_Republisher {
 
 			if ( \intval( \get_post_meta( $copy_id, '_dp_has_been_republished', true ) ) === 1 ) {
 				$this->delete_copy( $copy_id, $post_id );
-			} else {
+			}
+			else {
 				\wp_die( \esc_html__( 'An error occurred while deleting the Rewrite & Republish copy.', 'duplicate-post' ) );
 			}
 		}

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -124,7 +124,8 @@ class Utils {
 				\esc_attr( \sprintf( \__( 'Edit &#8220;%s&#8221;', 'default' ), $title ) ),
 				$title
 			);
-		} elseif ( \is_post_type_viewable( $post_type_object ) ) {
+		}
+		elseif ( \is_post_type_viewable( $post_type_object ) ) {
 			if ( \in_array( $post->post_status, [ 'pending', 'draft', 'future' ], true ) ) {
 				if ( $can_edit_post ) {
 					$preview_link = \get_preview_post_link( $post );
@@ -136,7 +137,8 @@ class Utils {
 						$title
 					);
 				}
-			} elseif ( $post->post_status !== 'trash' ) {
+			}
+			elseif ( $post->post_status !== 'trash' ) {
 				return \sprintf(
 					'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
 					\get_permalink( $post->ID ),

--- a/src/handlers/class-link-handler.php
+++ b/src/handlers/class-link-handler.php
@@ -157,13 +157,15 @@ class Link_Handler {
 		if ( ! $sendback || strpos( $sendback, 'post.php' ) !== false || strpos( $sendback, 'post-new.php' ) !== false ) {
 			if ( $post_type === 'attachment' ) {
 				$sendback = \admin_url( 'upload.php' );
-			} else {
+			}
+			else {
 				$sendback = \admin_url( 'edit.php' );
 				if ( ! empty( $post_type ) ) {
 					$sendback = \add_query_arg( 'post_type', $post_type, $sendback );
 				}
 			}
-		} else {
+		}
+		else {
 			$sendback = \remove_query_arg( [ 'trashed', 'untrashed', 'deleted', 'cloned', 'ids' ], $sendback );
 		}
 

--- a/src/ui/class-admin-bar.php
+++ b/src/ui/class-admin-bar.php
@@ -111,7 +111,8 @@ class Admin_Bar {
 					'href'   => $this->link_builder->build_rewrite_and_republish_link( $post ),
 				]
 			);
-		} else {
+		}
+		else {
 			if ( $show_new_draft ) {
 				$wp_admin_bar->add_menu(
 					[
@@ -167,7 +168,8 @@ class Admin_Bar {
 
 		if ( \is_admin() ) {
 			$post = \get_post();
-		} else {
+		}
+		else {
 			$post = $wp_the_query->get_queried_object();
 		}
 

--- a/src/ui/class-link-builder.php
+++ b/src/ui/class-link-builder.php
@@ -79,7 +79,8 @@ class Link_Builder {
 
 		if ( $context === 'display' ) {
 			$action = '?action=' . $action_name . '&amp;post=' . $post->ID;
-		} else {
+		}
+		else {
 			$action = '?action=' . $action_name . '&post=' . $post->ID;
 		}
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

YoastCS enforces that a potential `else[if]` starts on a new line, rather than straight after the closing `}` of the preceding `[else]if`.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.