### PR TITLE
Travis/Composer: switch over to parallel linting of PHP files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,13 @@ matrix:
     - php: "nightly"
 
 before_install:
-  - if [[ "$SNIFF" == "1" || "$PHPUNIT" == "1" ]]; then composer install; fi
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      composer install --ignore-platform-reqs
+    else
+      composer install
+    fi
+
 
 before_script:
 - export -f travis_fold
@@ -42,7 +48,7 @@ before_script:
 - export -f travis_time_finish
 
 script:
-  - find -L . ./compat/ ./src/ \( -path ./vendor -o -path ./node_modules \) -prune -o -name '*.php'  -print0 | xargs -0 -n 1 -P 4 php -l
+  - composer lint
   - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
   - if [[ "$SNIFF" == "1" ]]; then composer check-vip; fi
   # PHP Unit Tests

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
         "phpcompatibility/phpcompatibility-wp": "^2.1.0",
         "automattic/vipwpcs": "^2.0",
         "phpunit/phpunit": "^5.7",
-        "brain/monkey": "^2.5"
+        "brain/monkey": "^2.5",
+        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-console-highlighter": "^0.5"
     },
     "autoload": {
         "classmap": [
@@ -38,6 +40,9 @@
         ]
     },
     "scripts": {
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude node_modules --exclude .git"
+        ],
         "check-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1"
         ],


### PR DESCRIPTION
## Context

* Improve dev tooling

## Summary

This PR can be summarized in the following changelog entry:

* Improve dev tooling

## Relevant technical choices:

## Composer

This installs two additional PHP packages in `require-dev`:
* [`php-parallel-lint`](https://packagist.org/packages/php-parallel-lint/php-parallel-lint) which allows for linting PHP files in parallel (faster), as well as automatically recursively walking directories.
* [`php-console-highlighter`](https://packagist.org/packages/php-parallel-lint/php-console-highlighter) which provides PHP code highlighting in the command line console, allowing the linter to display the results in a more meaningful manner.

It also adds a new `lint` script for use with Composer.

## Travis

* Switch out the script part in the Travis script which did the linting the "old-fashioned" way to use the new Parallel linting option.
* Adjust the `composer install` command in the `install` section to always run.
    Note: for PHP 8/nightly we need to ignore platform requirements at this time due to the low PHPUnit version being required.

Ref:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.2.0
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v0.5


## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check out this branch.
* Run `composer lint` to see it in action.
* Introduce a parse error in one or more files, run `composer lint` again to see the error reporting with syntax highlighting.

Also:
* Verify the linting is working correctly in the Travis builds.