### PR TITLE
CS: remove redundant file docblocks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -57,6 +57,9 @@
 
 		<!-- YoastCS demands else on new line. -->
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+
+		<!-- YoastCS recommends no file docblock in namespaced files. -->
+		<exclude name="Squiz.Commenting.FileComment.Missing"/>
 	</rule>
 
 	<config name="testVersion" value="5.5-"/>

--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Options page
- *
- * @package Duplicate Post
- * @since   2.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 

--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -1,18 +1,11 @@
 <?php
-/**
- * Duplicate Post plugin file.
- *
- * @package Yoast\WP\Duplicate_Post\Admin
- */
 
 namespace Yoast\WP\Duplicate_Post\Admin;
 
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Class Options_Form_Generator
- *
- * @package Yoast\WP\Duplicate_Post\Admin
+ * Class Options_Form_Generator.
  */
 class Options_Form_Generator {
 

--- a/src/admin/class-options-inputs.php
+++ b/src/admin/class-options-inputs.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Duplicate Post plugin file.
- *
- * @package Yoast\WP\Duplicate_Post\Admin
- */
 
 namespace Yoast\WP\Duplicate_Post\Admin;
 
 /**
- * Class Options_Inputs
+ * Class Options_Inputs.
  */
 class Options_Inputs {
 

--- a/src/admin/class-options-page.php
+++ b/src/admin/class-options-page.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post plugin file.
- *
- * @package Yoast\WP\Duplicate_Post\Admin
- */
 
 namespace Yoast\WP\Duplicate_Post\Admin;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Duplicate_Post\UI\Asset_Manager;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Class Options_Page
+ * Class Options_Page.
  */
 class Options_Page {
 

--- a/src/admin/class-options.php
+++ b/src/admin/class-options.php
@@ -1,15 +1,11 @@
 <?php
-/**
- * Options class
- *
- * @package Duplicate Post
- * @since   4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Admin;
 
 /**
- * Class Options
+ * Options class.
+ *
+ * @since 4.0
  */
 class Options {
 

--- a/src/class-duplicate-post.php
+++ b/src/class-duplicate-post.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Duplicate Post main class.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 
@@ -13,7 +7,9 @@ use Yoast\WP\Duplicate_Post\UI\User_Interface;
 use Yoast\WP\Duplicate_Post\Watchers\Watchers;
 
 /**
- * Represents the Duplicate Post main class.
+ * Duplicate Post main class.
+ *
+ * @since 4.0
  */
 class Duplicate_Post {
 

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -1,15 +1,11 @@
 <?php
-/**
- * Permissions helper for Duplicate Post.
- *
- * @package Duplicate_Post
- * @since   4.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 
 /**
- * Represents the Permissions_Helper class.
+ * Permissions helper for Duplicate Post.
+ *
+ * @since 4.0
  */
 class Permissions_Helper {
 

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -1,15 +1,11 @@
 <?php
-/**
- * Duplicate Post class to create copies.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 
 /**
- * Represents the Post Duplicator class.
+ * Duplicate Post class to create copies.
+ *
+ * @since 4.0
  */
 class Post_Duplicator {
 

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Duplicate Post class to republish a rewritten post.
- *
- * @package Duplicate_Post
- * @since   4.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 
 use WP_Post;
 
 /**
- * Represents the Post Republisher class.
+ * Duplicate Post class to republish a rewritten post.
+ *
+ * @since 4.0
  */
 class Post_Republisher {
 

--- a/src/class-revisions-migrator.php
+++ b/src/class-revisions-migrator.php
@@ -1,15 +1,11 @@
 <?php
-/**
- * Duplicate Post class to migrate revisions from the Rewrite & Republish copy to the original post.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 
 /**
- * Represents the Revisions Migrator class.
+ * Duplicate Post class to migrate revisions from the Rewrite & Republish copy to the original post.
+ *
+ * @since 4.0
  */
 class Revisions_Migrator {
 

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -1,15 +1,11 @@
 <?php
-/**
- * Utility methods for Duplicate Post.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post;
 
 /**
- * Represents the Utils class.
+ * Utility methods for Duplicate Post.
+ *
+ * @since 4.0
  */
 class Utils {
 

--- a/src/handlers/class-bulk-handler.php
+++ b/src/handlers/class-bulk-handler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Duplicate Post handler class for duplication bulk actions.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Handlers;
 
@@ -13,7 +7,9 @@ use Yoast\WP\Duplicate_Post\Post_Duplicator;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the handler for duplication bulk actions.
+ * Duplicate Post handler class for duplication bulk actions.
+ *
+ * @since 4.0
  */
 class Bulk_Handler {
 

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Duplicate Post handler class for changes overview.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Handlers;
 
@@ -12,7 +6,11 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
+ * Duplicate Post handler class for changes overview.
+ *
  * Represents the handler for checking the changes between a copy and the original post.
+ *
+ * @since 4.0
  */
 class Check_Changes_Handler {
 

--- a/src/handlers/class-handler.php
+++ b/src/handlers/class-handler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Duplicate Post handler class for duplication actions.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Handlers;
 
@@ -12,7 +6,9 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
 
 /**
- * Represents the handler for duplication actions.
+ * Duplicate Post handler class for duplication actions.
+ *
+ * @since 4.0
  */
 class Handler {
 

--- a/src/handlers/class-link-handler.php
+++ b/src/handlers/class-link-handler.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Duplicate Post handler class for duplication actions from links.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Handlers;
 
@@ -12,7 +6,9 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
 
 /**
- * Represents the handler for duplication actions from links.
+ * Duplicate Post handler class for duplication actions from links.
+ *
+ * @since 4.0
  */
 class Link_Handler {
 

--- a/src/handlers/class-save-post-handler.php
+++ b/src/handlers/class-save-post-handler.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Duplicate Post handler class for save_post action.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Handlers;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Represents the handler for save_post action.
+ * Duplicate Post handler class for save_post action.
+ *
+ * @since 4.0
  */
 class Save_Post_Handler {
 

--- a/src/ui/class-admin-bar.php
+++ b/src/ui/class-admin-bar.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the admin bar.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Admin_Bar class.
+ * Duplicate Post class to manage the admin bar.
  */
 class Admin_Bar {
 

--- a/src/ui/class-asset-manager.php
+++ b/src/ui/class-asset-manager.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Duplicate Post class to manage assets.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Duplicate Post Asset Manager class.
+ * Duplicate Post class to manage assets.
  */
 class Asset_Manager {
 

--- a/src/ui/class-block-editor.php
+++ b/src/ui/class-block-editor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the block editor UI.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Block_Editor class.
+ * Duplicate Post class to manage the block editor UI.
  */
 class Block_Editor {
 

--- a/src/ui/class-bulk-actions.php
+++ b/src/ui/class-bulk-actions.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the bulk actions menu.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Bulk_Actions class.
+ * Duplicate Post class to manage the bulk actions menu.
  */
 class Bulk_Actions {
 

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the classic editor UI.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Classic_Editor class.
+ * Duplicate Post class to manage the classic editor UI.
  */
 class Classic_Editor {
 

--- a/src/ui/class-column.php
+++ b/src/ui/class-column.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the custom column + quick edit.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Column class.
+ * Duplicate Post class to manage the custom column + quick edit.
  */
 class Column {
 

--- a/src/ui/class-link-builder.php
+++ b/src/ui/class-link-builder.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * Duplicate Post link builder.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
 /**
- * Class Link_Builder
- *
- * @package Yoast\WP\Duplicate_Post
+ * Duplicate Post link builder.
  */
 class Link_Builder {
 

--- a/src/ui/class-metabox.php
+++ b/src/ui/class-metabox.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the metabox.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Metabox class.
+ * Duplicate Post class to manage the metabox.
  */
 class Metabox {
 

--- a/src/ui/class-post-states.php
+++ b/src/ui/class-post-states.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the post states display.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Post_States class.
+ * Duplicate Post class to manage the post states display.
  */
 class Post_States {
 

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post class to manage the row actions.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
- * Represents the Row_Action class.
+ * Duplicate Post class to manage the row actions.
  */
 class Row_Actions {
 

--- a/src/ui/class-user-interface.php
+++ b/src/ui/class-user-interface.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Duplicate Post user interface.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Represents the Duplicate Post User Interface class.
+ * Duplicate Post user interface.
  */
 class User_Interface {
 

--- a/src/watchers/class-bulk-actions-watcher.php
+++ b/src/watchers/class-bulk-actions-watcher.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Duplicate Post class to watch for the bulk actions and show notices.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
 /**
- * Represents the Bulk_Actions_Watcher class.
+ * Duplicate Post class to watch for the bulk actions and show notices.
  */
 class Bulk_Actions_Watcher {
 

--- a/src/watchers/class-copied-post-watcher.php
+++ b/src/watchers/class-copied-post-watcher.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Duplicate Post class to watch if the current post has a Rewrite & Republish copy.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Represents the Copied_Post_Watcher class.
+ * Duplicate Post class to watch if the current post has a Rewrite & Republish copy.
  */
 class Copied_Post_Watcher {
 

--- a/src/watchers/class-link-actions-watcher.php
+++ b/src/watchers/class-link-actions-watcher.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Duplicate Post class to watch for the link actions and show notices.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Represents the Link_Actions_Watcher class.
+ * Duplicate Post class to watch for the link actions and show notices.
  */
 class Link_Actions_Watcher {
 

--- a/src/watchers/class-original-post-watcher.php
+++ b/src/watchers/class-original-post-watcher.php
@@ -1,19 +1,15 @@
 <?php
-/**
- * Duplicate Post Original post watcher class.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Original post watcher.
+ * Duplicate Post Original post watcher class.
  *
  * Watches the original post for changes.
+ *
+ * @since 4.0
  */
 class Original_Post_Watcher {
 

--- a/src/watchers/class-republished-post-watcher.php
+++ b/src/watchers/class-republished-post-watcher.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Duplicate Post class to watch if the post has been republished for Rewrite & Republish.
- *
- * @package Duplicate_Post
- * @since 4.0
- */
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Represents the Republished_Post_Watcher class.
+ * Duplicate Post class to watch if the post has been republished for Rewrite & Republish.
+ *
+ * @since 4.0
  */
 class Republished_Post_Watcher {
 

--- a/src/watchers/class-watchers.php
+++ b/src/watchers/class-watchers.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Duplicate Post user interface.
- *
- * @package Duplicate_Post
- */
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
- * Represents the Duplicate Post User Interface class.
+ * Duplicate Post user interface.
  */
 class Watchers {
 

--- a/tests/admin/class-options-form-generator-test.php
+++ b/tests/admin/class-options-form-generator-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Admin;
 

--- a/tests/admin/class-options-inputs-test.php
+++ b/tests/admin/class-options-inputs-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Admin;
 

--- a/tests/admin/class-options-page-test.php
+++ b/tests/admin/class-options-page-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Admin;
 

--- a/tests/admin/class-options-test.php
+++ b/tests/admin/class-options-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Admin;
 

--- a/tests/class-permissions-helper-test.php
+++ b/tests/class-permissions-helper-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 

--- a/tests/class-post-duplicator-test.php
+++ b/tests/class-post-duplicator-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 

--- a/tests/class-post-republisher-test.php
+++ b/tests/class-post-republisher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 

--- a/tests/class-revisions-migrator-test.php
+++ b/tests/class-revisions-migrator-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post base test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 

--- a/tests/class-utils-test.php
+++ b/tests/class-utils-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 

--- a/tests/handlers/class-check-changes-handler-test.php
+++ b/tests/handlers/class-check-changes-handler-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Handlers;
 

--- a/tests/ui/class-admin-bar-test.php
+++ b/tests/ui/class-admin-bar-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-asset-manager-test.php
+++ b/tests/ui/class-asset-manager-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-bulk-actions-test.php
+++ b/tests/ui/class-bulk-actions-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-classic-editor-test.php
+++ b/tests/ui/class-classic-editor-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-column-test.php
+++ b/tests/ui/class-column-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-link-builder-test.php
+++ b/tests/ui/class-link-builder-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-metabox-test.php
+++ b/tests/ui/class-metabox-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-post-states-test.php
+++ b/tests/ui/class-post-states-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/ui/class-row-actions-test.php
+++ b/tests/ui/class-row-actions-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 

--- a/tests/watchers/class-bulk-actions-watcher-test.php
+++ b/tests/watchers/class-bulk-actions-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 

--- a/tests/watchers/class-copied-post-watcher-test.php
+++ b/tests/watchers/class-copied-post-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 

--- a/tests/watchers/class-link-actions-watcher-test.php
+++ b/tests/watchers/class-link-actions-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 

--- a/tests/watchers/class-original-post-watcher-test.php
+++ b/tests/watchers/class-original-post-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 

--- a/tests/watchers/class-republished-post-watcher-test.php
+++ b/tests/watchers/class-republished-post-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Duplicate Post test file.
- *
- * @package Duplicate_Post\Tests
- */
 
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

In YoastCS, namespaced files do not require a docblock and it is recommended not to have one.

This commit fixes this for all namespaced files in the Duplicate Post plugin.

Includes:
* Moving the functionality description from the file docblock to the class docblock if it was more descriptive than the description given in the class docblock.
* Moving any other relevant tags, like `@since` from the file docblock to the class docblock.
* Removing redundant `@package` tags in class docblock.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.