### PR TITLE
QA: use global constants with a fully qualified name

### DIFF
--- a/src/admin/class-options-page.php
+++ b/src/admin/class-options-page.php
@@ -149,7 +149,7 @@ class Options_Page {
 	public function generate_page() {
 		$this->register_capabilities();
 
-		require_once DUPLICATE_POST_PATH . 'src/admin/views/options.php';
+		require_once \DUPLICATE_POST_PATH . 'src/admin/views/options.php';
 	}
 
 	/**

--- a/src/class-post-republisher.php
+++ b/src/class-post-republisher.php
@@ -244,7 +244,7 @@ class Post_Republisher {
 	 * @return bool Whether or not the request is a REST request.
 	 */
 	public function is_rest_request() {
-		return \defined( 'REST_REQUEST' ) && REST_REQUEST;
+		return \defined( 'REST_REQUEST' ) && \REST_REQUEST;
 	}
 
 	/**

--- a/src/handlers/class-check-changes-handler.php
+++ b/src/handlers/class-check-changes-handler.php
@@ -194,7 +194,7 @@ class Check_Changes_Handler {
 		\set_current_screen( 'revision' );
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- The revision screen expects $post to be set.
 		$post = $this->post;
-		require_once ABSPATH . 'wp-admin/admin-header.php';
+		require_once \ABSPATH . 'wp-admin/admin-header.php';
 	}
 
 	/**
@@ -205,6 +205,6 @@ class Check_Changes_Handler {
 	 * @return void
 	 */
 	public function require_wordpress_footer() {
-		require_once ABSPATH . 'wp-admin/admin-footer.php';
+		require_once \ABSPATH . 'wp-admin/admin-footer.php';
 	}
 }

