### PR TITLE
CS: consistency for file includes

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -10,10 +10,10 @@ if ( ! is_admin() ) {
 	return;
 }
 
-require_once __DIR__ . '/duplicate-post-options.php';
+require_once DUPLICATE_POST_PATH . 'duplicate-post-options.php';
 
-require_once __DIR__ . '/compat/duplicate-post-wpml.php';
-require_once __DIR__ . '/compat/duplicate-post-jetpack.php';
+require_once DUPLICATE_POST_PATH . 'compat/duplicate-post-wpml.php';
+require_once DUPLICATE_POST_PATH . 'compat/duplicate-post-jetpack.php';
 
 /**
  * Wrapper for the option 'duplicate_post_version'.

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -47,7 +47,7 @@ if ( ! defined( 'DUPLICATE_POST_PATH' ) ) {
 
 define( 'DUPLICATE_POST_CURRENT_VERSION', '4.1.2' );
 
-$duplicate_post_autoload_file = __DIR__ . '/vendor/autoload.php';
+$duplicate_post_autoload_file = DUPLICATE_POST_PATH . 'vendor/autoload.php';
 
 if ( is_readable( $duplicate_post_autoload_file ) ) {
 	require $duplicate_post_autoload_file;
@@ -99,8 +99,8 @@ function duplicate_post_plugin_actions( $actions ) {
 	return $actions;
 }
 
-require_once __DIR__ . '/duplicate-post-common.php';
+require_once DUPLICATE_POST_PATH . 'duplicate-post-common.php';
 
 if ( is_admin() ) {
-	include_once __DIR__ . '/duplicate-post-admin.php';
+	include_once DUPLICATE_POST_PATH . 'duplicate-post-admin.php';
 }


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

The `DUPLICATE_POST_PATH` constant is declared early in the plugin bootstrap file.
For consistency, it is recommended to use this constant throughout the application for file includes.

Note: the `DUPLICATE_POST_PATH` constant is based on `plugin_dir_path()` which returns the path with a trailing slash, so leading slashes in the "file name" part of the paths have been removed.


## Test instructions

This PR can be tested by following these steps:
* Open any admin page on which this plugin is loaded. If there are no fatal errors, we're good ;-)