### PR TITLE
Composer/Travis: remove sniffing against VIPCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ before_script:
 script:
   - composer lint
   - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
-  - if [[ "$SNIFF" == "1" ]]; then composer check-vip; fi
   # PHP Unit Tests
   - |
     if [[ "$PHPUNIT" == "1" ]]; then

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "wp-coding-standards/wpcs": "^2.1",
         "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-        "automattic/vipwpcs": "^2.0",
         "phpunit/phpunit": "^5.7",
         "brain/monkey": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -45,9 +44,6 @@
         ],
         "check-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1"
-        ],
-        "check-vip": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -psl . ./compat/ ./src/ ./js/src/ --standard=WordPress-VIP-Go --runtime-set ignore_warnings_on_exit 1"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"


### PR DESCRIPTION
## Context

* Improve CI setup

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI setup

## Relevant technical choices:

As discussed.

The VIPCS rulesets have a couple of drawbacks:
1. As it stands, they can not be combined with WordPressCS as they will silence various sniffs from WPCS which we _do_ want to receive notice from.
2. The sniffs themselves are not always that accurate.
3. The sniffs will, at times, recommend using functionality only available on the VIP platform, which means that certain "issues" are not fixable.

It is the intention to include select sniffs - not the rulesets - from VIPCS is a future version of YoastCS.

With that in mind, the sniffing against VIPCS is being removed, in favour of inheriting sniffing against select VIP sniffs via YoastCS in the future.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_