### PR TITLE
QA: consistently use `use` statements for classes

### DIFF
--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Admin;
 
+use WP_Taxonomy;
 use Yoast\WP\Duplicate_Post\Utils;
 
 /**
@@ -104,8 +105,8 @@ class Options_Form_Generator {
 	/**
 	 * Sorts taxonomy objects based on being public, followed by being private.
 	 *
-	 * @param \WP_Taxonomy $taxonomy1 First taxonomy object.
-	 * @param \WP_Taxonomy $taxonomy2 Second taxonomy object.
+	 * @param WP_Taxonomy $taxonomy1 First taxonomy object.
+	 * @param WP_Taxonomy $taxonomy2 Second taxonomy object.
 	 *
 	 * @return bool True when the first taxonomy is public.
 	 */

--- a/src/class-permissions-helper.php
+++ b/src/class-permissions-helper.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Duplicate_Post;
 
+use WP_Post;
+
 /**
  * Permissions helper for Duplicate Post.
  *
@@ -57,33 +59,33 @@ class Permissions_Helper {
 	/**
 	 * Determines if the post is a copy intended for Rewrite & Republish.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the post is a copy intended for Rewrite & Republish.
 	 */
-	public function is_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function is_rewrite_and_republish_copy( WP_Post $post ) {
 		return ( \intval( \get_post_meta( $post->ID, '_dp_is_rewrite_republish_copy', true ) ) === 1 );
 	}
 
 	/**
 	 * Gets the Rewrite & Republish copy ID for the passed post.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return int The Rewrite & Republish copy ID.
 	 */
-	public function get_rewrite_and_republish_copy_id( \WP_Post $post ) {
+	public function get_rewrite_and_republish_copy_id( WP_Post $post ) {
 		return \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true );
 	}
 
 	/**
 	 * Gets the copy post object for the passed post.
 	 *
-	 * @param \WP_Post $post The post to get the copy for.
+	 * @param WP_Post $post The post to get the copy for.
 	 *
-	 * @return \WP_Post|null The copy's post object or null if it doesn't exist.
+	 * @return WP_Post|null The copy's post object or null if it doesn't exist.
 	 */
