### PR TITLE
QA: improve output escaping [1]

### DIFF
--- a/duplicate-post-admin.php
+++ b/duplicate-post-admin.php
@@ -793,14 +793,14 @@ function duplicate_post_add_plugin_links( $links, $file ) {
 function duplicate_post_newsletter_signup_form() {
 	$copy = sprintf(
 		/* translators: 1: Yoast */
-		__(
+		esc_html__(
 			'If you want to stay up to date about all the exciting developments around Duplicate Post, subscribe to the %1$s newsletter!',
 			'duplicate-post'
 		),
 		'Yoast'
 	);
 
-	$email_label = __( 'Email Address', 'duplicate-post' );
+	$email_label = esc_html__( 'Email Address', 'duplicate-post' );
 
 	$html = '
 <!-- Begin Mailchimp Signup Form -->


### PR DESCRIPTION
## Context

* Security hardening

## Summary

This PR can be summarized in the following changelog entry:

* Security hardening

## Relevant technical choices:

The `duplicate_post_newsletter_signup_form()` is documented as returning an output escaped form, but didn't properly escape all variables.


## Test instructions

This PR can be tested by following these steps:
* _N/A_ This should have no effect on functionality (other than when translators would have added HTML to the translated texts, which would now be correctly escaped).