### PR TITLE
QA: call global functions using a fully qualified name

### DIFF
--- a/duplicate-post-options.php
+++ b/duplicate-post-options.php
@@ -8,7 +8,7 @@ use Yoast\WP\Duplicate_Post\Admin\Options_Inputs;
 use Yoast\WP\Duplicate_Post\Admin\Options_Page;
 use Yoast\WP\Duplicate_Post\UI\Asset_Manager;
 
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! \defined( 'ABSPATH' ) ) {
 	exit();
 }
 

--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -192,7 +192,7 @@ class Options_Form_Generator {
 		foreach ( Utils::get_roles() as $name => $display_name ) {
 			$role = \get_role( $name );
 
-			if ( count( \array_intersect_key( $role->capabilities, $edit_capabilities ) ) > 0 ) {
+			if ( \count( \array_intersect_key( $role->capabilities, $edit_capabilities ) ) > 0 ) {
 				$output .= $this->generate_options_input(
 					[
 						'duplicate_post_roles[]' => [

--- a/src/admin/class-options.php
+++ b/src/admin/class-options.php
@@ -213,8 +213,8 @@ class Options {
 				'label'       => \__( 'Do not copy these fields', 'duplicate-post' ),
 				'value'       => \get_option( 'duplicate_post_blacklist' ),
 				'description' => [
-					__( 'Comma-separated list of meta fields that must not be copied.', 'duplicate-post' ),
-					__( 'You can use * to match zero or more alphanumeric characters or underscores: e.g. field*', 'duplicate-post' ),
+					\__( 'Comma-separated list of meta fields that must not be copied.', 'duplicate-post' ),
+					\__( 'You can use * to match zero or more alphanumeric characters or underscores: e.g. field*', 'duplicate-post' ),
 				],
 			],
 			'duplicate_post_taxonomies_blacklist'         => [
@@ -236,7 +236,7 @@ class Options {
 				'label'       => \__( 'In a metabox in the Edit screen', 'duplicate-post' ),
 				'value'       => 1,
 				'description' => [
-					__( "You'll also be able to delete the reference to the original item with a checkbox", 'duplicate-post' ),
+					\__( "You'll also be able to delete the reference to the original item with a checkbox", 'duplicate-post' ),
 				],
 			],
 			'duplicate_post_show_original_column'         => [
@@ -246,7 +246,7 @@ class Options {
 				'label'       => \__( 'In a column in the Post list', 'duplicate-post' ),
 				'value'       => 1,
 				'description' => [
-					__( "You'll also be able to delete the reference to the original item with a checkbox in Quick Edit", 'duplicate-post' ),
+					\__( "You'll also be able to delete the reference to the original item with a checkbox in Quick Edit", 'duplicate-post' ),
 				],
 			],
 			'duplicate_post_show_original_in_post_states' => [

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -244,7 +244,7 @@ class Post_Republisher {
 	 * @return bool Whether or not the request is a REST request.
 	 */
 	public function is_rest_request() {
-		return defined( 'REST_REQUEST' ) && REST_REQUEST;
+		return \defined( 'REST_REQUEST' ) && REST_REQUEST;
 	}
 
 	/**

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -130,8 +130,8 @@ class Check_Changes_Handler {
 
 						$args = [
 							'show_split_view' => true,
-							'title_left'      => __( 'Removed', 'default' ),
-							'title_right'     => __( 'Added', 'default' ),
+							'title_left'      => \__( 'Removed', 'default' ),
+							'title_right'     => \__( 'Added', 'default' ),
 						];
 
 						if ( \version_compare( $wp_version, '5.7' ) < 0 ) {
@@ -148,7 +148,7 @@ class Check_Changes_Handler {
 						foreach ( $fields as $field => $name ) {
 							/** This filter is documented in wp-admin/includes/revision.php */
 							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
-							$content_from = apply_filters( "_wp_post_revision_field_{$field}", $this->original->$field, $field, $this->original, 'from' );
+							$content_from = \apply_filters( "_wp_post_revision_field_{$field}", $this->original->$field, $field, $this->original, 'from' );
 
 							/** This filter is documented in wp-admin/includes/revision.php */
 							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.

--- a/src/handlers/class-link-handler.php
+++ b/src/handlers/class-link-handler.php
@@ -150,7 +150,7 @@ class Link_Handler {
 
 		$post_type = $post->post_type;
 		$sendback  = \wp_get_referer();
-		if ( ! $sendback || strpos( $sendback, 'post.php' ) !== false || strpos( $sendback, 'post-new.php' ) !== false ) {
+		if ( ! $sendback || \strpos( $sendback, 'post.php' ) !== false || \strpos( $sendback, 'post-new.php' ) !== false ) {
 			if ( $post_type === 'attachment' ) {
 				$sendback = \admin_url( 'upload.php' );
 			}

--- a/src/ui/class-bulk-actions.php
+++ b/src/ui/class-bulk-actions.php
@@ -64,7 +64,7 @@ class Bulk_Actions {
 	 */
 	public function register_bulk_action( $bulk_actions ) {
 		// phpcs:ignore WordPress.Security.NonceVerification
-		$is_draft_or_trash = isset( $_REQUEST['post_status'] ) && in_array( $_REQUEST['post_status'], [ 'draft', 'trash' ], true );
+		$is_draft_or_trash = isset( $_REQUEST['post_status'] ) && \in_array( $_REQUEST['post_status'], [ 'draft', 'trash' ], true );
 
 		if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'clone' ) ) === 1 ) {
 			$bulk_actions['duplicate_post_bulk_clone'] = \esc_html__( 'Clone', 'duplicate-post' );

--- a/src/watchers/class-link-actions-watcher.php
+++ b/src/watchers/class-link-actions-watcher.php
@@ -110,7 +110,7 @@ class Link_Actions_Watcher {
 		if ( ! empty( $_REQUEST['rewriting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$notice = [
 				'text'          => \wp_slash(
-					__(
+					\__(
 						'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", this rewritten post will replace the original post.',
 						'duplicate-post'
 					)

--- a/tests/admin/class-options-page-test.php
+++ b/tests/admin/class-options-page-test.php
@@ -131,8 +131,8 @@ class Options_Page_Test extends TestCase {
 		Monkey\Functions\expect( '\add_options_page' )
 			->with(
 				[
-					__( 'Duplicate Post Options', 'duplicate-post' ),
-					__( 'Duplicate Post', 'duplicate-post' ),
+					\__( 'Duplicate Post Options', 'duplicate-post' ),
+					\__( 'Duplicate Post', 'duplicate-post' ),
 					'manage_options',
 					'duplicatepost',
 					[ $this, 'generate_page' ],

--- a/tests/admin/class-options-test.php
+++ b/tests/admin/class-options-test.php
@@ -64,7 +64,7 @@ class Options_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options::register_settings
 	 */
 	public function test_register_settings() {
-		foreach ( array_keys( $this->fake_options ) as $fake_option ) {
+		foreach ( \array_keys( $this->fake_options ) as $fake_option ) {
 			Monkey\Functions\expect( '\register_setting' )
 				->once()
 				->with( 'duplicate_post_group', $fake_option );

--- a/tests/class-post-republisher-test.php
+++ b/tests/class-post-republisher-test.php
@@ -108,7 +108,7 @@ class Post_Republisher_Test extends TestCase {
 	 */
 	public function test_is_classic_editor_post_request_when_rest_request() {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WordPress constant used in a test.
-		define( 'REST_REQUEST', true );
+		\define( 'REST_REQUEST', true );
 		$this->assertFalse( $this->instance->is_classic_editor_post_request() );
 	}
 


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

* No functional changes.
* Code style compliance.

When PHP encounters an unqualified function call in a namespaced file, it will first try and find the function within the namespace and only when it can not find it in the namespace, fall-back to the global function.

Using fully qualified function names when calling a global function ensures that PHP will bypass the search within the namespace and call the global function directly.

It also ensures that optimal use is made of the PHP7 opcodes on VM level which have been implemented for a select group of PHP internal functions resulting in faster code execution.

Ref: https://www.php.net/manual/en/language.namespaces.fallback.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.