### PR TITLE
PHPCS: Switch over to using YoastCS

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -147,4 +147,20 @@
 		<exclude-pattern>/src/ui/link-builder\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Technical debt: nonce verification should be added to cover
+		 all relevant uses of superglobals. This will be addressed
+		 by the team at a future date. -->
+	<rule ref="WordPress.Security.NonceVerification.Missing">
+		<exclude-pattern>/src/handlers/save-post-handler\.php$</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.NonceVerification.Recommended">
+		<exclude-pattern>/compat/gutenberg-functions\.php$</exclude-pattern>
+		<exclude-pattern>/src/post-republisher\.php$</exclude-pattern>
+		<exclude-pattern>/src/admin/options-page\.php$</exclude-pattern>
+		<exclude-pattern>/src/ui/bulk-actions\.php$</exclude-pattern>
+		<exclude-pattern>/src/ui/classic-editor\.php$</exclude-pattern>
+		<exclude-pattern>/src/watchers/(bulk|link)-actions-watcher\.php$</exclude-pattern>
+		<exclude-pattern>/src/watchers/republished-post-watcher\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -14,14 +14,6 @@
 
 	<file>.</file>
 
-	<!-- Always exclude all files in version management related directories. -->
-	<exclude-pattern>*/.git/*</exclude-pattern>
-	<exclude-pattern>*/.wordpress-svn/*</exclude-pattern>
-
-	<!-- Exclude the build tool and dependency related directories. -->
-	<exclude-pattern>/vendor/*</exclude-pattern>
-	<exclude-pattern>/node_modules/*</exclude-pattern>
-
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
 
@@ -40,34 +32,29 @@
 
 	<!--
 	#############################################################################
-	USE THE WordPress + PHPCompatibilityWP RULESETS
+	USE THE YoastCS RULESET
 	#############################################################################
 	-->
 
-	<!-- Include the WordPress standard. -->
-	<rule ref="WordPress">
-		<!-- No need for this sniff as every Yoast travis script includes linting all files. -->
-		<exclude name="Generic.PHP.Syntax"/>
+	<rule ref="Yoast">
+		<properties>
+			<!-- Set the custom test class list for all sniffs which use it in one go.
+				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+			-->
+			<property name="custom_test_class_whitelist" type="array">
+				<element value="Yoast\WP\Duplicate_Post\Tests\TestCase"/>
+			</property>
 
-        <!-- WPCS demands long arrays. YoastCS demands short arrays. -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\Duplicate_Post"/>
+				<element value="duplicate_post"/>
+				<element value="dp_"/>
+			</property>
+		</properties>
 
-		<!-- Demanding Yoda conditions is stupid. -->
-		<exclude name="WordPress.PHP.YodaConditions"/>
-
-		<!-- YoastCS demands else on new line. -->
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-
-		<!-- YoastCS recommends no file docblock in namespaced files. -->
-		<exclude name="Squiz.Commenting.FileComment.Missing"/>
-
-		<!-- YoastCS has different file name rules. -->
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
-	</rule>
-
-	<config name="testVersion" value="5.5-"/>
-	<rule ref="PHPCompatibilityWP">
-		<include-pattern>*\.php$</include-pattern>
+		<!-- This plugin is not dependent on YoastSEO, so the replacement function will not be available. -->
+		<exclude name="Yoast.Yoast.AlternativeFunctions.json_encode_wp_json_encode"/>
 	</rule>
 
 
@@ -77,8 +64,7 @@
 	#############################################################################
 	-->
 
-	<config name="minimum_supported_wp_version" value="3.6"/>
-
+	<!-- Verify that all gettext calls use the correct text domain. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
@@ -88,26 +74,77 @@
 		</properties>
 	</rule>
 
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<property name="prefixes" type="array">
-				<element value="Yoast\WP\Duplicate_Post"/>
-				<element value="duplicate_post"/>
-				<element value="dp_"/>
+			<!-- Indicate which directories should be treated as project root directories for
+				 path-to-namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="src"/>
 			</property>
 		</properties>
 	</rule>
 
-	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
-		<type>error</type>
+	<rule ref="Yoast.Files.FileName">
 		<properties>
-			<!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->
-			<property name="exact" value="false"/>
-			<!-- Don't align multi-line items if ALL items in the array are multi-line. -->
-			<property name="alignMultilineItems" value="!=100"/>
-			<!-- Array Assignment operator should always be on the same line as the array key. -->
-			<property name="ignoreNewlines" value="false"/>
+			<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
+			<property name="excluded_files_strict_check" type="array">
+				<element value="duplicate-post.php"/>
+			</property>
+
+			<!-- Remove the following prefixes from the names of object structures. -->
+			<property name="oo_prefixes" type="array">
+				<element value="duplicate_post"/>
+			</property>
 		</properties>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
+
+	<!-- TEST CODE -->
+
+	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created, which is fine. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Test code does not go into production, so security is not an issue. -->
+	<rule ref="WordPress.Security">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- These tests are not run within the context of a WP install, so overwritting globals is fine. -->
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	TEMPORARY ADJUSTMENTS
+	Adjustments which should be removed once the associated issue has been resolved.
+	#############################################################################
+	-->
+
+	<!-- Temporary exclude due to a bug in YoastCS.
+		 The bug has already been fixed and this exclude can be removed once YoastCS 2.2.0
+		 has been released. -->
+	<rule ref="Yoast.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>/src/duplicate-post\.php$</exclude-pattern>
+	</rule>
+
+	<!-- The renaming of the hooks to use the namespace-like prefix is
+		 a breaking change and will be planned in to be actioned
+		 at a future date. -->
+	<rule ref="Yoast.NamingConventions.ValidHookName.WrongPrefix">
+		<exclude-pattern>/(admin|common)-functions\.php$</exclude-pattern>
+		<exclude-pattern>/src/(permissions-helper|post-(duplicator|republisher))\.php$</exclude-pattern>
+		<exclude-pattern>/src/ui/link-builder\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -253,8 +253,8 @@ function duplicate_post_show_update_notice() {
 
 	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '" style="display: flex; align-items: center;">
 			<img src="' . esc_url( $img_path ) . '" alt=""/>
-			<div style="margin: 0.5em">' . $sanitized_message . // phpcs:ignore WordPress.Security.EscapeOutput
-			'</div></div>';
+			<div style="margin: 0.5em">' . $sanitized_message // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: escaped properly above.
+			. '</div></div>';
 
 	echo "<script>
 			function duplicate_post_dismiss_notice(){

--- a/compat/wpml-functions.php
+++ b/compat/wpml-functions.php
@@ -21,7 +21,7 @@ function duplicate_post_wpml_init() {
 	}
 }
 
-global $duplicated_posts;    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+global $duplicated_posts;
 $duplicated_posts = []; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 /**

--- a/compat/wpml-functions.php
+++ b/compat/wpml-functions.php
@@ -22,7 +22,9 @@ function duplicate_post_wpml_init() {
 }
 
 global $duplicated_posts;
-$duplicated_posts = []; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Reason: Renaming a global variable is a BC break.
+$duplicated_posts = [];
 
 /**
  * Copy post translations.
@@ -66,7 +68,9 @@ function duplicate_post_wpml_copy_translations( $post_id, $post, $status = '' ) 
 				}
 			}
 		}
-		$duplicated_posts[ $post->ID ] = $post_id; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Reason: see above.
+		$duplicated_posts[ $post->ID ] = $post_id;
 	}
 }
 
@@ -75,13 +79,16 @@ function duplicate_post_wpml_copy_translations( $post_id, $post, $status = '' ) 
  *
  * @global array() $duplicated_posts Array of duplicated posts.
  */
