### PR TITLE
QA: no FQN function calls in non-namespaced file

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -192,12 +192,12 @@ function duplicate_post_migrate_show_links_in_options( $defaults ) {
 
 	$new_options = [];
 	foreach ( $options_to_migrate as $old => $new ) {
-		$new_options[ $new ] = \get_option( $old, $defaults[ $new ] );
+		$new_options[ $new ] = get_option( $old, $defaults[ $new ] );
 
-		\delete_option( $old );
+		delete_option( $old );
 	}
 
-	\update_option( 'duplicate_post_show_link_in', $new_options );
+	update_option( 'duplicate_post_show_link_in', $new_options );
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,30 +6,30 @@
  */
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- Reason: CS configuration is not complete yet.
-\define( 'ABSPATH', true );
+define( 'ABSPATH', true );
 
-\define( 'MINUTE_IN_SECONDS', 60 );
-\define( 'HOUR_IN_SECONDS', 3600 );
-\define( 'DAY_IN_SECONDS', 86400 );
-\define( 'WEEK_IN_SECONDS', 604800 );
-\define( 'MONTH_IN_SECONDS', 2592000 );
-\define( 'YEAR_IN_SECONDS', 31536000 );
+define( 'MINUTE_IN_SECONDS', 60 );
+define( 'HOUR_IN_SECONDS', 3600 );
+define( 'DAY_IN_SECONDS', 86400 );
+define( 'WEEK_IN_SECONDS', 604800 );
+define( 'MONTH_IN_SECONDS', 2592000 );
+define( 'YEAR_IN_SECONDS', 31536000 );
 
-\define( 'OBJECT', 'OBJECT' );
-\define( 'ARRAY_A', 'ARRAY_A' );
-\define( 'ARRAY_N', 'ARRAY_N' );
+define( 'OBJECT', 'OBJECT' );
+define( 'ARRAY_A', 'ARRAY_A' );
+define( 'ARRAY_N', 'ARRAY_N' );
 
-\define( 'DUPLICATE_POST_FILE', '/var/www/html/wp-content/plugins/duplicate-post/duplicate-post.php' );
-\define( 'DUPLICATE_POST_CURRENT_VERSION', '4.0' );
+define( 'DUPLICATE_POST_FILE', '/var/www/html/wp-content/plugins/duplicate-post/duplicate-post.php' );
+define( 'DUPLICATE_POST_CURRENT_VERSION', '4.0' );
 // phpcs:enable
 
 // phpcs:disable PHPCompatibility.FunctionUse.NewFunctions -- Reason: Properly wrapped within a check.
-if ( \function_exists( 'opcache_reset' ) ) {
+if ( function_exists( 'opcache_reset' ) ) {
 	opcache_reset();
 }
 // phpcs:enable
 
-if ( \file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
+if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

* No functional changes.

Using fully qualified function calls in non-namespaced files is redundant and may actually cause PHP to throw a warning in certain circumstances.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.