### PR TITLE
Travis: only lint against high/low PHP and run tests on more PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,26 @@ cache:
     - $HOME/.composer/cache
 
 php:
-    - '5.6'
     - '7.0'
     - '7.1'
     - '7.2'
     - '7.3'
-    - '7.4'
-    - '8.0'
-    - "nightly"
+
+env:
+  - PHPUNIT=1
 
 jobs:
   fast_finish: true
   include:
     # Arbitrary PHP version to run the sniffs against.
+    - php: '5.6'
+      env: LINT=1 PHPUNIT=1
     - php: '7.4'
       env: SNIFF=1 PHPUNIT=1
+    - php: '8.0'
+      env: LINT=1
+    - php: "nightly"
+      env: LINT=1
 
   allow_failures:
     - php: "nightly"
@@ -52,7 +57,7 @@ before_script:
 - export -f travis_time_finish
 
 script:
-  - composer lint
+  - if [[ "$LINT" == "1" ]]; then composer lint; fi
   - if [[ "$SNIFF" == "1" ]]; then composer check-cs; fi
   # PHP Unit Tests
   - |


### PR DESCRIPTION
## Context

* Improve CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

As it was, the unit tests were only being run against PHP 7.4, while the plugin is supposed to be compatible with PHP 5.6 - 8.0.
To safeguard that properly, the tests should be run against all the supported PHP versions.

At this time, however, it is not (yet) possible to run the tests against PHP 8 due to the PHPUnit version being used (PHPUnit 5-7) in combination with certain tests features.
This will be fixed in the near future in a separate PR.

So, for now, this commit makes the following changes to the CI setup:
* Run the tests against all currently supported PHP versions, with the exception of PHP 8.0 which will be enabled at a later point in time.
* Only lint the code against high/low PHP versions, including against "future" PHP versions, like PHP 8.1 (nightly).
    As the tests are being run on all PHP versions, we don't really need to lint against all PHP versions anymore as most parse errors would be discovered by the tests anyhow. So linting against the highest and lowest supported PHP versions, including against PHP version for which the test runs are not yet enabled will be sufficient.


## Test instructions

This PR can be tested by following these steps:
* Verify that the Travis output logs to make sure linting and the tests are being run against the annotated PHP versions and that the tests pass.