### PR TITLE
QA: remove double output escaping

### DIFF
--- a/src/admin/class-options-form-generator.php
+++ b/src/admin/class-options-form-generator.php
@@ -164,7 +164,7 @@ class Options_Form_Generator {
 						'id'      => 'duplicate-post-' . $this->prepare_input_id( $name ),
 						'value'   => $name,
 						'checked' => \in_array( $taxonomy->name, $taxonomies_blacklist, true ),
-						'label'   => \esc_html( $taxonomy->labels->name . ' [' . $taxonomy->name . ']' ),
+						'label'   => $taxonomy->labels->name . ' [' . $taxonomy->name . ']',
 					],
 				]
 			);
@@ -200,7 +200,7 @@ class Options_Form_Generator {
 							'id'      => 'duplicate-post-' . $this->prepare_input_id( $name ),
 							'value'   => $name,
 							'checked' => $role->has_cap( 'copy_posts' ),
-							'label'   => \esc_html( \translate_user_role( $display_name ) ),
+							'label'   => \translate_user_role( $display_name ),
 						],
 					]
 				);
@@ -234,7 +234,7 @@ class Options_Form_Generator {
 						'id'      => 'duplicate-post-' . $this->prepare_input_id( $name ),
 						'value'   => $name,
 						'checked' => $this->is_post_type_enabled( $post_type_object->name ),
-						'label'   => \esc_html( $post_type_object->labels->name ),
+						'label'   => $post_type_object->labels->name,
 					],
 				]
 			);


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

These arrays are all input arrays for calls to the `generate_options_input()` method.

The `generate_options_input()` method already does the output escaping for the checkbox label on line 84, so these `esc_html()` calls can be removed.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.