-function duplicate_wpml_string_packages() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+function duplicate_wpml_string_packages() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Reason: renaming the function would be a BC-break.
 	global $duplicated_posts;
 
 	foreach ( $duplicated_posts as $original_post_id => $duplicate_post_id ) {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Reason: using WPML native filter.
+		$original_string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $original_post_id );
 
-		$original_string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $original_post_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-		$new_string_packages      = apply_filters( 'wpml_st_get_post_string_packages', false, $duplicate_post_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Reason: using WPML native filter.
+		$new_string_packages = apply_filters( 'wpml_st_get_post_string_packages', false, $duplicate_post_id );
+
 		if ( is_array( $original_string_packages ) ) {
 			foreach ( $original_string_packages as $original_string_package ) {
 				$translated_original_strings = $original_string_package->get_translated_strings( [] );
@@ -96,7 +103,8 @@ function duplicate_wpml_string_packages() { // phpcs:ignore WordPress.NamingConv
 							foreach ( $translated_original_strings[ $new_string->name ] as $language => $translated_string ) {
 
 								do_action(
-									'wpml_add_string_translation', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+									// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Reason: using WPML native filter.
+									'wpml_add_string_translation',
 									$new_string->id,
 									$language,
 									$translated_string['value'],

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,11 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "wp-coding-standards/wpcs": "^2.1",
-        "phpcompatibility/phpcompatibility-wp": "^2.1.0",
         "phpunit/phpunit": "^5.7",
         "brain/monkey": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "php-parallel-lint/php-console-highlighter": "^0.5"
+        "php-parallel-lint/php-console-highlighter": "^0.5",
+        "yoast/yoastcs": "^2.1"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude node_modules --exclude .git"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -59,7 +59,11 @@ if ( is_readable( $duplicate_post_autoload_file ) ) {
 /**
  * Loads the Duplicate Post main class.
  *
- * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore,WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function name change would be BC-break.
+ * {@internal Function name change would be BC-break.}
+ *
+ * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
+ * @phpcs:disable WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  */
 function __duplicate_post_main() {
 	new Duplicate_Post();

--- a/src/admin/options-page.php
+++ b/src/admin/options-page.php
@@ -158,7 +158,7 @@ class Options_Page {
 	 * @return bool Whether or not the settings have been updated.
 	 */
 	protected function settings_updated() {
-		return isset( $_GET['settings-updated'] ) && $_GET['settings-updated'] === 'true'; // phpcs:ignore WordPress.Security.NonceVerification
+		return isset( $_GET['settings-updated'] ) && $_GET['settings-updated'] === 'true';
 	}
 
 	/**

--- a/src/handlers/check-changes-handler.php
+++ b/src/handlers/check-changes-handler.php
@@ -62,17 +62,17 @@ class Check_Changes_Handler {
 	public function check_changes_action_handler() {
 		global $wp_version;
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
-			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_check_changes' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] )
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_check_changes' ) ) ) {
 			\wp_die(
 				\esc_html__( 'No post has been supplied!', 'duplicate-post' )
 			);
 			return;
 		}
 
-		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) ); // Input var okay.
+		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) );
 
-		\check_admin_referer( 'duplicate_post_check_changes_' . $id ); // Input var okay.
+		\check_admin_referer( 'duplicate_post_check_changes_' . $id );
 
 		$this->post = \get_post( $id );
 

--- a/src/handlers/check-changes-handler.php
+++ b/src/handlers/check-changes-handler.php
@@ -142,16 +142,16 @@ class Check_Changes_Handler {
 						$post_array = \get_post( $this->post, \ARRAY_A );
 
 						/** This filter is documented in wp-admin/includes/revision.php */
-						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
+						// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: using WP core hook.
 						$fields = \apply_filters( '_wp_post_revision_fields', $fields, $post_array );
 
 						foreach ( $fields as $field => $name ) {
 							/** This filter is documented in wp-admin/includes/revision.php */
-							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
+							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: using WP core hook.
 							$content_from = \apply_filters( "_wp_post_revision_field_{$field}", $this->original->$field, $field, $this->original, 'from' );
 
 							/** This filter is documented in wp-admin/includes/revision.php */
-							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: we want to use a WP filter from the revision feature.
+							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Reason: using WP core hook.
 							$content_to = \apply_filters( "_wp_post_revision_field_{$field}", $this->post->$field, $field, $this->post, 'to' );
 
 							$diff = \wp_text_diff( $content_from, $content_to, $args );

--- a/src/handlers/link-handler.php
+++ b/src/handlers/link-handler.php
@@ -58,14 +58,14 @@ class Link_Handler {
 			\wp_die( \esc_html__( 'Current user is not allowed to copy posts.', 'duplicate-post' ) );
 		}
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
-			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_new_draft' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] )
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_new_draft' ) ) ) {
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
-		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) ); // Input var okay.
+		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) );
 
-		\check_admin_referer( 'duplicate_post_new_draft_' . $id ); // Input var okay.
+		\check_admin_referer( 'duplicate_post_new_draft_' . $id );
 
 		$post = \get_post( $id );
 
@@ -114,14 +114,14 @@ class Link_Handler {
 			\wp_die( \esc_html__( 'Current user is not allowed to copy posts.', 'duplicate-post' ) );
 		}
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
-			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_clone' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] )
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_clone' ) ) ) {
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
-		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) ); // Input var okay.
+		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) );
 
-		\check_admin_referer( 'duplicate_post_clone_' . $id ); // Input var okay.
+		\check_admin_referer( 'duplicate_post_clone_' . $id );
 
 		$post = \get_post( $id );
 
@@ -188,14 +188,14 @@ class Link_Handler {
 			\wp_die( \esc_html__( 'Current user is not allowed to copy posts.', 'duplicate-post' ) );
 		}
 
-		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] ) // Input var okay.
-			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_rewrite' ) ) ) { // Input var okay.
+		if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] )
+			|| ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'duplicate_post_rewrite' ) ) ) {
 			\wp_die( \esc_html__( 'No post to duplicate has been supplied!', 'duplicate-post' ) );
 		}
 
