### PR TITLE
QA: improve output escaping [3]

### DIFF
--- a/src/class-utils.php
+++ b/src/class-utils.php
@@ -117,7 +117,7 @@ class Utils {
 		if ( $can_edit_post && $post->post_status !== 'trash' ) {
 			return \sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
-				\get_edit_post_link( $post->ID ),
+				\esc_url( \get_edit_post_link( $post->ID ) ),
 				/* translators: %s: post title */
 				\esc_attr( \sprintf( \__( 'Edit &#8220;%s&#8221;', 'default' ), $title ) ),
 				$title
@@ -139,13 +139,14 @@ class Utils {
 			elseif ( $post->post_status !== 'trash' ) {
 				return \sprintf(
 					'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
-					\get_permalink( $post->ID ),
+					\esc_url( \get_permalink( $post->ID ) ),
 					/* translators: %s: post title */
 					\esc_attr( \sprintf( \__( 'View &#8220;%s&#8221;', 'default' ), $title ) ),
 					$title
 				);
 			}
 		}
+
 		return $title;
 	}
 


### PR DESCRIPTION
## Context

* Security hardening

## Summary

This PR can be summarized in the following changelog entry:

* Security hardening

## Relevant technical choices:

The return value of the `Utils::get_edit_or_view_link()` method is treated as properly escaped HTML ready for output, however, the escaping was incomplete.

Note: The `$title` variable should probably also be escaped, using `esc_html()`, however, I'm not 100% sure if the title can contain HTML.
If that's the case, it should probably be escaped with `wp_kses_post()`.

Second opinion needed.



## Test instructions

This PR can be tested by following these steps:
* Check out this branch
* Open an admin page which uses this functionality
* Verify whether the link(s) still work correctly.