### PR TITLE
 QA: Unit tests: use the correct parameter order

### DIFF
--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -483,7 +483,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( $this->instance->change_republish_strings_classic_editor( '', $text ), 'Republish on: %s' );
+		$this->assertEquals( 'Republish on: %s', $this->instance->change_republish_strings_classic_editor( '', $text ) );
 	}
 
 	/**
@@ -506,7 +506,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( $this->instance->change_republish_strings_classic_editor( '', $text ), 'Republish' );
+		$this->assertEquals( 'Republish', $this->instance->change_republish_strings_classic_editor( '', $text ) );
 	}
 
 	/**
@@ -530,7 +530,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->assertEquals( $this->instance->change_republish_strings_classic_editor( $translation, $text ), 'Publish' );
+		$this->assertEquals( 'Publish', $this->instance->change_republish_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -555,7 +555,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( $this->instance->change_republish_strings_classic_editor( $translation, $text ), 'Test' );
+		$this->assertEquals( 'Test', $this->instance->change_republish_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -578,7 +578,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( $this->instance->change_schedule_strings_classic_editor( '', $text ), 'Schedule republish' );
+		$this->assertEquals( 'Schedule republish', $this->instance->change_schedule_strings_classic_editor( '', $text ) );
 	}
 
 	/**
@@ -602,7 +602,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->assertEquals( $this->instance->change_schedule_strings_classic_editor( $translation, $text ), 'Schedule' );
+		$this->assertEquals( 'Schedule', $this->instance->change_schedule_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -627,7 +627,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( $this->instance->change_schedule_strings_classic_editor( $translation, $text ), 'Test' );
+		$this->assertEquals( 'Test', $this->instance->change_schedule_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -739,7 +739,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $time_format, $post )
 			->andReturn( $scheduled_time );
 
-		$this->assertEquals( $this->instance->change_scheduled_notice_classic_editor( $messages ), $result );
+		$this->assertEquals( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
 	}
 
 	/**
@@ -851,7 +851,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $time_format, $post )
 			->andReturn( $scheduled_time );
 
-		$this->assertEquals( $this->instance->change_scheduled_notice_classic_editor( $messages ), $result );
+		$this->assertEquals( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improve test suite


## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite


## Relevant technical choices:

For PHPUnit assertions which expect an `$expected` and a `$result` parameter, the parameter order is always `( $expected, $result, ...).

While it may not seem important to use the correct parameter order for assertions doing a straight comparison, in actual fact, it is.
The PHPUnit output when the assertions fail expects this order and the failure message will be reversed if the parameters are passed in reversed order which leads to confusion and makes it more difficult to debug a failing test.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (test runs), we're good.