--- a/src/handlers/class-save-post-handler.php
+++ b/src/handlers/class-save-post-handler.php
@@ -47,7 +47,7 @@ class Save_Post_Handler {
 	 * @return void
 	 */
 	public function delete_on_save_post( $post_id ) {
-		if ( ( \defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		if ( ( \defined( 'DOING_AUTOSAVE' ) && \DOING_AUTOSAVE )
 			|| empty( $_POST['duplicate_post_remove_original'] ) // phpcs:ignore WordPress.Security.NonceVerification
 			|| ! \current_user_can( 'edit_post', $post_id ) ) {
 			return;

--- a/src/ui/class-asset-manager.php
+++ b/src/ui/class-asset-manager.php
@@ -25,8 +25,8 @@ class Asset_Manager {
 	 * @return void
 	 */
 	public function register_styles() {
-		\wp_register_style( 'duplicate-post', \plugins_url( '/css/duplicate-post.css', DUPLICATE_POST_FILE ), [], DUPLICATE_POST_CURRENT_VERSION );
-		\wp_register_style( 'duplicate-post-options', \plugins_url( '/css/duplicate-post-options.css', DUPLICATE_POST_FILE ), [], DUPLICATE_POST_CURRENT_VERSION );
+		\wp_register_style( 'duplicate-post', \plugins_url( '/css/duplicate-post.css', \DUPLICATE_POST_FILE ), [], \DUPLICATE_POST_CURRENT_VERSION );
+		\wp_register_style( 'duplicate-post-options', \plugins_url( '/css/duplicate-post-options.css', \DUPLICATE_POST_FILE ), [], \DUPLICATE_POST_CURRENT_VERSION );
 	}
 
 	/**
@@ -35,45 +35,45 @@ class Asset_Manager {
 	 * @return void
 	 */
 	public function register_scripts() {
-		$flattened_version = Utils::flatten_version( DUPLICATE_POST_CURRENT_VERSION );
+		$flattened_version = Utils::flatten_version( \DUPLICATE_POST_CURRENT_VERSION );
 
 		\wp_register_script(
 			'duplicate_post_edit_script',
-			\plugins_url( \sprintf( 'js/dist/duplicate-post-edit-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
+			\plugins_url( \sprintf( 'js/dist/duplicate-post-edit-%s.js', $flattened_version ), \DUPLICATE_POST_FILE ),
 			[
 				'wp-components',
 				'wp-element',
 				'wp-i18n',
 			],
-			DUPLICATE_POST_CURRENT_VERSION,
+			\DUPLICATE_POST_CURRENT_VERSION,
 			true
 		);
 
 		\wp_register_script(
 			'duplicate_post_strings',
-			\plugins_url( \sprintf( 'js/dist/duplicate-post-strings-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
+			\plugins_url( \sprintf( 'js/dist/duplicate-post-strings-%s.js', $flattened_version ), \DUPLICATE_POST_FILE ),
 			[
 				'wp-components',
 				'wp-element',
 				'wp-i18n',
 			],
-			DUPLICATE_POST_CURRENT_VERSION,
+			\DUPLICATE_POST_CURRENT_VERSION,
 			true
 		);
 
 		\wp_register_script(
 			'duplicate_post_quick_edit_script',
-			\plugins_url( \sprintf( 'js/dist/duplicate-post-quick-edit-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
+			\plugins_url( \sprintf( 'js/dist/duplicate-post-quick-edit-%s.js', $flattened_version ), \DUPLICATE_POST_FILE ),
 			[ 'jquery' ],
-			DUPLICATE_POST_CURRENT_VERSION,
+			\DUPLICATE_POST_CURRENT_VERSION,
 			true
 		);
 
 		\wp_register_script(
 			'duplicate_post_options_script',
-			\plugins_url( \sprintf( 'js/dist/duplicate-post-options-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
+			\plugins_url( \sprintf( 'js/dist/duplicate-post-options-%s.js', $flattened_version ), \DUPLICATE_POST_FILE ),
 			[ 'jquery' ],
-			DUPLICATE_POST_CURRENT_VERSION,
+			\DUPLICATE_POST_CURRENT_VERSION,
 			true
 		);
 	}
@@ -161,14 +161,14 @@ class Asset_Manager {
 	 * @return void
 	 */
 	public function enqueue_elementor_script( $object = [] ) {
-		$flattened_version = Utils::flatten_version( DUPLICATE_POST_CURRENT_VERSION );
+		$flattened_version = Utils::flatten_version( \DUPLICATE_POST_CURRENT_VERSION );
 		$handle            = 'duplicate_post_elementor_script';
 
 		\wp_register_script(
 			$handle,
-			\plugins_url( \sprintf( 'js/dist/duplicate-post-elementor-%s.js', $flattened_version ), DUPLICATE_POST_FILE ),
+			\plugins_url( \sprintf( 'js/dist/duplicate-post-elementor-%s.js', $flattened_version ), \DUPLICATE_POST_FILE ),
 			[ 'jquery' ],
-			DUPLICATE_POST_CURRENT_VERSION,
+			\DUPLICATE_POST_CURRENT_VERSION,
 			true
 		);
 		\wp_enqueue_script( $handle );

--- a/tests/ui/class-asset-manager-test.php
+++ b/tests/ui/class-asset-manager-test.php
@@ -58,7 +58,7 @@ class Asset_Manager_Test extends TestCase {
 				'duplicate-post',
 				$styles_url,
 				[],
-				DUPLICATE_POST_CURRENT_VERSION
+				\DUPLICATE_POST_CURRENT_VERSION
 			);
 
 		Monkey\Functions\expect( '\wp_register_style' )
@@ -66,7 +66,7 @@ class Asset_Manager_Test extends TestCase {
 				'duplicate-post-options',
 				$options_styles_url,
 				[],
-				DUPLICATE_POST_CURRENT_VERSION
+				\DUPLICATE_POST_CURRENT_VERSION
 			);
 
 		$this->instance->register_styles();
@@ -88,7 +88,7 @@ class Asset_Manager_Test extends TestCase {
 		$options_script_url    = 'http://basic.wordpress.test/wp-content/plugins/duplicate-post/js/dist/duplicate-post-options-40.js';
 
 		$utils->expects( 'flatten_version' )
-			->with( DUPLICATE_POST_CURRENT_VERSION )
+			->with( \DUPLICATE_POST_CURRENT_VERSION )
 			->andReturn( $flattened_version );
 
 		Monkey\Functions\expect( '\plugins_url' )
@@ -103,7 +103,7 @@ class Asset_Manager_Test extends TestCase {
 					'wp-element',
 					'wp-i18n',
 				],
-				DUPLICATE_POST_CURRENT_VERSION,
+				\DUPLICATE_POST_CURRENT_VERSION,
 				true
 			);
 
@@ -116,7 +116,7 @@ class Asset_Manager_Test extends TestCase {
 					'wp-element',
 					'wp-i18n',
 				],
-				DUPLICATE_POST_CURRENT_VERSION,
+				\DUPLICATE_POST_CURRENT_VERSION,
 				true
 			);
 
@@ -125,7 +125,7 @@ class Asset_Manager_Test extends TestCase {
 				'duplicate_post_quick_edit_script',
 				$quick_edit_script_url,
 				[ 'jquery' ],
-				DUPLICATE_POST_CURRENT_VERSION,
+				\DUPLICATE_POST_CURRENT_VERSION,
 				true
 			);
 
@@ -134,7 +134,7 @@ class Asset_Manager_Test extends TestCase {
 				'duplicate_post_options_script',
 				$options_script_url,
 				[ 'jquery' ],
-				DUPLICATE_POST_CURRENT_VERSION,
+				\DUPLICATE_POST_CURRENT_VERSION,
 				true
 			);
 


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

* No functional changes.
* Code style compliance.

When PHP encounters an unqualified constant in a namespaced file, it will first try and find the constant within the namespace and only when it can not find it in the namespace, fall-back to the global constant.

Using fully qualified constant names when using a global constant ensures that PHP will bypass the search within the namespace and use the global constant directly.

Ref: https://www.php.net/manual/en/language.namespaces.fallback.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