-	public function get_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function get_rewrite_and_republish_copy( WP_Post $post ) {
 		$copy_id = $this->get_rewrite_and_republish_copy_id( $post );
 
 		if ( empty( $copy_id ) ) {
@@ -96,22 +98,22 @@ class Permissions_Helper {
 	/**
 	 * Determines if the post has a copy intended for Rewrite & Republish.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the post has a copy intended for Rewrite & Republish.
 	 */
-	public function has_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function has_rewrite_and_republish_copy( WP_Post $post ) {
 		return ( ! empty( $this->get_rewrite_and_republish_copy_id( $post ) ) );
 	}
 
 	/**
 	 * Determines if the post has a copy intended for Rewrite & Republish which is scheduled to be published.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
-	 * @return bool|\WP_Post The scheduled copy if present, false if the post has no scheduled copy.
+	 * @return bool|WP_Post The scheduled copy if present, false if the post has no scheduled copy.
 	 */
-	public function has_scheduled_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function has_scheduled_rewrite_and_republish_copy( WP_Post $post ) {
 		$copy = $this->get_rewrite_and_republish_copy( $post );
 
 		if ( ! empty( $copy ) && $copy->post_status === 'future' ) {
@@ -172,11 +174,11 @@ class Permissions_Helper {
 	/**
 	 * Determines if the original post has changed since the creation of the copy.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the original post has changed since the creation of the copy.
 	 */
-	public function has_original_changed( \WP_Post $post ) {
+	public function has_original_changed( WP_Post $post ) {
 		if ( ! $this->is_rewrite_and_republish_copy( $post ) ) {
 			return false;
 		}
@@ -196,16 +198,16 @@ class Permissions_Helper {
 	/**
 	 * Determines if duplicate links for the post can be displayed.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the links can be displayed.
 	 */
-	public function should_links_be_displayed( \WP_Post $post ) {
+	public function should_links_be_displayed( WP_Post $post ) {
 		/**
 		 * Filter allowing displaying duplicate post links for current post.
 		 *
-		 * @param bool     $display_links Whether the duplicate links will be displayed.
-		 * @param \WP_Post $post          The post object.
+		 * @param bool    $display_links Whether the duplicate links will be displayed.
+		 * @param WP_Post $post          The post object.
 		 *
 		 * @return bool Whether or not to display the duplicate post links.
 		 */
@@ -217,11 +219,11 @@ class Permissions_Helper {
 	/**
 	 * Determines if the Rewrite & Republish link for the post should be displayed.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the links should be displayed.
 	 */
-	public function should_rewrite_and_republish_be_allowed( \WP_Post $post ) {
+	public function should_rewrite_and_republish_be_allowed( WP_Post $post ) {
 		return $post->post_status === 'publish'
 			&& ! $this->is_rewrite_and_republish_copy( $post )
 			&& ! $this->has_rewrite_and_republish_copy( $post );
@@ -247,22 +249,22 @@ class Permissions_Helper {
 	/**
 	 * Determines whether a Rewrite & Republish copy can be republished.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the Rewrite & Republish copy can be republished.
 	 */
-	public function is_copy_allowed_to_be_republished( \WP_Post $post ) {
+	public function is_copy_allowed_to_be_republished( WP_Post $post ) {
 		return \in_array( $post->post_status, [ 'dp-rewrite-republish', 'private' ], true );
 	}
 
 	/**
 	 * Determines if the post has a trashed copy intended for Rewrite & Republish.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param WP_Post $post The post object.
 	 *
 	 * @return bool Whether the post has a trashed copy intended for Rewrite & Republish.
 	 */
-	public function has_trashed_rewrite_and_republish_copy( \WP_Post $post ) {
+	public function has_trashed_rewrite_and_republish_copy( WP_Post $post ) {
 		$copy_id = \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true );
 
 		if ( ! $copy_id ) {

--- a/src/class-post-duplicator.php
+++ b/src/class-post-duplicator.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\Duplicate_Post;
 
+use WP_Error;
+use WP_Post;
+
 /**
  * Duplicate Post class to create copies.
  *
@@ -44,12 +47,12 @@ class Post_Duplicator {
 	/**
 	 * Creates a copy of a post object, accordingly to an options array.
 	 *
-	 * @param \WP_Post $post    The original post object.
-	 * @param array    $options The options overriding the default ones.
+	 * @param WP_Post $post    The original post object.
+	 * @param array   $options The options overriding the default ones.
 	 *
-	 * @return int|\WP_Error The copy ID, or a WP_Error object on failure.
+	 * @return int|WP_Error The copy ID, or a WP_Error object on failure.
 	 */
-	public function create_duplicate( \WP_Post $post, array $options = [] ) {
+	public function create_duplicate( WP_Post $post, array $options = [] ) {
 		$defaults = $this->get_default_options();
 		$options  = \wp_parse_args( $options, $defaults );
 
@@ -95,8 +98,8 @@ class Post_Duplicator {
 			/**
 			 * Filter new post values.
 			 *
-			 * @param array    $new_post New post values.
-			 * @param \WP_Post $post     Original post object.
+			 * @param array   $new_post New post values.
+			 * @param WP_Post $post     Original post object.
 			 *
 			 * @return array
 			 */
@@ -137,11 +140,11 @@ class Post_Duplicator {
 	/**
 	 * Wraps the function to create a copy for the Rewrite & Republish feature.
 	 *
-	 * @param \WP_Post $post The original post object.
+	 * @param WP_Post $post The original post object.
 	 *
-	 * @return int|\WP_Error The copy ID, or a WP_Error object on failure.
+	 * @return int|WP_Error The copy ID, or a WP_Error object on failure.
 	 */
-	public function create_duplicate_for_rewrite_and_republish( \WP_Post $post ) {
+	public function create_duplicate_for_rewrite_and_republish( WP_Post $post ) {
 		$options  = [
 			'copy_title'      => true,
 			'copy_date'       => true,
@@ -172,9 +175,9 @@ class Post_Duplicator {
 	/**
 	 * Copies the taxonomies of a post to another post.
 	 *
-	 * @param int      $new_id  New post ID.
-	 * @param \WP_Post $post    The original post object.
-	 * @param array    $options The options array.
+	 * @param int     $new_id  New post ID.
+	 * @param WP_Post $post    The original post object.
+	 * @param array   $options The options array.
 	 *
 	 * @return void
 	 */
@@ -224,9 +227,9 @@ class Post_Duplicator {
 	/**
 	 * Copies the meta information of a post to another post.
 	 *
-	 * @param int      $new_id  The new post ID.
-	 * @param \WP_Post $post    The original post object.
-	 * @param array    $options The options array.
+	 * @param int     $new_id  The new post ID.
+	 * @param WP_Post $post    The original post object.
+	 * @param array   $options The options array.
 	 *
 	 * @return void
 	 */
@@ -296,12 +299,12 @@ class Post_Duplicator {
 	/**
 	 * Generates and returns the title for the copy.
 	 *
-	 * @param \WP_Post $post    The original post object.
-	 * @param array    $options The options array.
+	 * @param WP_Post $post    The original post object.
+	 * @param array   $options The options array.
 	 *
 	 * @return string The calculated title for the copy.
 	 */
-	public function generate_copy_title( \WP_Post $post, array $options ) {
+	public function generate_copy_title( WP_Post $post, array $options ) {
 		$prefix = \sanitize_text_field( $options['title_prefix'] );
 		$suffix = \sanitize_text_field( $options['title_suffix'] );
 		if ( $options['copy_title'] ) {
@@ -322,12 +325,12 @@ class Post_Duplicator {
 	/**
 	 * Generates and returns the status for the copy.
 	 *
-	 * @param \WP_Post $post    The original post object.
-	 * @param array    $options The options array.
+	 * @param WP_Post $post    The original post object.
+	 * @param array   $options The options array.
 	 *
 	 * @return string The calculated status for the copy.
 	 */
-	public function generate_copy_status( \WP_Post $post, array $options ) {
+	public function generate_copy_status( WP_Post $post, array $options ) {
 		$new_post_status = 'draft';
 
 		if ( $options['copy_status'] ) {
@@ -353,12 +356,12 @@ class Post_Duplicator {
 	/**
 	 * Generates and returns the author ID for the copy.
 	 *
-	 * @param \WP_Post $post    The original post object.
-	 * @param array    $options The options array.
+	 * @param WP_Post $post    The original post object.
+	 * @param array   $options The options array.
 	 *
 	 * @return int|string The calculated author ID for the copy.
 	 */
-	public function generate_copy_author( \WP_Post $post, array $options ) {
+	public function generate_copy_author( WP_Post $post, array $options ) {
 		$new_post_author    = \wp_get_current_user();
 		$new_post_author_id = $new_post_author->ID;
 		if ( $options['copy_author'] ) {

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -122,7 +122,7 @@ class Post_Republisher {
 	/**
 	 * Executes the republish request.
 	 *
-	 * @param \WP_Post $post The copy's post object.
+	 * @param WP_Post $post The copy's post object.
 	 *
 	 * @return void
 	 */
@@ -152,7 +152,7 @@ class Post_Republisher {
 	/**
 	 * Republishes the original post with the passed post, when using the Block Editor.
 	 *
-	 * @param \WP_Post $post The copy's post object.
+	 * @param WP_Post $post The copy's post object.
 	 *
 	 * @return void
 	 */
@@ -166,8 +166,8 @@ class Post_Republisher {
 	 * Runs also in the Block Editor to save the custom meta data only when there
 	 * are custom meta boxes.
 	 *
-	 * @param int      $post_id The copy's post ID.
-	 * @param \WP_Post $post    The copy's post object.
+	 * @param int     $post_id The copy's post ID.
+	 * @param WP_Post $post    The copy's post object.
 	 *
 	 * @return void
 	 */
@@ -182,7 +182,7 @@ class Post_Republisher {
 	/**
 	 * Republishes the scheduled Rewrited and Republish post.
 	 *
-	 * @param \WP_Post $copy The scheduled copy.
+	 * @param WP_Post $copy The scheduled copy.
 	 *
 	 * @return void
 	 */
@@ -303,8 +303,8 @@ class Post_Republisher {
 	/**
 	 * Republishes the post elements overwriting the original post.
 	 *
-	 * @param \WP_Post $post          The post object.
-	 * @param \WP_Post $original_post The original post.
+	 * @param WP_Post $post          The post object.
+	 * @param WP_Post $original_post The original post.
 	 *
 	 * @return void
 	 */
@@ -335,7 +335,7 @@ class Post_Republisher {
 	/**
 	 * Republishes the post taxonomies overwriting the ones of the original post.
 	 *
-	 * @param \WP_Post $post The copy's post object.
+	 * @param WP_Post $post The copy's post object.
 	 *
 	 * @return void
 	 */
@@ -353,7 +353,7 @@ class Post_Republisher {
 	/**
 	 * Republishes the post meta overwriting the ones of the original post.
 	 *
-	 * @param \WP_Post $post The copy's post object.
+	 * @param WP_Post $post The copy's post object.
 	 *
 	 * @return void
 	 */
@@ -394,8 +394,8 @@ class Post_Republisher {
 	/**
 	 * Determines the post status to use when publishing the Rewrite & Republish copy.
 	 *
-	 * @param \WP_Post $post          The post object.
-	 * @param \WP_Post $original_post The original post object.
+	 * @param WP_Post $post          The post object.
+	 * @param WP_Post $original_post The original post object.
 	 *
 	 * @return string The post status to use.
 	 */

--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Duplicate_Post;
 
+use WP_Post;
+
 /**
  * Utility methods for Duplicate Post.
  *
@@ -53,10 +55,10 @@ class Utils {
 	/**
 	 * Gets the original post.
 	 *
-	 * @param int|\WP_Post|null $post   Optional. Post ID or Post object.
-	 * @param string            $output Optional, default is Object. Either OBJECT, ARRAY_A, or ARRAY_N.
+	 * @param int|WP_Post|null $post   Optional. Post ID or Post object.
+	 * @param string           $output Optional, default is Object. Either OBJECT, ARRAY_A, or ARRAY_N.
 	 *
-	 * @return \WP_Post|null Post data if successful, null otherwise.
+	 * @return WP_Post|null Post data if successful, null otherwise.
 	 */
 	public static function get_original( $post = null, $output = \OBJECT ) {
 		$post = \get_post( $post );
@@ -78,8 +80,8 @@ class Utils {
 	 *
 	 * If we are copying children, and the post has already an ancestor marked for copy, we have to filter it out.
 	 *
-	 * @param \WP_Post $post     The post object.
-	 * @param array    $post_ids The array of marked post IDs.
+	 * @param WP_Post $post     The post object.
+	 * @param array   $post_ids The array of marked post IDs.
 	 *
 	 * @return bool Whether the post has ancestors marked for copy.
 	 */
@@ -98,7 +100,7 @@ class Utils {
 	/**
 	 * Returns a link to edit, preview or view a post, in accordance to user capabilities.
 	 *
-	 * @param \WP_Post $post Post ID or Post object.
+	 * @param WP_Post $post Post ID or Post object.
 	 *
 	 * @return string|null The link to edit, preview or view a post.
 	 */

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Handlers;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
@@ -24,14 +25,14 @@ class Check_Changes_Handler {
 	/**
 	 * Holds the current post object.
 	 *
-	 * @var \WP_Post
+	 * @var WP_Post
 	 */
 	private $post;
 
 	/**
 	 * Holds the original post object.
 	 *
-	 * @var \WP_Post
+	 * @var WP_Post
 	 */
 	private $original;
 

--- a/src/ui/class-classic-editor.php
+++ b/src/ui/class-classic-editor.php
@@ -111,7 +111,7 @@ class Classic_Editor {
 	/**
 	 * Adds a button in the post/page edit screen to create a clone
 	 *
-	 * @param \WP_Post|null $post The post object that's being edited.
+	 * @param WP_Post|null $post The post object that's being edited.
 	 *
 	 * @return void
 	 */
@@ -137,7 +137,7 @@ class Classic_Editor {
 	/**
 	 * Adds a button in the post/page edit screen to create a clone for Rewrite & Republish.
 	 *
-	 * @param \WP_Post|null $post The post object that's being edited.
+	 * @param WP_Post|null $post The post object that's being edited.
 	 *
 	 * @return void
 	 */
@@ -166,7 +166,7 @@ class Classic_Editor {
 	/**
 	 * Adds a message in the post/page edit screen to create a clone for Rewrite & Republish.
 	 *
-	 * @param \WP_Post|null $post The post object that's being edited.
+	 * @param WP_Post|null $post The post object that's being edited.
 	 *
 	 * @return void
 	 */
@@ -278,7 +278,7 @@ class Classic_Editor {
 	/**
 	 * Determines if the Rewrite & Republish copies for the post should be used.
 	 *
-	 * @param \WP_Post $post The current post object.
+	 * @param WP_Post $post The current post object.
 	 *
 	 * @return bool True if the Rewrite & Republish copies should be used.
 	 */
@@ -298,8 +298,8 @@ class Classic_Editor {
 	/**
 	 * Removes the slug meta box in the Classic Editor when the post is a Rewrite & Republish copy.
 	 *
-	 * @param string   $post_type Post type.
-	 * @param \WP_Post $post      Post object.
+	 * @param string  $post_type Post type.
+	 * @param WP_Post $post      Post object.
 	 *
 	 * @return void
 	 */
@@ -312,11 +312,11 @@ class Classic_Editor {
 	/**
 	 * Removes the sample permalink slug editor in the Classic Editor when the post is a Rewrite & Republish copy.
 	 *
-	 * @param string   $return    Sample permalink HTML markup.
-	 * @param int      $post_id   Post ID.
-	 * @param string   $new_title New sample permalink title.
-	 * @param string   $new_slug  New sample permalink slug.
-	 * @param \WP_Post $post      Post object.
+	 * @param string  $return    Sample permalink HTML markup.
+	 * @param int     $post_id   Post ID.
+	 * @param string  $new_title New sample permalink title.
+	 * @param string  $new_slug  New sample permalink slug.
+	 * @param WP_Post $post      Post object.
 	 *
 	 * @return string The filtered HTML of the sample permalink slug editor.
 	 */

--- a/src/ui/class-link-builder.php
+++ b/src/ui/class-link-builder.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
+
 /**
  * Duplicate Post link builder.
  */
@@ -10,8 +12,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for duplication action for the Rewrite & Republish feature.
 	 *
-	 * @param int|\WP_Post $post    The post object or ID.
-	 * @param string       $context The context in which the URL will be used.
+	 * @param int|WP_Post $post    The post object or ID.
+	 * @param string      $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -22,8 +24,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for the "Clone" action.
 	 *
-	 * @param int|\WP_Post $post    The post object or ID.
-	 * @param string       $context The context in which the URL will be used.
+	 * @param int|WP_Post $post    The post object or ID.
+	 * @param string      $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -34,8 +36,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for the "Copy to a new draft" action.
 	 *
-	 * @param int|\WP_Post $post    The post object or ID.
-	 * @param string       $context The context in which the URL will be used.
+	 * @param int|WP_Post $post    The post object or ID.
+	 * @param string      $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -46,8 +48,8 @@ class Link_Builder {
 	/**
 	 * Builds URL for the "Check Changes" action.
 	 *
-	 * @param int|\WP_Post $post    The post object or ID.
-	 * @param string       $context The context in which the URL will be used.
+	 * @param int|WP_Post $post    The post object or ID.
+	 * @param string      $context The context in which the URL will be used.
 	 *
 	 * @return string The URL for the link.
 	 */
@@ -58,15 +60,15 @@ class Link_Builder {
 	/**
 	 * Builds URL for duplication action.
 	 *
-	 * @param int|\WP_Post $post        The post object or ID.
-	 * @param string       $context     The context in which the URL will be used.
-	 * @param string       $action_name The action for the URL.
+	 * @param int|WP_Post $post        The post object or ID.
+	 * @param string      $context     The context in which the URL will be used.
+	 * @param string      $action_name The action for the URL.
 	 *
 	 * @return string The URL for the link.
 	 */
 	public function build_link( $post, $context, $action_name ) {
 		$post = \get_post( $post );
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return '';
 		}
 

--- a/src/ui/class-metabox.php
+++ b/src/ui/class-metabox.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\UI;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Utils;
 
@@ -40,8 +41,8 @@ class Metabox {
 	/**
 	 * Adds a metabox to Edit screen.
 	 *
-	 * @param string   $post_type The post type.
-	 * @param \WP_Post $post      The current post object.
+	 * @param string  $post_type The post type.
+	 * @param WP_Post $post      The current post object.
 	 *
 	 * @return void
 	 */
@@ -49,10 +50,10 @@ class Metabox {
 		$enabled_post_types = $this->permissions_helper->get_enabled_post_types();
 
 		if ( \in_array( $post_type, $enabled_post_types, true )
-			&& $post instanceof \WP_Post ) {
+			&& $post instanceof WP_Post ) {
 			$original_item = Utils::get_original( $post );
 
-			if ( $original_item instanceof \WP_Post ) {
+			if ( $original_item instanceof WP_Post ) {
 				\add_meta_box(
 					'duplicate_post_show_original',
 					\__( 'Duplicate Post', 'duplicate-post' ),
@@ -69,8 +70,8 @@ class Metabox {
 	/**
 	 * Outputs the HTML for the metabox.
 	 *
-	 * @param \WP_Post $post    The current post.
-	 * @param array    $metabox The array containing the metabox data.
+	 * @param WP_Post $post    The current post.
+	 * @param array   $metabox The array containing the metabox data.
 	 *
 	 * @return void
 	 */

--- a/src/ui/class-post-states.php
+++ b/src/ui/class-post-states.php
@@ -39,8 +39,8 @@ class Post_States {
 	/**
 	 * Shows link to original post in the post states.
 	 *
-	 * @param array    $post_states The array of post states.
-	 * @param \WP_Post $post        The current post.
+	 * @param array   $post_states The array of post states.
+	 * @param WP_Post $post        The current post.
 	 *
 	 * @return array The updated post states array.
 	 */

--- a/src/ui/class-row-actions.php
+++ b/src/ui/class-row-actions.php
@@ -65,8 +65,8 @@ class Row_Actions {
 	/**
 	 * Hooks in the `post_row_actions` and `page_row_actions` filters to add a 'Clone' link.
 	 *
-	 * @param array    $actions The array of actions from the filter.
-	 * @param \WP_Post $post    The post object.
+	 * @param array   $actions The array of actions from the filter.
+	 * @param WP_Post $post    The post object.
 	 *
 	 * @return array The updated array of actions.
 	 */
@@ -92,8 +92,8 @@ class Row_Actions {
 	/**
 	 * Hooks in the `post_row_actions` and `page_row_actions` filters to add a 'New Draft' link.
 	 *
-	 * @param array    $actions The array of actions from the filter.
-	 * @param \WP_Post $post    The post object.
+	 * @param array   $actions The array of actions from the filter.
+	 * @param WP_Post $post    The post object.
 	 *
 	 * @return array The updated array of actions.
 	 */
@@ -120,8 +120,8 @@ class Row_Actions {
 	/**
 	 * Hooks in the `post_row_actions` and `page_row_actions` filters to add a 'Rewrite & Republish' link.
 	 *
-	 * @param array    $actions The array of actions from the filter.
-	 * @param \WP_Post $post    The post object.
+	 * @param array   $actions The array of actions from the filter.
+	 * @param WP_Post $post    The post object.
 	 *
 	 * @return array The updated array of actions.
 	 */

--- a/src/watchers/class-copied-post-watcher.php
+++ b/src/watchers/class-copied-post-watcher.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
@@ -40,7 +41,7 @@ class Copied_Post_Watcher {
 	/**
 	 * Generates the translated text for the notice.
 	 *
-	 * @param \WP_Post $post The current post object.
+	 * @param WP_Post $post The current post object.
 	 *
 	 * @return string The translated text for the notice.
 	 */
@@ -83,7 +84,7 @@ class Copied_Post_Watcher {
 
 		$post = \get_post();
 
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return;
 		}
 
@@ -102,7 +103,7 @@ class Copied_Post_Watcher {
 	public function add_block_editor_notice() {
 		$post = \get_post();
 
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return;
 		}
 

--- a/src/watchers/class-original-post-watcher.php
+++ b/src/watchers/class-original-post-watcher.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Watchers;
 
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
@@ -65,7 +66,7 @@ class Original_Post_Watcher {
 
 		$post = \get_post();
 
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return;
 		}
 
@@ -84,7 +85,7 @@ class Original_Post_Watcher {
 	public function add_block_editor_notice() {
 		$post = \get_post();
 
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return;
 		}
 

--- a/tests/admin/class-options-form-generator-test.php
+++ b/tests/admin/class-options-form-generator-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\Admin;
 
 use Brain\Monkey;
 use Mockery;
+use stdClass;
 use Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator;
 use Yoast\WP\Duplicate_Post\Admin\Options_Inputs;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
@@ -36,7 +37,7 @@ class Options_Form_Generator_Test extends TestCase {
 		$this->options_inputs = Mockery::mock( Options_Inputs::class )->makePartial();
 		$this->instance       = Mockery::mock( Options_Form_Generator::class, [ $this->options_inputs ] )->makePartial();
 
-		$labels       = new \stdClass();
+		$labels       = new stdClass();
 		$labels->name = 'Custom Type';
 
 		$caps = [
@@ -278,7 +279,7 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator::generate_taxonomy_exclusion_list
 	 */
 	public function test_generate_taxonomy_exclusion_list() {
-		$labels       = new \stdClass();
+		$labels       = new stdClass();
 		$labels->name = 'Custom Taxonomy';
 
 		$taxonomy1         = Mockery::mock( 'WP_Taxonomy' );

--- a/tests/class-permissions-helper-test.php
+++ b/tests/class-permissions-helper-test.php
@@ -4,6 +4,9 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
+use WP_Post_Type;
+use WP_Screen;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 
 /**
@@ -95,7 +98,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::is_rewrite_and_republish_copy
 	 */
 	public function test_is_rewrite_and_republish_copy_successful() {
-		$post     = Mockery::mock( \WP_Post::class );
+		$post     = Mockery::mock( WP_Post::class );
 		$post->ID = 123;
 
 		Monkey\Functions\expect( '\get_post_meta' )
@@ -111,7 +114,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::is_rewrite_and_republish_copy
 	 */
 	public function test_is_rewrite_and_republish_copy_unsuccessful() {
-		$post     = Mockery::mock( \WP_Post::class );
+		$post     = Mockery::mock( WP_Post::class );
 		$post->ID = 123;
 
 		Monkey\Functions\expect( '\get_post_meta' )
@@ -127,7 +130,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_rewrite_and_republish_copy
 	 */
 	public function test_has_rewrite_and_republish_copy_successful() {
-		$post     = Mockery::mock( \WP_Post::class );
+		$post     = Mockery::mock( WP_Post::class );
 		$post->ID = 123;
 
 		Monkey\Functions\expect( '\get_post_meta' )
@@ -143,7 +146,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_rewrite_and_republish_copy
 	 */
 	public function test_has_rewrite_and_republish_copy_unsuccessful() {
-		$post     = Mockery::mock( \WP_Post::class );
+		$post     = Mockery::mock( WP_Post::class );
 		$post->ID = 123;
 
 		Monkey\Functions\expect( '\get_post_meta' )
@@ -159,9 +162,9 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_scheduled_rewrite_and_republish_copy
 	 */
 	public function test_has_scheduled_rewrite_and_republish_copy_successful() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->ID          = 123;
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->post_status = 'future';
 		$copy_id           = 321;
 
@@ -185,7 +188,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_scheduled_rewrite_and_republish_copy
 	 */
 	public function test_has_scheduled_rewrite_and_republish_copy_no_copy() {
-		$post     = Mockery::mock( \WP_Post::class );
+		$post     = Mockery::mock( WP_Post::class );
 		$post->ID = 123;
 
 		Monkey\Functions\expect( '\get_post_meta' )
@@ -204,9 +207,9 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_scheduled_rewrite_and_republish_copy
 	 */
 	public function test_has_scheduled_rewrite_and_republish_copy_not_scheduled() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->ID          = 123;
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->post_status = 'draft';
 		$copy_id           = 321;
 
@@ -231,7 +234,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_is_edit_post_screen( $original, $expected ) {
-		$screen         = Mockery::mock( \WP_Screen::class );
+		$screen         = Mockery::mock( WP_Screen::class );
 		$screen->base   = $original['base'];
 		$screen->action = $original['action'];
 
@@ -304,7 +307,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_is_new_post_screen( $original, $expected ) {
-		$screen         = Mockery::mock( \WP_Screen::class );
+		$screen         = Mockery::mock( WP_Screen::class );
 		$screen->base   = $original['base'];
 		$screen->action = $original['action'];
 
@@ -377,7 +380,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_is_classic_editor( $original, $expected ) {
-		$screen = Mockery::mock( \WP_Screen::class );
+		$screen = Mockery::mock( WP_Screen::class );
 
 		$this->instance->expects( 'is_edit_post_screen' )
 			->andReturn( $original['is_edit_post_screen'] );
@@ -453,10 +456,10 @@ class Permissions_Helper_Test extends TestCase {
 	 */
 	public function test_has_original_changed_successful() {
 		$utils                       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post                        = Mockery::mock( \WP_Post::class );
+		$post                        = Mockery::mock( WP_Post::class );
 		$post->ID                    = 123;
 		$copy_creation_date_gmt      = '2020-12-01 12:35:55';
-		$original                    = Mockery::mock( \WP_Post::class );
+		$original                    = Mockery::mock( WP_Post::class );
 		$original->post_modified_gmt = '2020-12-02 11:30:45';
 
 		$this->instance
@@ -484,10 +487,10 @@ class Permissions_Helper_Test extends TestCase {
 	 */
 	public function test_has_original_changed_no() {
 		$utils                       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post                        = Mockery::mock( \WP_Post::class );
+		$post                        = Mockery::mock( WP_Post::class );
 		$post->ID                    = 123;
 		$copy_creation_date_gmt      = '2020-12-01 12:35:55';
-		$original                    = Mockery::mock( \WP_Post::class );
+		$original                    = Mockery::mock( WP_Post::class );
 		$original->post_modified_gmt = '2020-12-01 12:35:55';
 
 		$this->instance
@@ -512,7 +515,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_original_changed
 	 */
 	public function test_has_original_changed_not_rewrite_and_republish() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->instance
 			->expects( 'is_rewrite_and_republish_copy' )
@@ -528,7 +531,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::should_links_be_displayed
 	 */
 	public function test_should_links_be_displayed_successful() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->instance
@@ -554,7 +557,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::should_links_be_displayed
 	 */
 	public function test_should_links_be_displayed_unsuccessful_user_not_allowed_to_copy() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->instance
@@ -580,7 +583,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::should_links_be_displayed
 	 */
 	public function test_should_links_be_displayed_unsuccessful_post_type_not_enabled_for_copy() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->instance
@@ -606,7 +609,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::should_links_be_displayed
 	 */
 	public function test_should_links_be_displayed_unsuccessful_post_is_rewrite_and_republish() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->instance
@@ -636,7 +639,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_should_rewrite_and_republish_be_allowed( $original, $expected ) {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
 		$post->post_status = $original['post_status'];
 
@@ -716,7 +719,7 @@ class Permissions_Helper_Test extends TestCase {
 	 */
 	public function test_post_type_has_admin_bar( $original, $expected ) {
 		$post_type                           = 'post';
-		$post_type_object                    = Mockery::mock( \WP_Post_Type::class );
+		$post_type_object                    = Mockery::mock( WP_Post_Type::class );
 		$post_type_object->public            = $original['public'];
 		$post_type_object->show_in_admin_bar = $original['show_in_admin_bar'];
 
@@ -791,7 +794,7 @@ class Permissions_Helper_Test extends TestCase {
 	 * @param mixed $expected    Expected output.
 	 */
 	public function test_is_copy_allowed_to_be_republished( $post_status, $expected ) {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = $post_status;
 
 		$this->assertEquals( $expected, $this->instance->is_copy_allowed_to_be_republished( $post ) );
@@ -825,9 +828,9 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_trashed_rewrite_and_republish_copy
 	 */
 	public function test_has_trashed_rewrite_and_republish_copy() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->ID          = 123;
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->post_status = 'trash';
 		$copy_id           = 321;
 
@@ -848,9 +851,9 @@ class Permissions_Helper_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Permissions_Helper::has_trashed_rewrite_and_republish_copy
 	 */
 	public function test_does_not_have_trashed_rewrite_and_republish_copy() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->ID          = 123;
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->post_status = 'draft';
 		$copy_id           = 321;
 

--- a/tests/class-post-duplicator-test.php
+++ b/tests/class-post-duplicator-test.php
@@ -4,6 +4,8 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
+use WP_User;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
 
 /**
@@ -72,7 +74,7 @@ class Post_Duplicator_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_generate_copy_title( $original, $expected ) {
-		$post             = Mockery::mock( \WP_Post::class );
+		$post             = Mockery::mock( WP_Post::class );
 		$post->post_title = 'Title';
 
 		Monkey\Functions\expect( '\sanitize_text_field' )
@@ -158,7 +160,7 @@ class Post_Duplicator_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_generate_copy_status( $original, $expected ) {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = $original['post_status'];
 		$post->post_type   = $original['post_type'];
 
@@ -255,14 +257,14 @@ class Post_Duplicator_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_generate_copy_author( $original, $expected ) {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_author = 1;
 		$post->post_type   = $original['post_type'];
 
 		$options                = [];
 		$options['copy_author'] = $original['copy_author'];
 
-		$user     = Mockery::mock( \WP_User::class );
+		$user     = Mockery::mock( WP_User::class );
 		$user->ID = 2;
 
 		Monkey\Functions\expect( '\wp_get_current_user' )

--- a/tests/class-post-republisher-test.php
+++ b/tests/class-post-republisher-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
 use Yoast\WP\Duplicate_Post\Post_Republisher;
@@ -169,7 +170,7 @@ class Post_Republisher_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_change_post_copy_status( $input, $expected ) {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->ID          = 123;
 		$post->post_status = $input['post_status'];
 		$postarr           = [];
@@ -224,11 +225,11 @@ class Post_Republisher_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_republish_scheduled_post() {
-		$original              = Mockery::mock( \WP_Post::class );
+		$original              = Mockery::mock( WP_Post::class );
 		$original->ID          = 1;
 		$original->post_status = 'publish';
 
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->ID          = 123;
 		$copy->post_status = 'future';
 
@@ -257,7 +258,7 @@ class Post_Republisher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_scheduled_post
 	 */
 	public function test_republish_scheduled_post_invalid_copy() {
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->ID          = 123;
 		$copy->post_status = 'publish';
 
@@ -281,7 +282,7 @@ class Post_Republisher_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_republish_scheduled_post_original_deleted() {
-		$copy              = Mockery::mock( \WP_Post::class );
+		$copy              = Mockery::mock( WP_Post::class );
 		$copy->ID          = 123;
 		$copy->post_status = 'publish';
 

--- a/tests/class-revisions-migrator-test.php
+++ b/tests/class-revisions-migrator-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Revisions_Migrator;
 
 /**
@@ -47,14 +48,14 @@ class Revisions_Migrator_Test extends TestCase {
 	public function test_migrate_revisions_unlimited() {
 		$post_id           = 128;
 		$original_id       = 64;
-		$post              = Mockery::mock( \WP_Post::class );
-		$original_post     = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
+		$original_post     = Mockery::mock( WP_Post::class );
 		$original_post->ID = $original_id;
 		$revisions         = [
-			Mockery::mock( \WP_Post::class ),
-			Mockery::mock( \WP_Post::class ),
-			Mockery::mock( \WP_Post::class ),
-			Mockery::mock( \WP_Post::class ),
+			Mockery::mock( WP_Post::class ),
+			Mockery::mock( WP_Post::class ),
+			Mockery::mock( WP_Post::class ),
+			Mockery::mock( WP_Post::class ),
 		];
 
 		Monkey\Functions\expect( '\get_post' )
@@ -89,11 +90,11 @@ class Revisions_Migrator_Test extends TestCase {
 	public function test_migrate_revisions_limited() {
 		$post_id             = 128;
 		$original_id         = 64;
-		$post                = Mockery::mock( \WP_Post::class );
-		$revision            = Mockery::mock( \WP_Post::class );
+		$post                = Mockery::mock( WP_Post::class );
+		$revision            = Mockery::mock( WP_Post::class );
 		$revision->ID        = 123;
 		$revision->post_name = 'revision';
-		$original_post       = Mockery::mock( \WP_Post::class );
+		$original_post       = Mockery::mock( WP_Post::class );
 		$original_post->ID   = $original_id;
 		$revisions           = [
 			$revision,
@@ -145,8 +146,8 @@ class Revisions_Migrator_Test extends TestCase {
 	public function test_migrate_revisions_none() {
 		$post_id       = 128;
 		$original_id   = 64;
-		$post          = Mockery::mock( \WP_Post::class );
-		$original_post = Mockery::mock( \WP_Post::class );
+		$post          = Mockery::mock( WP_Post::class );
+		$original_post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post, $original_post );

--- a/tests/handlers/class-check-changes-handler-test.php
+++ b/tests/handlers/class-check-changes-handler-test.php
@@ -3,6 +3,8 @@
 namespace Yoast\WP\Duplicate_Post\Tests\Handlers;
 
 use Brain\Monkey;
+use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Handlers\Check_Changes_Handler;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
@@ -32,9 +34,9 @@ class Check_Changes_Handler_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->permissions_helper = \Mockery::mock( Permissions_Helper::class );
+		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
-		$this->instance = \Mockery::mock( Check_Changes_Handler::class, [ $this->permissions_helper ] )->makePartial();
+		$this->instance = Mockery::mock( Check_Changes_Handler::class, [ $this->permissions_helper ] )->makePartial();
 	}
 
 	/**
@@ -65,15 +67,15 @@ class Check_Changes_Handler_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_check_changes_action_handler_successful() {
-		$utils                  = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils                  = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$_GET['post']           = '123';
 		$_REQUEST['action']     = 'duplicate_post_check_changes';
-		$post                   = \Mockery::mock( \WP_Post::class );
+		$post                   = Mockery::mock( WP_Post::class );
 		$post->ID               = 123;
 		$post->post_title       = 'Unchanged Title';
 		$post->post_content     = 'Updated content';
 		$post->post_excerpt     = 'Updated excerpt';
-		$original               = \Mockery::mock( \WP_Post::class );
+		$original               = Mockery::mock( WP_Post::class );
 		$original->ID           = 100;
 		$original->post_title   = 'Unchanged Title';
 		$original->post_content = 'Original content';
@@ -179,10 +181,10 @@ class Check_Changes_Handler_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_check_changes_action_handler_no_original() {
-		$utils              = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils              = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$_GET['post']       = '123';
 		$_REQUEST['action'] = 'duplicate_post_check_changes';
-		$post               = \Mockery::mock( \WP_Post::class );
+		$post               = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\check_admin_referer' )
 			->with( 'duplicate_post_check_changes_123' );

--- a/tests/ui/class-admin-bar-test.php
+++ b/tests/ui/class-admin-bar-test.php
@@ -4,6 +4,10 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Admin_Bar;
+use WP_Post;
+use WP_Query;
+use WP_Term;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Admin_Bar;
@@ -105,8 +109,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_successful_both() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( \WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post              = Mockery::mock( \WP_Post::class );
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -158,8 +162,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_successful_one() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( \WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post              = Mockery::mock( \WP_Post::class );
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'pending';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -204,8 +208,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_unsuccessful_no_admin_bar() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( \WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post              = Mockery::mock( \WP_Post::class );
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -240,8 +244,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_unsuccessful_no_post() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( \WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post              = Mockery::mock( \WP_Post::class );
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -274,7 +278,7 @@ class Admin_Bar_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Admin_Bar::enqueue_styles
 	 */
 	public function test_enqueue_styles_successful() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -294,7 +298,7 @@ class Admin_Bar_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Admin_Bar::enqueue_styles
 	 */
 	public function test_enqueue_styles_unsuccessful_no_admin_bar() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -316,7 +320,7 @@ class Admin_Bar_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Admin_Bar::enqueue_styles
 	 */
 	public function test_enqueue_styles_unsuccessful_no_post() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\is_admin_bar_showing' )
@@ -338,8 +342,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_successful_backend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( \WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post            = Mockery::mock( \WP_Post::class );
+		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\is_admin' )
@@ -375,8 +379,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_successful_frontend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( \WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post            = Mockery::mock( \WP_Post::class );
+		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\is_admin' )
@@ -413,7 +417,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_backend() {
 		global $wp_the_query;
-		$wp_the_query = Mockery::mock( \WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_the_query = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
 		$post         = null;
 
 		Monkey\Functions\expect( '\is_admin' )
@@ -450,8 +454,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_frontend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( \WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post            = Mockery::mock( \WP_Term::class );
+		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post            = Mockery::mock( WP_Term::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\is_admin' )
@@ -489,8 +493,8 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_should_not_be_displayed() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( \WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
-		$post            = Mockery::mock( \WP_Post::class );
+		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\is_admin' )

--- a/tests/ui/class-block-editor-test.php
+++ b/tests/ui/class-block-editor-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Asset_Manager;
@@ -147,7 +148,7 @@ class Block_Editor_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_should_previously_used_keyword_assessment_run( $original, $expected ) {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'is_edit_post_screen' )
@@ -248,7 +249,7 @@ class Block_Editor_Test extends TestCase {
 	 */
 	public function test_enqueue_block_editor_scripts() {
 		$utils                      = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post                       = Mockery::mock( \WP_Post::class );
+		$post                       = Mockery::mock( WP_Post::class );
 		$new_draft_link             = 'http://fakeu.rl/new_draft';
 		$rewrite_and_republish_link = 'http://fakeu.rl/rewrite_and_republish';
 		$rewriting                  = 0;
@@ -326,7 +327,7 @@ class Block_Editor_Test extends TestCase {
 	 */
 	public function test_get_new_draft_permalink_rewrite_and_republish() {
 		$utils                      = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post                       = Mockery::mock( \WP_Post::class );
+		$post                       = Mockery::mock( WP_Post::class );
 		$new_draft_link             = 'http://fakeu.rl/new_draft';
 		$rewrite_and_republish_link = 'http://fakeu.rl/rewrite_and_republish';
 		$rewriting                  = 1;
@@ -449,7 +450,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_new_draft_permalink
 	 */
 	public function test_get_new_draft_permalink_successful() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 		$url  = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_new_draft&post=201&_wpnonce=94038b7dee';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -475,7 +476,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_new_draft_permalink
 	 */
 	public function test_get_new_draft_permalink_unsuccessful() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -500,7 +501,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
 	public function test_get_rewrite_republish_permalink_successful() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 		$url  = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_rewrite&post=201&_wpnonce=5e7abf68c9';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -535,7 +536,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
 	public function test_get_rewrite_republish_permalink_unsuccessful_is_rewrite_and_republish() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -570,7 +571,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
 	public function test_get_rewrite_republish_permalink_unsuccessful_has_a_rewrite_and_republish() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -604,7 +605,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_rewrite_republish_permalink
 	 */
 	public function test_get_rewrite_republish_permalink_unsuccessful_links_should_not_be_displayed() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -639,7 +640,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_check_permalink
 	 */
 	public function test_get_check_permalink_successful() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 		$url  = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_check_changes&post=201&_wpnonce=5e7abf68c9';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -665,7 +666,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::get_check_permalink
 	 */
 	public function test_get_check_permalink_not_rewrite_and_republish() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -692,7 +693,7 @@ class Block_Editor_Test extends TestCase {
 	 */
 	public function test_get_original_post_edit_url_successful() {
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post        = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
 		$post->ID    = 128;
 		$original_id = 64;
 		$nonce       = '12345678';
@@ -746,7 +747,7 @@ class Block_Editor_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_original_post_edit_url_not_rewrite_and_republish() {
-		$post     = Mockery::mock( \WP_Post::class );
+		$post     = Mockery::mock( WP_Post::class );
 		$post->ID = 128;
 
 		Monkey\Functions\expect( '\get_post' )
@@ -787,7 +788,7 @@ class Block_Editor_Test extends TestCase {
 	 */
 	public function test_get_original_post_edit_url_no_original() {
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post        = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
 		$post->ID    = 128;
 		$original_id = '';
 
@@ -816,7 +817,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::hide_elementor_post_status
 	 */
 	public function test_hide_elementor_post_status() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -842,7 +843,7 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::hide_elementor_post_status
 	 */
 	public function test_dont_remove_elementor_post_status() {
-		$post = Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );

--- a/tests/ui/class-bulk-actions-test.php
+++ b/tests/ui/class-bulk-actions-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Bulk_Actions;
@@ -32,8 +33,8 @@ class Bulk_Actions_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->permissions_helper = \Mockery::mock( Permissions_Helper::class );
-		$this->instance           = \Mockery::mock( Bulk_Actions::class, [ $this->permissions_helper ] )->makePartial();
+		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
+		$this->instance           = Mockery::mock( Bulk_Actions::class, [ $this->permissions_helper ] )->makePartial();
 	}
 
 	/**
@@ -53,7 +54,7 @@ class Bulk_Actions_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_register_hooks() {
-		$utils = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 
 		$utils->expects( 'get_option' )
 			->with( 'duplicate_post_show_link_in', 'bulkactions' )
@@ -138,7 +139,7 @@ class Bulk_Actions_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_register_bulk_action() {
-		$utils = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 
 		$utils->expects( 'get_option' )
 			->with( 'duplicate_post_show_link', 'clone' )

--- a/tests/ui/class-classic-editor-test.php
+++ b/tests/ui/class-classic-editor-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Asset_Manager;
@@ -122,7 +123,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_enqueue_classic_editor_scripts() {
 		$_GET['post'] = '123';
-		$post         = Mockery::mock( \WP_Post::class );
+		$post         = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper->expects( 'is_classic_editor' )
 			->andReturnTrue();
@@ -149,7 +150,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_enqueue_classic_editor_styles() {
 		$_GET['post'] = '123';
-		$post         = Mockery::mock( \WP_Post::class );
+		$post         = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper->expects( 'is_classic_editor' )
 			->andReturnTrue();
@@ -174,7 +175,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_successful() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 		$url             = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_new_draft&post=201&_wpnonce=94038b7dee';
 
@@ -207,7 +208,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_add_new_draft_post_button_successful_post_from_GET() {
 		$_GET['post']    = '123';
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 		$url             = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_new_draft&post=123&_wpnonce=94038b7dee';
 
@@ -267,7 +268,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_unsuccessful_no_link_allowed() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_option' )
@@ -297,7 +298,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_successful() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
 		$post->post_status = 'publish';
 		$url               = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_rewrite&post=201&_wpnonce=94038b7dee';
@@ -336,7 +337,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_add_rewrite_and_republish_post_button_post_from_GET() {
 		$_GET['post']      = '123';
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
 		$post->post_status = 'publish';
 		$url               = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_rewrite&post=201&_wpnonce=94038b7dee';
@@ -402,7 +403,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_unsuccessful_is_for_rewrite_and_republish() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
 		$post->post_status = 'publish';
 
@@ -438,7 +439,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_not_publish() {
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
 		$post->post_status = 'draft';
 
@@ -470,7 +471,7 @@ class Classic_Editor_Test extends TestCase {
 	public function test_should_change_republish_strings_date_label() {
 		$text = 'Publish on: %s';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -493,7 +494,7 @@ class Classic_Editor_Test extends TestCase {
 	public function test_should_change_republish_strings() {
 		$text = 'Publish';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -517,7 +518,7 @@ class Classic_Editor_Test extends TestCase {
 		$text        = 'Publish';
 		$translation = 'Publish';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -542,7 +543,7 @@ class Classic_Editor_Test extends TestCase {
 		$text        = 'Test';
 		$translation = 'Test';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -565,7 +566,7 @@ class Classic_Editor_Test extends TestCase {
 	public function test_should_change_schedule_strings() {
 		$text = 'Schedule';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -589,7 +590,7 @@ class Classic_Editor_Test extends TestCase {
 		$text        = 'Schedule';
 		$translation = 'Schedule';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -614,7 +615,7 @@ class Classic_Editor_Test extends TestCase {
 		$text        = 'Test';
 		$translation = 'Test';
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\get_post' )
@@ -635,7 +636,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
 	 */
 	public function test_should_change_scheduled_notice_post() {
-		$post             = Mockery::mock( \WP_Post::class );
+		$post             = Mockery::mock( WP_Post::class );
 		$post->post_type  = 'post';
 		$post->post_title = 'example_post';
 		$post->ID         = 1;
@@ -747,7 +748,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
 	 */
 	public function test_should_change_scheduled_notice_page() {
-		$post             = Mockery::mock( \WP_Post::class );
+		$post             = Mockery::mock( WP_Post::class );
 		$post->post_type  = 'page';
 		$post->post_title = 'example_page';
 		$post->ID         = 1;
@@ -862,7 +863,7 @@ class Classic_Editor_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'post.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
@@ -882,7 +883,7 @@ class Classic_Editor_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'post-new.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
@@ -903,7 +904,7 @@ class Classic_Editor_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'xx.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->assertFalse( $this->instance->should_change_rewrite_republish_copy( $post ) );
@@ -932,7 +933,7 @@ class Classic_Editor_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'post.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
 
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
@@ -949,7 +950,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::remove_slug_meta_box
 	 */
 	public function test_remove_slug_meta_box() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
@@ -970,7 +971,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::remove_slug_meta_box
 	 */
 	public function test_remove_slug_meta_box_not_rewrite_and_republish_copy() {
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
@@ -994,7 +995,7 @@ class Classic_Editor_Test extends TestCase {
 		$post_id         = '123';
 		$new_title       = null;
 		$new_slug        = null;
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
@@ -1015,7 +1016,7 @@ class Classic_Editor_Test extends TestCase {
 		$post_id         = '123';
 		$new_title       = null;
 		$new_slug        = null;
-		$post            = Mockery::mock( \WP_Post::class );
+		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
 		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )

--- a/tests/ui/class-link-builder-test.php
+++ b/tests/ui/class-link-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Link_Builder;
 
@@ -34,7 +35,7 @@ class Link_Builder_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Link_Builder::build_rewrite_and_republish_link
 	 */
 	public function test_build_rewrite_and_republish_link() {
-		$post    = Mockery::mock( \WP_Post::class );
+		$post    = Mockery::mock( WP_Post::class );
 		$context = 'display';
 		$url     = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_rewrite&amp;post=123';
 
@@ -55,7 +56,7 @@ class Link_Builder_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Link_Builder::build_clone_link
 	 */
 	public function test_build_clone_link() {
-		$post    = Mockery::mock( \WP_Post::class );
+		$post    = Mockery::mock( WP_Post::class );
 		$context = 'display';
 		$url     = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_clone&amp;post=123';
 
@@ -76,7 +77,7 @@ class Link_Builder_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Link_Builder::build_new_draft_link
 	 */
 	public function test_build_new_draft_link() {
-		$post    = Mockery::mock( \WP_Post::class );
+		$post    = Mockery::mock( WP_Post::class );
 		$context = 'display';
 		$url     = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_new_draft&amp;post=123';
 
@@ -97,7 +98,7 @@ class Link_Builder_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Link_Builder::build_check_link
 	 */
 	public function test_build_check_link() {
-		$post    = Mockery::mock( \WP_Post::class );
+		$post    = Mockery::mock( WP_Post::class );
 		$context = 'display';
 		$url     = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_check_changes&amp;post=123';
 
@@ -118,7 +119,7 @@ class Link_Builder_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Link_Builder::build_link
 	 */
 	public function test_build_link() {
-		$post        = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
 		$post->ID    = 123;
 		$context     = 'display';
 		$action_name = 'duplicate_post_clone';
@@ -149,7 +150,7 @@ class Link_Builder_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Link_Builder::build_link
 	 */
 	public function test_build_link_not_display() {
-		$post        = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
 		$post->ID    = 123;
 		$context     = '';
 		$action_name = 'duplicate_post_clone';

--- a/tests/ui/class-metabox-test.php
+++ b/tests/ui/class-metabox-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Metabox;
@@ -75,8 +76,8 @@ class Metabox_Test extends TestCase {
 	public function test_add_custom_metabox() {
 		$utils              = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$enabled_post_types = [ 'post', 'page' ];
-		$post               = Mockery::mock( \WP_Post::class );
-		$original_item      = Mockery::mock( \WP_Post::class );
+		$post               = Mockery::mock( WP_Post::class );
+		$original_item      = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper->expects( 'get_enabled_post_types' )
 			->andReturn( $enabled_post_types );
@@ -108,7 +109,7 @@ class Metabox_Test extends TestCase {
 	 */
 	public function test_add_custom_metabox_post_type_not_enabled() {
 		$enabled_post_types = [ 'post' ];
-		$post               = Mockery::mock( \WP_Post::class );
+		$post               = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'get_enabled_post_types' )
@@ -130,7 +131,7 @@ class Metabox_Test extends TestCase {
 	public function test_add_custom_metabox_not_copy() {
 		$utils              = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$enabled_post_types = [ 'post', 'page' ];
-		$post               = Mockery::mock( \WP_Post::class );
+		$post               = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'get_enabled_post_types' )

--- a/tests/ui/class-post-states-test.php
+++ b/tests/ui/class-post-states-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Post_States;
@@ -67,8 +68,8 @@ class Post_States_Test extends TestCase {
 	 */
 	public function test_show_original_in_post_states_successful() {
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post        = Mockery::mock( \WP_Post::class );
-		$original    = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
+		$original    = Mockery::mock( WP_Post::class );
 		$post_states = [
 			'draft' => 'Draft',
 		];
@@ -108,7 +109,7 @@ class Post_States_Test extends TestCase {
 	 */
 	public function test_show_original_in_post_states_unsuccessful() {
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post        = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
 		$post_states = [
 			'draft' => 'Draft',
 		];
@@ -145,8 +146,8 @@ class Post_States_Test extends TestCase {
 	 */
 	public function test_show_original_in_rewrite_republish_post_successful() {
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post        = Mockery::mock( \WP_Post::class );
-		$original    = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
+		$original    = Mockery::mock( WP_Post::class );
 		$post_states = [
 			'draft' => 'Draft',
 		];
@@ -186,7 +187,7 @@ class Post_States_Test extends TestCase {
 	 */
 	public function test_show_original_in_rewrite_republish_post_unsuccessful() {
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
-		$post        = Mockery::mock( \WP_Post::class );
+		$post        = Mockery::mock( WP_Post::class );
 		$post_states = [
 			'draft' => 'Draft',
 		];

--- a/tests/ui/class-row-actions-test.php
+++ b/tests/ui/class-row-actions-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\UI;
 
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\UI\Link_Builder;
@@ -66,7 +67,7 @@ class Row_Actions_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_register_hooks() {
-		$utils = \Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 
 		$utils->expects( 'get_option' )
 			->with( 'duplicate_post_show_link_in', 'row' )
@@ -110,7 +111,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post             = Mockery::mock( \WP_Post::class );
+		$post             = Mockery::mock( WP_Post::class );
 		$post->post_title = 'Title';
 		$post->post_type  = 'post';
 		$post->ID         = '464';
@@ -158,7 +159,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post    = Mockery::mock( \WP_Post::class );
+		$post    = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'should_links_be_displayed' )
@@ -195,7 +196,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post             = Mockery::mock( \WP_Post::class );
+		$post             = Mockery::mock( WP_Post::class );
 		$post->post_title = 'Title';
 		$post->post_type  = 'post';
 		$post->ID         = '464';
@@ -243,7 +244,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post    = Mockery::mock( \WP_Post::class );
+		$post    = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'should_links_be_displayed' )
@@ -280,7 +281,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_title  = 'Title';
 		$post->post_type   = 'post';
 		$post->post_status = 'publish';
@@ -334,7 +335,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
 		$this->permissions_helper
@@ -377,7 +378,7 @@ class Row_Actions_Test extends TestCase {
 			'trash'                => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=trash&amp;_wpnonce=e52d0bff9b" class="submitdelete" aria-label="Move &#8220;Title&#8221; to the Trash">Trash</a>',
 			'view'                 => '<a href="http://basic.wordpress.test/?p=464&#038;preview=true" rel="bookmark" aria-label="Preview &#8220;Title&#8221;">Preview</a>',
 		];
-		$post              = Mockery::mock( \WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'draft';
 
 		$this->permissions_helper

--- a/tests/watchers/class-bulk-actions-watcher-test.php
+++ b/tests/watchers/class-bulk-actions-watcher-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 
+use Mockery;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\Watchers\Bulk_Actions_Watcher;
 
@@ -23,7 +24,7 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = \Mockery::mock( Bulk_Actions_Watcher::class )->makePartial();
+		$this->instance = Mockery::mock( Bulk_Actions_Watcher::class )->makePartial();
 	}
 
 	/**

--- a/tests/watchers/class-copied-post-watcher-test.php
+++ b/tests/watchers/class-copied-post-watcher-test.php
@@ -3,6 +3,8 @@
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 
 use Brain\Monkey;
+use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher;
@@ -32,9 +34,9 @@ class Copied_Post_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->permissions_helper = \Mockery::mock( Permissions_Helper::class );
+		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
-		$this->instance = \Mockery::mock(
+		$this->instance = Mockery::mock(
 			Copied_Post_Watcher::class
 		)->makePartial();
 		$this->instance->__construct( $this->permissions_helper );
@@ -67,7 +69,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text_not_scheduled() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'has_scheduled_rewrite_and_republish_copy' )
@@ -91,8 +93,8 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text_scheduled() {
-		$post = \Mockery::mock( \WP_Post::class );
-		$copy = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
+		$copy = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'has_scheduled_rewrite_and_republish_copy' )
@@ -124,7 +126,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text_copy_in_the_trash() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'has_scheduled_rewrite_and_republish_copy' )
@@ -147,7 +149,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_classic() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'is_classic_editor' )
@@ -191,7 +193,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_not_rewrite_and_republish() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'is_classic_editor' )
@@ -216,7 +218,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_block_editor_notice
 	 */
 	public function test_add_block_editor_notice() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -257,7 +259,7 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_block_editor_notice
 	 */
 	public function test_add_block_editor_notice_not_rewrite_and_republish() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );

--- a/tests/watchers/class-link-actions-watcher-test.php
+++ b/tests/watchers/class-link-actions-watcher-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\Watchers\Link_Actions_Watcher;
@@ -32,9 +33,9 @@ class Link_Actions_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->permissions_helper = \Mockery::mock( Permissions_Helper::class );
+		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
-		$this->instance = \Mockery::mock(
+		$this->instance = Mockery::mock(
 			Link_Actions_Watcher::class
 		)->makePartial();
 		$this->instance->__construct( $this->permissions_helper );

--- a/tests/watchers/class-original-post-watcher-test.php
+++ b/tests/watchers/class-original-post-watcher-test.php
@@ -3,6 +3,8 @@
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 
 use Brain\Monkey;
+use Mockery;
+use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\Watchers\Original_Post_Watcher;
@@ -32,9 +34,9 @@ class Original_Post_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->permissions_helper = \Mockery::mock( Permissions_Helper::class );
+		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
-		$this->instance = \Mockery::mock(
+		$this->instance = Mockery::mock(
 			Original_Post_Watcher::class
 		)->makePartial();
 		$this->instance->__construct( $this->permissions_helper );
@@ -79,7 +81,7 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Original_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_classic() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'is_classic_editor' )
@@ -123,7 +125,7 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_original_not_changed() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
 			->expects( 'is_classic_editor' )
@@ -148,7 +150,7 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_block_editor_notice
 	 */
 	public function test_add_block_editor_notice() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );
@@ -188,7 +190,7 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_block_editor_notice
 	 */
 	public function test_add_block_editor_notice_original_not_changed() {
-		$post = \Mockery::mock( \WP_Post::class );
+		$post = Mockery::mock( WP_Post::class );
 
 		Monkey\Functions\expect( '\get_post' )
 			->andReturn( $post );

--- a/tests/watchers/class-republished-post-watcher-test.php
+++ b/tests/watchers/class-republished-post-watcher-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Duplicate_Post\Tests\Watchers;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
 use Yoast\WP\Duplicate_Post\Watchers\Republished_Post_Watcher;
@@ -32,9 +33,9 @@ class Republished_Post_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->permissions_helper = \Mockery::mock( Permissions_Helper::class );
+		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
-		$this->instance = \Mockery::mock(
+		$this->instance = Mockery::mock(
 			Republished_Post_Watcher::class
 		)->makePartial();
 		$this->instance->__construct( $this->permissions_helper );


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

* No functional changes.
* Code style compliance.

QA: consistently use `use` statements for classes

Always use `use` statements for every class used not in the exact same namespace, even when the class is only used in docblocks.

This is on the one hand about consistency, on the other hand about documenting which classes are used in a file.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.