### PR TITLE
 CS: consistent placement of operators

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -210,10 +210,9 @@ function duplicate_post_show_update_notice() {
 	}
 
 	$current_screen = get_current_screen();
-	if (
-		empty( $current_screen ) ||
-		empty( $current_screen->base ) ||
-		( $current_screen->base !== 'dashboard' && $current_screen->base !== 'plugins' )
+	if ( empty( $current_screen )
+		|| empty( $current_screen->base )
+		|| ( $current_screen->base !== 'dashboard' && $current_screen->base !== 'plugins' )
 	) {
 		return;
 	}

--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -624,8 +624,8 @@ function duplicate_post_create_duplicate( $post, $status = '', $parent_id = '' )
 	if ( ! duplicate_post_is_post_type_enabled( $post->post_type ) && $post->post_type !== 'attachment' ) {
 		wp_die(
 			esc_html(
-				__( 'Copy features for this post type are not enabled in options page', 'duplicate-post' ) . ': ' .
-				$post->post_type
+				__( 'Copy features for this post type are not enabled in options page', 'duplicate-post' ) . ': '
+				. $post->post_type
 			)
 		);
 	}

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -63,8 +63,8 @@ class Check_Changes_Handler {
 	public function check_changes_action_handler() {
 		global $wp_version;
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_check_changes' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_check_changes' ) ) ) { // Input var okay.
 			\wp_die(
 				\esc_html__( 'No post has been supplied!', 'duplicate-post' )
 			);

--- a/src/handlers/class-link-handler.php
+++ b/src/handlers/class-link-handler.php
@@ -62,8 +62,8 @@ class Link_Handler {
 			\wp_die( \esc_html__( 'Current user is not allowed to copy posts.', 'duplicate-post' ) );
 		}
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_new_draft' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_new_draft' ) ) ) { // Input var okay.
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
@@ -118,8 +118,8 @@ class Link_Handler {
 			\wp_die( \esc_html__( 'Current user is not allowed to copy posts.', 'duplicate-post' ) );
 		}
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_clone' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_clone' ) ) ) { // Input var okay.
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
@@ -190,8 +190,8 @@ class Link_Handler {
 			\wp_die( \esc_html__( 'Current user is not allowed to copy posts.', 'duplicate-post' ) );
 		}
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) || // Input var okay.
-			( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_rewrite' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_rewrite' ) ) ) { // Input var okay.
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -84,12 +84,12 @@ class Row_Actions {
 
 		$title = \_draft_or_post_title( $post );
 
-		$actions['clone'] = '<a href="' . $this->link_builder->build_clone_link( $post->ID ) .
-			'" aria-label="' . \esc_attr(
+		$actions['clone'] = '<a href="' . $this->link_builder->build_clone_link( $post->ID )
+			. '" aria-label="' . \esc_attr(
 				/* translators: %s: Post title. */
 				\sprintf( \__( 'Clone &#8220;%s&#8221;', 'duplicate-post' ), $title )
-			) . '">' .
-			\esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
+			) . '">'
+			. \esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
 
 		return $actions;
 	}
@@ -111,13 +111,13 @@ class Row_Actions {
 
 		$title = \_draft_or_post_title( $post );
 
-		$actions['edit_as_new_draft'] = '<a href="' . $this->link_builder->build_new_draft_link( $post->ID ) .
-			'" aria-label="' . \esc_attr(
+		$actions['edit_as_new_draft'] = '<a href="' . $this->link_builder->build_new_draft_link( $post->ID )
+			. '" aria-label="' . \esc_attr(
 				/* translators: %s: Post title. */
 				\sprintf( \__( 'New draft of &#8220;%s&#8221;', 'duplicate-post' ), $title )
-			) . '">' .
-			\esc_html__( 'New Draft', 'duplicate-post' ) .
-			'</a>';
+			) . '">'
+			. \esc_html__( 'New Draft', 'duplicate-post' )
+			. '</a>';
 
 		return $actions;
 	}
@@ -142,12 +142,12 @@ class Row_Actions {
 
 		$title = \_draft_or_post_title( $post );
 
-		$actions['rewrite'] = '<a href="' . $this->link_builder->build_rewrite_and_republish_link( $post->ID ) .
-			'" aria-label="' . \esc_attr(
+		$actions['rewrite'] = '<a href="' . $this->link_builder->build_rewrite_and_republish_link( $post->ID )
+			. '" aria-label="' . \esc_attr(
 				/* translators: %s: Post title. */
 				\sprintf( \__( 'Rewrite & Republish &#8220;%s&#8221;', 'duplicate-post' ), $title )
-			) . '">' .
-			\esc_html_x( 'Rewrite & Republish', 'verb', 'duplicate-post' ) . '</a>';
+			) . '">'
+			. \esc_html_x( 'Rewrite & Republish', 'verb', 'duplicate-post' ) . '</a>';
 
 		return $actions;
 	}

--- a/src/watchers/class-bulk-actions-watcher.php
+++ b/src/watchers/class-bulk-actions-watcher.php
@@ -54,8 +54,8 @@ class Bulk_Actions_Watcher {
 		if ( ! empty( $_REQUEST['bulk_cloned'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$copied_posts = \intval( $_REQUEST['bulk_cloned'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			\printf(
-				'<div id="message" class="notice notice-success fade"><p>' .
-				\esc_html(
+				'<div id="message" class="notice notice-success fade"><p>'
+				. \esc_html(
 					/* translators: %s: Number of posts copied. */
 					\_n(
 						'%s item copied.',
@@ -78,8 +78,8 @@ class Bulk_Actions_Watcher {
 		if ( ! empty( $_REQUEST['bulk_rewriting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$copied_posts = \intval( $_REQUEST['bulk_rewriting'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			\printf(
-				'<div id="message" class="notice notice-success fade"><p>' .
-				\esc_html(
+				'<div id="message" class="notice notice-success fade"><p>'
+				. \esc_html(
 					/* translators: %s: Number of posts copied. */
 					\_n(
 						'%s post duplicated. You can now start rewriting your post in the duplicate of the original post. Once you choose to republish it your changes will be merged back into the original post.',

--- a/src/watchers/class-copied-post-watcher.php
+++ b/src/watchers/class-copied-post-watcher.php
@@ -93,9 +93,9 @@ class Copied_Post_Watcher {
 		}
 
 		if ( $this->permissions_helper->has_rewrite_and_republish_copy( $post ) ) {
-			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>' .
-				\esc_html( $this->get_notice_text( $post ) ) .
-				'</p></div>';
+			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>'
+				. \esc_html( $this->get_notice_text( $post ) )
+				. '</p></div>';
 		}
 	}
 

--- a/src/watchers/class-link-actions-watcher.php
+++ b/src/watchers/class-link-actions-watcher.php
@@ -72,8 +72,8 @@ class Link_Actions_Watcher {
 
 			$copied_posts = \intval( $_REQUEST['cloned'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			\printf(
-				'<div id="message" class="notice notice-success fade"><p>' .
-				\esc_html(
+				'<div id="message" class="notice notice-success fade"><p>'
+				. \esc_html(
 					/* translators: %s: Number of posts copied. */
 					\_n(
 						'%s item copied.',
@@ -98,11 +98,11 @@ class Link_Actions_Watcher {
 				return;
 			}
 
-			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>' .
-			\esc_html__(
-				'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", your changes will be merged into the original post and you’ll be redirected there.',
-				'duplicate-post'
-			) . '</p></div>';
+			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>'
+				. \esc_html__(
+					'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", your changes will be merged into the original post and you’ll be redirected there.',
+					'duplicate-post'
+				) . '</p></div>';
 		}
 	}
 

--- a/src/watchers/class-original-post-watcher.php
+++ b/src/watchers/class-original-post-watcher.php
@@ -74,9 +74,9 @@ class Original_Post_Watcher {
 		}
 
 		if ( $this->permissions_helper->has_original_changed( $post ) ) {
-			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>' .
-				\esc_html( $this->get_notice_text() ) .
-				'</p></div>';
+			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>'
+				. \esc_html( $this->get_notice_text() )
+				. '</p></div>';
 		}
 	}
 

--- a/src/watchers/class-republished-post-watcher.php
+++ b/src/watchers/class-republished-post-watcher.php
@@ -83,9 +83,9 @@ class Republished_Post_Watcher {
 		}
 
 		if ( ! empty( $_REQUEST['dprepublished'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			echo '<div id="message" class="notice notice-success is-dismissible"><p>' .
-				\esc_html( $this->get_notice_text() ) .
-				'</p></div>';
+			echo '<div id="message" class="notice notice-success is-dismissible"><p>'
+				. \esc_html( $this->get_notice_text() )
+				. '</p></div>';
 		}
 	}
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.


### CS: consistent placement of boolean operators

Boolean operator should be placed at the start of the line in multi-line conditions

This generally makes for a smaller diff if something changes and improves readability.

### CS: concatenation operator at the start of the line 

Same thing, but then for multi-line concatenation.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.