### PR TITLE
Composer: set minimum supported PHP version in `require`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,22 @@
 {
+    "homepage": "https://wordpress.org/plugins/duplicate-post/",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Team Yoast",
+            "email": "support@yoast.com",
+            "homepage": "https://yoast.com"
+        }
+    ],
+    "type": "wordpress-plugin",
+    "support": {
+        "issues": "https://github.com/Yoast/duplicate-post/issues",
+        "forum":  "https://wordpress.org/plugins/duplicate-post/",
+        "source": "https://github.com/Yoast/duplicate-post"
+    },
+    "require": {
+        "php": ">=5.6"
+    },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "wp-coding-standards/wpcs": "^2.1",
@@ -7,11 +25,11 @@
         "phpunit/phpunit": "^5.7",
         "brain/monkey": "^2.5"
     },
-	"autoload": {
-		"classmap": [
-			"src/"
-		]
-	},
+    "autoload": {
+        "classmap": [
+            "src/"
+        ]
+    },
     "autoload-dev": {
         "classmap": [
             "tests/"

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,11 @@
 {
+    "name": "yoast/duplicate-post",
+    "description": "The go-to tool for cloning posts and pages, including the powerful Rewrite & Republish feature.",
     "homepage": "https://wordpress.org/plugins/duplicate-post/",
     "license": "GPL-2.0-or-later",
     "authors": [
         {
-            "name": "Team Yoast",
+            "name": "Enrico Battocchi & Team Yoast",
             "email": "support@yoast.com",
             "homepage": "https://yoast.com"
         }


### PR DESCRIPTION
## Context

* Project documentation

## Summary

This PR can be summarized in the following changelog entry:

* Project documentation

## Relevant technical choices:

Set minimum supported PHP version in `require` and various other minor tweaks to the Composer file.

While this change does not have a serious effect while the package is not listed on (WP)Packagist, it still improves the documentation of the package.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `composer show --self`.