-		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) ); // Input var okay.
+		$id = ( isset( $_GET['post'] ) ? \intval( \wp_unslash( $_GET['post'] ) ) : \intval( \wp_unslash( $_POST['post'] ) ) );
 
-		\check_admin_referer( 'duplicate_post_rewrite_' . $id ); // Input var okay.
+		\check_admin_referer( 'duplicate_post_rewrite_' . $id );
 
 		$post = \get_post( $id );
 

--- a/src/handlers/save-post-handler.php
+++ b/src/handlers/save-post-handler.php
@@ -48,7 +48,7 @@ class Save_Post_Handler {
 	 */
 	public function delete_on_save_post( $post_id ) {
 		if ( ( \defined( 'DOING_AUTOSAVE' ) && \DOING_AUTOSAVE )
-			|| empty( $_POST['duplicate_post_remove_original'] ) // phpcs:ignore WordPress.Security.NonceVerification
+			|| empty( $_POST['duplicate_post_remove_original'] )
 			|| ! \current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}

--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -235,7 +235,7 @@ class Post_Republisher {
 			return false;
 		}
 
-		return isset( $_GET['meta-box-loader'] ) === false; // phpcs:ignore WordPress.Security.NonceVerification
+		return isset( $_GET['meta-box-loader'] ) === false;
 	}
 
 	/**

--- a/src/ui/bulk-actions.php
+++ b/src/ui/bulk-actions.php
@@ -63,7 +63,6 @@ class Bulk_Actions {
 	 * @return array The bulk actions array.
 	 */
 	public function register_bulk_action( $bulk_actions ) {
-		// phpcs:ignore WordPress.Security.NonceVerification
 		$is_draft_or_trash = isset( $_REQUEST['post_status'] ) && \in_array( $_REQUEST['post_status'], [ 'draft', 'trash' ], true );
 
 		if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'clone' ) ) === 1 ) {

--- a/src/ui/classic-editor.php
+++ b/src/ui/classic-editor.php
@@ -81,8 +81,8 @@ class Classic_Editor {
 	 * @return void
 	 */
 	public function enqueue_classic_editor_scripts() {
-		if ( $this->permissions_helper->is_classic_editor() && isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$id   = \intval( \wp_unslash( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( $this->permissions_helper->is_classic_editor() && isset( $_GET['post'] ) ) {
+			$id   = \intval( \wp_unslash( $_GET['post'] ) );
 			$post = \get_post( $id );
 
 			if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
@@ -98,8 +98,8 @@ class Classic_Editor {
 	 */
 	public function enqueue_classic_editor_styles() {
 		if ( $this->permissions_helper->is_classic_editor()
-			&& isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$id   = \intval( \wp_unslash( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			&& isset( $_GET['post'] ) ) {
+			$id   = \intval( \wp_unslash( $_GET['post'] ) );
 			$post = \get_post( $id );
 
 			if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
@@ -117,8 +117,8 @@ class Classic_Editor {
 	 */
 	public function add_new_draft_post_button( $post = null ) {
 		if ( \is_null( $post ) ) {
-			if ( isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$id   = \intval( \wp_unslash( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			if ( isset( $_GET['post'] ) ) {
+				$id   = \intval( \wp_unslash( $_GET['post'] ) );
 				$post = \get_post( $id );
 			}
 		}
@@ -143,8 +143,8 @@ class Classic_Editor {
 	 */
 	public function add_rewrite_and_republish_post_button( $post = null ) {
 		if ( \is_null( $post ) ) {
-			if ( isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$id   = \intval( \wp_unslash( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			if ( isset( $_GET['post'] ) ) {
+				$id   = \intval( \wp_unslash( $_GET['post'] ) );
 				$post = \get_post( $id );
 			}
 		}
@@ -172,8 +172,8 @@ class Classic_Editor {
 	 */
 	public function add_check_changes_link( $post = null ) {
 		if ( \is_null( $post ) ) {
-			if ( isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$id   = \intval( \wp_unslash( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			if ( isset( $_GET['post'] ) ) {
+				$id   = \intval( \wp_unslash( $_GET['post'] ) );
 				$post = \get_post( $id );
 			}
 		}

--- a/src/watchers/bulk-actions-watcher.php
+++ b/src/watchers/bulk-actions-watcher.php
@@ -46,8 +46,8 @@ class Bulk_Actions_Watcher {
 	 * @return void
 	 */
 	public function add_bulk_clone_admin_notice() {
-		if ( ! empty( $_REQUEST['bulk_cloned'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$copied_posts = \intval( $_REQUEST['bulk_cloned'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['bulk_cloned'] ) ) {
+			$copied_posts = \intval( $_REQUEST['bulk_cloned'] );
 			\printf(
 				'<div id="message" class="notice notice-success fade"><p>'
 				. \esc_html(
@@ -70,8 +70,8 @@ class Bulk_Actions_Watcher {
 	 * @return void
 	 */
 	public function add_bulk_rewrite_and_republish_admin_notice() {
-		if ( ! empty( $_REQUEST['bulk_rewriting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$copied_posts = \intval( $_REQUEST['bulk_rewriting'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['bulk_rewriting'] ) ) {
+			$copied_posts = \intval( $_REQUEST['bulk_rewriting'] );
 			\printf(
 				'<div id="message" class="notice notice-success fade"><p>'
 				. \esc_html(

--- a/src/watchers/link-actions-watcher.php
+++ b/src/watchers/link-actions-watcher.php
@@ -60,12 +60,12 @@ class Link_Actions_Watcher {
 	 * @return void
 	 */
 	public function add_clone_admin_notice() {
-		if ( ! empty( $_REQUEST['cloned'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['cloned'] ) ) {
 			if ( ! $this->permissions_helper->is_classic_editor() ) {
 				return;
 			}
 
-			$copied_posts = \intval( $_REQUEST['cloned'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			$copied_posts = \intval( $_REQUEST['cloned'] );
 			\printf(
 				'<div id="message" class="notice notice-success fade"><p>'
 				. \esc_html(
@@ -88,7 +88,7 @@ class Link_Actions_Watcher {
 	 * @return void
 	 */
 	public function add_rewrite_and_republish_admin_notice() {
-		if ( ! empty( $_REQUEST['rewriting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['rewriting'] ) ) {
 			if ( ! $this->permissions_helper->is_classic_editor() ) {
 				return;
 			}
@@ -107,7 +107,7 @@ class Link_Actions_Watcher {
 	 * @return void
 	 */
 	public function add_rewrite_and_republish_block_editor_notice() {
-		if ( ! empty( $_REQUEST['rewriting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['rewriting'] ) ) {
 			$notice = [
 				'text'          => \wp_slash(
 					\__(

--- a/src/watchers/republished-post-watcher.php
+++ b/src/watchers/republished-post-watcher.php
@@ -78,7 +78,7 @@ class Republished_Post_Watcher {
 			return;
 		}
 
-		if ( ! empty( $_REQUEST['dprepublished'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['dprepublished'] ) ) {
 			echo '<div id="message" class="notice notice-success is-dismissible"><p>'
 				. \esc_html( $this->get_notice_text() )
 				. '</p></div>';
@@ -91,7 +91,7 @@ class Republished_Post_Watcher {
 	 * @return void
 	 */
 	public function add_block_editor_notice() {
-		if ( ! empty( $_REQUEST['dprepublished'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! empty( $_REQUEST['dprepublished'] ) ) {
 			$notice = [
 				'text'          => \wp_slash( $this->get_notice_text() ),
 				'status'        => 'success',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,6 @@
  * @package Yoast\WP\Duplicate_Post\Tests
  */
 
-// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- Reason: CS configuration is not complete yet.
 define( 'ABSPATH', true );
 
 define( 'MINUTE_IN_SECONDS', 60 );
@@ -21,13 +20,10 @@ define( 'ARRAY_N', 'ARRAY_N' );
 
 define( 'DUPLICATE_POST_FILE', '/var/www/html/wp-content/plugins/duplicate-post/duplicate-post.php' );
 define( 'DUPLICATE_POST_CURRENT_VERSION', '4.0' );
-// phpcs:enable
 
-// phpcs:disable PHPCompatibility.FunctionUse.NewFunctions -- Reason: Properly wrapped within a check.
 if ( function_exists( 'opcache_reset' ) ) {
 	opcache_reset();
 }
-// phpcs:enable
 
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -107,7 +107,6 @@ class Post_Republisher_Test extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_is_classic_editor_post_request_when_rest_request() {
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WordPress constant used in a test.
 		\define( 'REST_REQUEST', true );
 		$this->assertFalse( $this->instance->is_classic_editor_post_request() );
 	}
@@ -124,7 +123,7 @@ class Post_Republisher_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->assertFalse( $this->instance->is_classic_editor_post_request() );
-		unset( $_GET['meta-box-loader'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		unset( $_GET['meta-box-loader'] );
 	}
 
 	/**

--- a/tests/ui/admin-bar-test.php
+++ b/tests/ui/admin-bar-test.php
@@ -109,7 +109,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_successful_both() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class );
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
@@ -162,7 +162,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_successful_one() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class );
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'pending';
 
@@ -208,7 +208,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_unsuccessful_no_admin_bar() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class );
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
@@ -244,7 +244,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_admin_bar_render_unsuccessful_no_post() {
 		global $wp_admin_bar;
-		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class );
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = 'publish';
 
@@ -342,7 +342,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_successful_backend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_the_query    = Mockery::mock( WP_Query::class );
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
@@ -379,7 +379,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_successful_frontend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_the_query    = Mockery::mock( WP_Query::class );
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 
@@ -417,7 +417,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_backend() {
 		global $wp_the_query;
-		$wp_the_query = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_the_query = Mockery::mock( WP_Query::class );
 		$post         = null;
 
 		Monkey\Functions\expect( '\is_admin' )
@@ -454,7 +454,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_frontend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_the_query    = Mockery::mock( WP_Query::class );
 		$post            = Mockery::mock( WP_Term::class );
 		$post->post_type = 'post';
 
@@ -493,7 +493,7 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_should_not_be_displayed() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( WP_Query::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$wp_the_query    = Mockery::mock( WP_Query::class );
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -240,7 +240,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_unsuccessful_no_post() {
-		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Intended, to be able to test the method.
+		unset( $_GET['post'] );
 
 		Monkey\Functions\expect( '\get_option' )
 			->with( 'duplicate_post_show_submitbox' )
@@ -375,7 +375,7 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_no_post() {
-		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Intended, to be able to test the method.
+		unset( $_GET['post'] );
 
 		Monkey\Functions\expect( '\get_option' )
 			->with( 'duplicate_post_show_submitbox' )
@@ -861,7 +861,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_change_rewrite_republish_copy_post() {
 		global $pagenow;
-		$pagenow = 'post.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$pagenow = 'post.php';
 
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
@@ -881,7 +881,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_change_rewrite_republish_copy_new_post() {
 		global $pagenow;
-		$pagenow = 'post-new.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$pagenow = 'post-new.php';
 
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
@@ -902,7 +902,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_not_change_rewrite_republish_copy_not_post_edit_screen() {
 		global $pagenow;
-		$pagenow = 'xx.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$pagenow = 'xx.php';
 
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
@@ -918,7 +918,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_not_change_rewrite_republish_copy_post_is_null() {
 		global $pagenow;
-		$pagenow = 'post.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$pagenow = 'post.php';
 
 		$this->assertFalse( $this->instance->should_change_rewrite_republish_copy( null ) );
 	}
@@ -931,7 +931,7 @@ class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_not_change_rewrite_republish_copy_not_republish_copy() {
 		global $pagenow;
-		$pagenow = 'post.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the method.
+		$pagenow = 'post.php';
 
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';

--- a/tests/watchers/republished-post-watcher-test.php
+++ b/tests/watchers/republished-post-watcher-test.php
@@ -97,7 +97,7 @@ class Republished_Post_Watcher_Test extends TestCase {
 		$this->instance->add_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success is-dismissible"><p>notice</p></div>' );
-		unset( $_REQUEST['dprepublished'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		unset( $_REQUEST['dprepublished'] );
 	}
 
 	/**
@@ -145,7 +145,7 @@ class Republished_Post_Watcher_Test extends TestCase {
 		$_REQUEST['dprepublished'] = '1';
 
 		$this->instance->add_block_editor_notice();
-		unset( $_REQUEST['dprepublished'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		unset( $_REQUEST['dprepublished'] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code consistency and code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency and code quality

## Relevant technical choices:

💡  **Pro-tip**: this PR will be easiest to review by going through each commit individually!

Also note: after this PR has been merged, **_all devs working on this plugin should run `composer update` to update their local dev environment._**

### Composer: require YoastCS

* Remove explicit `require`s for dependencies which are underlying dependencies of YoastCS.
    This will allow YoastCS to manage the version constraints as of now and minimizes the risk of version conflicts.
* Require YoastCS.

### PHPCS: adjust the ruleset for use of YoastCS

* Remove exclude patterns which are inherited automatically from YoastCS.
* Replace use of the `WordPress` and `PHPCompatibilityWP` rulesets with the `Yoast` ruleset which includes both.
* Add some properties which are used by multiple sniffs at the ruleset level.
* Remove the `minimum_supported_wp_version` config.
    As the plugin now follows the same "support latest WP + one previous version" principle, this config can, and will, be inherited from YoastCS.
* Remove the configuration for the `WordPress.NamingConventions.PrefixAllGlobals` sniff.
    The necessary `prefixes` property is now set at ruleset level as there are a number of Yoast specific sniffs which also use this property.
* Remove the custom configuration for the `WordPress.Arrays.MultipleStatementAlignment` sniff.
    This will now be inherited from the YoastCS ruleset.
* Add custom configuration for the `Yoast.NamingConventions.NamespaceName` sniff.
    This sniff guards that namespace names are in sync with the file location in the source, as well as that they are prefixed correctly and comply with depth restrictions.
* Add custom configuration for the `Yoast.Files.FileName` sniff and add a temporary exclusion for this sniff.
    The file rename proposal is still under review. Until such time as it is approved and actioned, the file names used will not yet comply.
* Add some selective exclusions for the test code.
    Test code will not go into production, so some rules can be disregarded.
* Add some temporary exclusions for select sniffs.
    These have each been discussed. See the inline documentation.

### Travis/Composer: remove silencing of warnings

With the new ruleset in place and the fixes which have been applied recently, running PHPCS against the current ruleset will yield no errors and no warnings. Perfect zero-score (aside from the temporary exclusions).

Let's keep it that way by allowing the CI build to also fail when warnings are detected (previously it only failed on errors).

### PHPCS: remove use of deprecated WPCS native ignore annotations

The use of WPCS native ignore annotations like `// Input var okay` has been deprecated in WordPressCS 2.0.0 and support for these annotations will be removed in WPCS 3.0.0.

With that in mind, there annotations should be removed and if necessary replaced by the PHPCS native ignore annotations, i.e. `// phpcs:ignore....`.

In the case of the `// Input var okay` annotations I'm removing in this commit, none of them need replacing as none are actually ignoring an error/warning.

These annotations may have entered the codebase via copy/paste or may have ignored violation reports in the past, but WPCS does not actually throw violations for these lines as they are now, anymore.

Refs:
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.0.0-RC1
* https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors

### PHPCS: remove redundant ignore annotations

Remove ignore annotations which have either become redundant due to the improved ruleset or were redundant anyway, possibly because of improvements made to the sniffs.

### PHPCS: remove inline ignore annotations for nonce verification

These issues should not be ignored, but fixed. A throughout review of the codebase is needed to verify that nonces are used everywhere and verified correctly.

To that end:
* A "Technical Debt" issue has been (or will be) created by Enrico to add this to the planning for the team.
* A temporary exclusion for the existing issues which were being flagged by PHPCS has been added to the ruleset.

When the review takes place, the temporary exclusion in the PHPCS ruleset can be commented out to see all the issues.
For those issues where nonce verification is handled correctly, the inline ignore annotation can be brought back, but should contain a reference to where the nonce verification is done. Example:

```php
// phpcs:ignore WordPress.Security.NonceVerification -- Reason: nonce is verified earlier in the code flow in function ClassName::noncecheck().
$id   = \intval( \wp_unslash( $_GET['post'] ) );
```

### PHPCS: improve remaining inline ignore annotations

The remaining inline ignore annotations have all been reviewed and found justified.

This commit tweaks them a little:
* For quite a few of them, it adds a reason for the ignore annotation. This should make future reviews of ignore annotations easier.
* Changes most _trailing_ annotations to _line before_ annotations for code readability.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Check the Travis CI run to verify that the CS check is running and passing correctly.
2. Test locally by:
    * Checking out this branch.
    * Run `composer update`
    * Run `composer check-cs` and see the CS check pass.
    * Introduce some CS error somewhere in the code, preferably against one of the Yoast rules not covered in WPCS, like adding a leading backslash to a `use` import statement, adding a Yoda condition, using long arrays etc.
    * Run `composer check-cs` again and see the CS check fail.
  
