### PR TITLE
QA: improve output escaping [2]

### DIFF
--- a/duplicate-post-common.php
+++ b/duplicate-post-common.php
@@ -76,10 +76,10 @@ function duplicate_post_clone_post_link( $link = null, $before = '', $after = ''
 	}
 
 	if ( $link === null ) {
-		$link = esc_html__( 'Copy to a new draft', 'duplicate-post' );
+		$link = __( 'Copy to a new draft', 'duplicate-post' );
 	}
 
-	$link = '<a class="post-clone-link" href="' . esc_url( $url ) . '">' . $link . '</a>';
+	$link = '<a class="post-clone-link" href="' . esc_url( $url ) . '">' . esc_html( $link ) . '</a>';
 
 	/**
 	 * Filter on the clone link HTML.


### PR DESCRIPTION
## Context

* Security hardening

## Summary

This PR can be summarized in the following changelog entry:

* Security hardening

## Relevant technical choices:

As things were, if `$link` was passed in as a parameter, it would not be escaped for output. Output escaping was only applied to the default anchor text string.

Fixed now.

## Test instructions

This PR can be tested by following these steps:
* _N/A_ This should have no effect on functionality (other than when translators would have added HTML to the translated texts, which would now be correctly escaped).