### PR TITLE
Travis: various minor tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 language: php
 
 branches:
@@ -13,6 +14,7 @@ branches:
 cache:
   directories:
     - .cache
+    - $HOME/.composer/cache
 
 php:
     - '5.6'
@@ -24,7 +26,8 @@ php:
     - '8.0'
     - "nightly"
 
-matrix:
+jobs:
+  fast_finish: true
   include:
     # Arbitrary PHP version to run the sniffs against.
     - php: '7.4'
@@ -34,11 +37,12 @@ matrix:
     - php: "nightly"
 
 before_install:
+  - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
-      composer install --ignore-platform-reqs
+      travis_retry composer install --ignore-platform-reqs
     else
-      composer install
+      travis_retry composer install
     fi
 
 
@@ -58,3 +62,6 @@ script:
       composer test
       travis_time_finish && travis_fold end "PHP.tests"
     fi
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - if [[ $TRAVIS_PHP_VERSION == "5.6" ]]; then composer validate --no-check-all; fi


### PR DESCRIPTION
## Context

* Improve CI setup

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI setup

## Relevant technical choices:

* Be explicit about the expected OS.
* Cache composer downloads for faster builds.
* Use the `jobs` key. The `matrix` key has been deprecated quite a while back.
* Use `fast_finish`.
    This will mark a build as "passed" as soon as all builds which are not allowed to fail have passed.
* Disable Xdebug when it's not needed.
    Xdebug is only needed for code coverage builds and slows down the Composer `install` and test runs significantly, so conditionally disabling it.
* Use `travis_retry` for the `composer install` to prevent failed builds due to time-outs and rate limits.
* Validate the `composer.json` file just to be sure.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of the Travis build.
* Check the "View config" tab in Travis to see only one warning left, instead of the previous three.
* Take note of the speed increase in the PHP 7.4 build, which is currently the only build which runs the tests + PHPCS. I realize it's only ~12 seconds (~15%), but when the tests will be enabled for more builds, those seconds still add up ;-)