### PR TITLE
QA: clean up global variables set in tests

### DIFF
--- a/tests/handlers/check-changes-handler-test.php
+++ b/tests/handlers/check-changes-handler-test.php
@@ -137,6 +137,9 @@ class Check_Changes_Handler_Test extends TestCase {
 		'
 		);
 		$this->instance->check_changes_action_handler();
+
+		// Clean up after the test.
+		unset( $_GET['post'], $_REQUEST['action'] );
 	}
 
 	/**
@@ -171,6 +174,9 @@ class Check_Changes_Handler_Test extends TestCase {
 			->with( 'Changes overview failed, could not find post with ID 123.' );
 
 		$this->instance->check_changes_action_handler();
+
+		// Clean up after the test.
+		unset( $_GET['post'], $_REQUEST['action'] );
 	}
 
 	/**
@@ -201,5 +207,8 @@ class Check_Changes_Handler_Test extends TestCase {
 			->with( 'Changes overview failed, could not find original post.' );
 
 		$this->instance->check_changes_action_handler();
+
+		// Clean up after the test.
+		unset( $_GET['post'], $_REQUEST['action'] );
 	}
 }

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -123,6 +123,8 @@ class Post_Republisher_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->assertFalse( $this->instance->is_classic_editor_post_request() );
+
+		// Clean up after the test.
 		unset( $_GET['meta-box-loader'] );
 	}
 

--- a/tests/ui/admin-bar-test.php
+++ b/tests/ui/admin-bar-test.php
@@ -151,6 +151,9 @@ class Admin_Bar_Test extends TestCase {
 			->times( 3 );
 
 		$this->instance->admin_bar_render();
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_admin_bar'] );
 	}
 
 	/**
@@ -199,6 +202,9 @@ class Admin_Bar_Test extends TestCase {
 			->once();
 
 		$this->instance->admin_bar_render();
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_admin_bar'] );
 	}
 
 	/**
@@ -235,6 +241,9 @@ class Admin_Bar_Test extends TestCase {
 			->never();
 
 		$this->instance->admin_bar_render();
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_admin_bar'] );
 	}
 
 	/**
@@ -270,6 +279,9 @@ class Admin_Bar_Test extends TestCase {
 			->never();
 
 		$this->instance->admin_bar_render();
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_admin_bar'] );
 	}
 
 	/**
@@ -370,6 +382,9 @@ class Admin_Bar_Test extends TestCase {
 			->andReturnTrue();
 
 		$this->assertSame( $post, $this->instance->get_current_post() );
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_the_query'] );
 	}
 
 	/**
@@ -408,6 +423,9 @@ class Admin_Bar_Test extends TestCase {
 			->andReturnTrue();
 
 		$this->assertSame( $post, $this->instance->get_current_post() );
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_the_query'] );
 	}
 
 	/**
@@ -445,6 +463,9 @@ class Admin_Bar_Test extends TestCase {
 
 		$this->assertFalse( $this->instance->get_current_post() );
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_the_query'] );
 	}
 
 	/**
@@ -484,6 +505,9 @@ class Admin_Bar_Test extends TestCase {
 
 		$this->assertFalse( $this->instance->get_current_post() );
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_the_query'] );
 	}
 
 	/**
@@ -528,5 +552,8 @@ class Admin_Bar_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->assertSame( false, $this->instance->get_current_post() );
+
+		// Clean up after the test.
+		unset( $GLOBALS['wp_the_query'] );
 	}
 }

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -141,6 +141,9 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'enqueue_strings_script' );
 
 		$this->instance->enqueue_classic_editor_scripts();
+
+		// Clean up after the test.
+		unset( $_GET['post'] );
 	}
 
 	/**
@@ -167,6 +170,9 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'enqueue_styles' );
 
 		$this->instance->enqueue_classic_editor_styles();
+
+		// Clean up after the test.
+		unset( $_GET['post'] );
 	}
 
 	/**
@@ -232,6 +238,9 @@ class Classic_Editor_Test extends TestCase {
 
 		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button();
+
+		// Clean up after the test.
+		unset( $_GET['post'] );
 	}
 
 	/**
@@ -240,8 +249,6 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_unsuccessful_no_post() {
-		unset( $_GET['post'] );
-
 		Monkey\Functions\expect( '\get_option' )
 			->with( 'duplicate_post_show_submitbox' )
 			->andReturn( '1' );
@@ -367,6 +374,9 @@ class Classic_Editor_Test extends TestCase {
 
 		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button();
+
+		// Clean up after the test.
+		unset( $_GET['post'] );
 	}
 
 	/**
@@ -375,8 +385,6 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_no_post() {
-		unset( $_GET['post'] );
-
 		Monkey\Functions\expect( '\get_option' )
 			->with( 'duplicate_post_show_submitbox' )
 			->andReturn( '1' );
@@ -872,6 +880,9 @@ class Classic_Editor_Test extends TestCase {
 			->andReturnTrue();
 
 		$this->assertTrue( $this->instance->should_change_rewrite_republish_copy( $post ) );
+
+		// Clean up after the test.
+		unset( $GLOBALS['pagenow'] );
 	}
 
 	/**
@@ -892,6 +903,9 @@ class Classic_Editor_Test extends TestCase {
 			->andReturnTrue();
 
 		$this->assertTrue( $this->instance->should_change_rewrite_republish_copy( $post ) );
+
+		// Clean up after the test.
+		unset( $GLOBALS['pagenow'] );
 	}
 
 	/**
@@ -908,6 +922,9 @@ class Classic_Editor_Test extends TestCase {
 		$post->post_type = 'post';
 
 		$this->assertFalse( $this->instance->should_change_rewrite_republish_copy( $post ) );
+
+		// Clean up after the test.
+		unset( $GLOBALS['pagenow'] );
 	}
 
 	/**
@@ -921,6 +938,9 @@ class Classic_Editor_Test extends TestCase {
 		$pagenow = 'post.php';
 
 		$this->assertFalse( $this->instance->should_change_rewrite_republish_copy( null ) );
+
+		// Clean up after the test.
+		unset( $GLOBALS['pagenow'] );
 	}
 
 	/**
@@ -942,6 +962,9 @@ class Classic_Editor_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->assertFalse( $this->instance->should_change_rewrite_republish_copy( $post ) );
+
+		// Clean up after the test.
+		unset( $GLOBALS['pagenow'] );
 	}
 
 	/**

--- a/tests/watchers/bulk-actions-watcher-test.php
+++ b/tests/watchers/bulk-actions-watcher-test.php
@@ -131,6 +131,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_bulk_clone_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success fade"><p>1 item copied.</p></div>' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['bulk_cloned'] );
 	}
 
 	/**
@@ -144,6 +147,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_bulk_clone_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success fade"><p>2 items copied.</p></div>' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['bulk_cloned'] );
 	}
 
 	/**
@@ -157,6 +163,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_bulk_rewrite_and_republish_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success fade"><p>1 post duplicated. You can now start rewriting your post in the duplicate of the original post. Once you choose to republish it your changes will be merged back into the original post.</p></div>' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['bulk_rewriting'] );
 	}
 
 	/**
@@ -170,5 +179,8 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_bulk_rewrite_and_republish_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success fade"><p>2 posts duplicated. You can now start rewriting your posts in the duplicates of the original posts. Once you choose to republish them your changes will be merged back into the original post.</p></div>' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['bulk_rewriting'] );
 	}
 }

--- a/tests/watchers/link-actions-watcher-test.php
+++ b/tests/watchers/link-actions-watcher-test.php
@@ -149,6 +149,9 @@ class Link_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_clone_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success fade"><p>1 item copied.</p></div>' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['cloned'] );
 	}
 
 	/**
@@ -166,6 +169,9 @@ class Link_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_clone_admin_notice();
 
 		$this->expectOutputString( '' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['cloned'] );
 	}
 
 	/**
@@ -183,6 +189,9 @@ class Link_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_rewrite_and_republish_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-warning is-dismissible fade"><p>You can now start rewriting your post in this duplicate of the original post. If you click "Republish", your changes will be merged into the original post and you’ll be redirected there.</p></div>' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['rewriting'] );
 	}
 
 	/**
@@ -200,6 +209,9 @@ class Link_Actions_Watcher_Test extends TestCase {
 		$this->instance->add_rewrite_and_republish_admin_notice();
 
 		$this->expectOutputString( '' );
+
+		// Clean up after the test.
+		unset( $_REQUEST['rewriting'] );
 	}
 
 	/**
@@ -228,5 +240,8 @@ class Link_Actions_Watcher_Test extends TestCase {
 			);
 
 		$this->instance->add_rewrite_and_republish_block_editor_notice();
+
+		// Clean up after the test.
+		unset( $_REQUEST['rewriting'] );
 	}
 }

--- a/tests/watchers/republished-post-watcher-test.php
+++ b/tests/watchers/republished-post-watcher-test.php
@@ -97,6 +97,8 @@ class Republished_Post_Watcher_Test extends TestCase {
 		$this->instance->add_admin_notice();
 
 		$this->expectOutputString( '<div id="message" class="notice notice-success is-dismissible"><p>notice</p></div>' );
+
+		// Clean up after the test.
 		unset( $_REQUEST['dprepublished'] );
 	}
 
@@ -145,6 +147,8 @@ class Republished_Post_Watcher_Test extends TestCase {
 		$_REQUEST['dprepublished'] = '1';
 
 		$this->instance->add_block_editor_notice();
+
+		// Clean up after the test.
 		unset( $_REQUEST['dprepublished'] );
 	}
 


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

When a (WP) global variable or a PHP superglobal variable key is set from within a test, it should be cleaned up at the end of the test to make sure the variable being set does not unduly influence other tests.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (test runs), we're good.