### PR TITLE
QA: use strict PHPUnit assertions

### DIFF
--- a/tests/admin/options-form-generator-test.php
+++ b/tests/admin/options-form-generator-test.php
@@ -120,7 +120,7 @@ class Options_Form_Generator_Test extends TestCase {
 
 		$output   = $this->instance->generate_options_input( $options );
 		$expected = '<input type="checkbox" /><label for="option-1">Show field</label> <span id="option-1-description">(test description)</span><br /><input type="checkbox" /><label for="option-2">Disable editing</label><br /><input type="text" /><br />';
-		$this->assertEquals( $expected, $output );
+		$this->assertSame( $expected, $output );
 	}
 
 	/**
@@ -213,7 +213,7 @@ class Options_Form_Generator_Test extends TestCase {
 			->text()
 			->andReturns( '<input type="text" />' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="text" name="option_2" id="option-2" value="1"  /><br />',
 			$this->instance->generate_options_input( $options )
 		);
@@ -239,7 +239,7 @@ class Options_Form_Generator_Test extends TestCase {
 
 		$this->instance->expects( 'is_checked' )->once();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="checkbox" name="option_1[sub_option_1]" id="option-1-sub-option-1" value="1"  /><label for="option-1-sub-option-1">Suboption 1</label><br />',
 			$this->instance->generate_options_input( $options )
 		);
@@ -251,7 +251,7 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator::extract_description
 	 */
 	public function test_extract_description() {
-		$this->assertEquals(
+		$this->assertSame(
 			'<span id="textfield-1-description">(this is a description)</span>',
 			$this->instance
 				->extract_description(
@@ -260,7 +260,7 @@ class Options_Form_Generator_Test extends TestCase {
 				)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<p id="textfield-1-description">this is a description<br />this is another description</p>',
 			$this->instance
 				->extract_description(
@@ -306,7 +306,7 @@ class Options_Form_Generator_Test extends TestCase {
 			->once()
 			->andReturn( [ 'custom_taxonomy_2' ] );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<div class="taxonomy_public"><input type="checkbox" name="duplicate_post_taxonomies_blacklist[]" id="duplicate-post-custom-taxonomy" value="custom_taxonomy"  /><label for="duplicate-post-custom-taxonomy">Custom Taxonomy [custom_taxonomy]</label><br /></div><div class="taxonomy_private"><input type="checkbox" name="duplicate_post_taxonomies_blacklist[]" id="duplicate-post-custom-taxonomy-2" value="custom_taxonomy_2" checked="checked" /><label for="duplicate-post-custom-taxonomy-2">Custom Taxonomy [custom_taxonomy_2]</label><br /></div>',
 			$this->instance->generate_taxonomy_exclusion_list()
 		);
@@ -332,7 +332,7 @@ class Options_Form_Generator_Test extends TestCase {
 				]
 			);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="checkbox" name="duplicate_post_roles[]" id="duplicate-post-editor" value="editor" checked="checked" /><label for="duplicate-post-editor">Editor</label><br /><input type="checkbox" name="duplicate_post_roles[]" id="duplicate-post-administrator" value="administrator" checked="checked" /><label for="duplicate-post-administrator">Administrator</label><br />',
 			$this->instance->generate_roles_permission_list()
 		);
@@ -364,7 +364,7 @@ class Options_Form_Generator_Test extends TestCase {
 			->with( 'Movies' )
 			->andReturnFalse();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="checkbox" name="duplicate_post_types_enabled[]" id="duplicate-post-Books" value="Books" checked="checked" /><label for="duplicate-post-Books">Custom Type</label><br /><input type="checkbox" name="duplicate_post_types_enabled[]" id="duplicate-post-Movies" value="Movies"  /><label for="duplicate-post-Movies">Custom Type</label><br />',
 			$this->instance->generate_post_types_list()
 		);
@@ -399,7 +399,7 @@ class Options_Form_Generator_Test extends TestCase {
 
 		$output = $this->instance->is_checked( $option, $option_values, $parent_option );
 
-		$this->assertEquals( $assertion['expected'], $output );
+		$this->assertSame( $assertion['expected'], $output );
 	}
 
 	/**
@@ -445,8 +445,8 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator::prepare_input_id
 	 */
 	public function test_prepare_input_id() {
-		$this->assertEquals( 'my-form-element-id', $this->instance->prepare_input_id( 'my_form_element_id' ) );
-		$this->assertEquals( 'my-form-element-id', $this->instance->prepare_input_id( 'my_form-element-id' ) );
-		$this->assertEquals( 'myFormElementId', $this->instance->prepare_input_id( 'myFormElementId' ) );
+		$this->assertSame( 'my-form-element-id', $this->instance->prepare_input_id( 'my_form_element_id' ) );
+		$this->assertSame( 'my-form-element-id', $this->instance->prepare_input_id( 'my_form-element-id' ) );
+		$this->assertSame( 'myFormElementId', $this->instance->prepare_input_id( 'myFormElementId' ) );
 	}
 }

--- a/tests/admin/options-inputs-test.php
+++ b/tests/admin/options-inputs-test.php
@@ -33,12 +33,12 @@ class Options_Inputs_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Inputs::checkbox
 	 */
 	public function test_checkbox() {
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="checkbox" name="test_checkbox" id="test-checkbox-id" value="1"  />',
 			$this->instance->checkbox( 'test_checkbox', 1, 'test-checkbox-id', false )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="checkbox" name="test_checkbox2" id="test-checkbox-id2" value="1" checked="checked" />',
 			$this->instance->checkbox( 'test_checkbox2', 1, 'test-checkbox-id2', true )
 		);
@@ -50,7 +50,7 @@ class Options_Inputs_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Inputs::text
 	 */
 	public function test_text() {
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="text" name="test_text" id="test-text-id" value="Hello world"  />',
 			$this->instance->text( 'test_text', 'Hello world', 'test-text-id' )
 		);
@@ -62,7 +62,7 @@ class Options_Inputs_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Inputs::number
 	 */
 	public function test_number() {
-		$this->assertEquals(
+		$this->assertSame(
 			'<input type="number" name="test_number" id="test-number-id" value="1" min="0" step="1" />',
 			$this->instance->number( 'test_number', '1', 'test-number-id' )
 		);

--- a/tests/admin/options-test.php
+++ b/tests/admin/options-test.php
@@ -81,7 +81,7 @@ class Options_Test extends TestCase {
 	public function test_get_options_for_first_tab() {
 		$options = $this->instance->get_options_for_tab( 'tab1' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'option_1' => [
 					'tab'      => 'tab1',
@@ -109,7 +109,7 @@ class Options_Test extends TestCase {
 	public function test_get_options_for_first_tab_and_fieldset() {
 		$options = $this->instance->get_options_for_tab( 'tab1', 'fieldset1' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'option_1' => [
 					'tab'      => 'tab1',
@@ -153,7 +153,7 @@ class Options_Test extends TestCase {
 	public function test_get_valid_option() {
 		$options = $this->instance->get_option( 'option_1' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'option_1' => [
 					'tab'      => 'tab1',

--- a/tests/permissions-helper-test.php
+++ b/tests/permissions-helper-test.php
@@ -42,7 +42,7 @@ class Permissions_Helper_Test extends TestCase {
 			->with( 'duplicate_post_types_enabled', [ 'post', 'page' ] )
 			->andReturn( $post_types );
 
-		$this->assertEquals( $post_types, $this->instance->get_enabled_post_types() );
+		$this->assertSame( $post_types, $this->instance->get_enabled_post_types() );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Permissions_Helper_Test extends TestCase {
 			->with( 'duplicate_post_types_enabled', [ 'post', 'page' ] )
 			->andReturn( $post_types );
 
-		$this->assertEquals( [ $post_types ], $this->instance->get_enabled_post_types() );
+		$this->assertSame( [ $post_types ], $this->instance->get_enabled_post_types() );
 	}
 
 	/**
@@ -655,7 +655,7 @@ class Permissions_Helper_Test extends TestCase {
 			->with( $post )
 			->andReturn( $original['has_rewrite_and_republish_copy'] );
 
-		$this->assertEquals( $expected, $this->instance->should_rewrite_and_republish_be_allowed( $post ) );
+		$this->assertSame( $expected, $this->instance->should_rewrite_and_republish_be_allowed( $post ) );
 	}
 
 	/**
@@ -797,7 +797,7 @@ class Permissions_Helper_Test extends TestCase {
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_status = $post_status;
 
-		$this->assertEquals( $expected, $this->instance->is_copy_allowed_to_be_republished( $post ) );
+		$this->assertSame( $expected, $this->instance->is_copy_allowed_to_be_republished( $post ) );
 	}
 
 	/**

--- a/tests/post-duplicator-test.php
+++ b/tests/post-duplicator-test.php
@@ -82,7 +82,7 @@ class Post_Duplicator_Test extends TestCase {
 			->twice()
 			->andReturnFirstArg();
 
-		$this->assertEquals( $expected, $this->instance->generate_copy_title( $post, $original ) );
+		$this->assertSame( $expected, $this->instance->generate_copy_title( $post, $original ) );
 	}
 
 	/**
@@ -183,7 +183,7 @@ class Post_Duplicator_Test extends TestCase {
 			->with( 'publish_pages' )
 			->andReturn( $original['capability'] );
 
-		$this->assertEquals( $expected, $this->instance->generate_copy_status( $post, $options ) );
+		$this->assertSame( $expected, $this->instance->generate_copy_status( $post, $options ) );
 	}
 
 	/**
@@ -287,7 +287,7 @@ class Post_Duplicator_Test extends TestCase {
 			->with( 'edit_others_posts' )
 			->andReturn( $original['capability'] );
 
-		$this->assertEquals( $expected, $this->instance->generate_copy_author( $post, $options ) );
+		$this->assertSame( $expected, $this->instance->generate_copy_author( $post, $options ) );
 	}
 
 	/**

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -187,7 +187,7 @@ class Post_Republisher_Test extends TestCase {
 			->andReturn( $input['is_copy'] );
 
 		$returned_post_data = $this->instance->change_post_copy_status( (array) $post, $postarr );
-		$this->assertEquals( $expected['post_status'], $returned_post_data['post_status'] );
+		$this->assertSame( $expected['post_status'], $returned_post_data['post_status'] );
 	}
 
 	/**

--- a/tests/ui/bulk-actions-test.php
+++ b/tests/ui/bulk-actions-test.php
@@ -156,7 +156,7 @@ class Bulk_Actions_Test extends TestCase {
 			'trash' => 'Move to Trash',
 		];
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'edit'                                  => 'Edit',
 				'trash'                                 => 'Move to Trash',

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -491,7 +491,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( 'Republish on: %s', $this->instance->change_republish_strings_classic_editor( '', $text ) );
+		$this->assertSame( 'Republish on: %s', $this->instance->change_republish_strings_classic_editor( '', $text ) );
 	}
 
 	/**
@@ -514,7 +514,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( 'Republish', $this->instance->change_republish_strings_classic_editor( '', $text ) );
+		$this->assertSame( 'Republish', $this->instance->change_republish_strings_classic_editor( '', $text ) );
 	}
 
 	/**
@@ -538,7 +538,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->assertEquals( 'Publish', $this->instance->change_republish_strings_classic_editor( $translation, $text ) );
+		$this->assertSame( 'Publish', $this->instance->change_republish_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -563,7 +563,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( 'Test', $this->instance->change_republish_strings_classic_editor( $translation, $text ) );
+		$this->assertSame( 'Test', $this->instance->change_republish_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -586,7 +586,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( 'Schedule republish', $this->instance->change_schedule_strings_classic_editor( '', $text ) );
+		$this->assertSame( 'Schedule republish', $this->instance->change_schedule_strings_classic_editor( '', $text ) );
 	}
 
 	/**
@@ -610,7 +610,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->assertEquals( 'Schedule', $this->instance->change_schedule_strings_classic_editor( $translation, $text ) );
+		$this->assertSame( 'Schedule', $this->instance->change_schedule_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -635,7 +635,7 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->assertEquals( 'Test', $this->instance->change_schedule_strings_classic_editor( $translation, $text ) );
+		$this->assertSame( 'Test', $this->instance->change_schedule_strings_classic_editor( $translation, $text ) );
 	}
 
 	/**
@@ -747,7 +747,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $time_format, $post )
 			->andReturn( $scheduled_time );
 
-		$this->assertEquals( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
+		$this->assertSame( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
 	}
 
 	/**
@@ -859,7 +859,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $time_format, $post )
 			->andReturn( $scheduled_time );
 
-		$this->assertEquals( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
+		$this->assertSame( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
 	}
 
 	/**
@@ -1026,7 +1026,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturnTrue();
 
-		$this->assertEquals( '', $this->instance->remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) );
+		$this->assertSame( '', $this->instance->remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) );
 	}
 
 	/**
@@ -1047,6 +1047,6 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturnFalse();
 
-		$this->assertEquals( 'sample-permalink-html', $this->instance->remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) );
+		$this->assertSame( 'sample-permalink-html', $this->instance->remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) );
 	}
 }

--- a/tests/ui/column-test.php
+++ b/tests/ui/column-test.php
@@ -101,7 +101,7 @@ class Column_Test extends TestCase {
 			'date'       => 'Date',
 		];
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'cb'                           => '<input type="checkbox" />',
 				'title'                        => 'Title',

--- a/tests/ui/link-builder-test.php
+++ b/tests/ui/link-builder-test.php
@@ -137,7 +137,7 @@ class Link_Builder_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_nonce_url' )
 			->andReturnFirstArg();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_clone&amp;post=123',
 			$this->instance->build_link( $post, $context, $action_name )
 		);
@@ -168,7 +168,7 @@ class Link_Builder_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_nonce_url' )
 			->andReturnFirstArg();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_clone&post=123',
 			$this->instance->build_link( $post, $context, $action_name )
 		);
@@ -194,7 +194,7 @@ class Link_Builder_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_nonce_url' )
 			->never();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'',
 			$this->instance->build_link( $post, $context, $action_name )
 		);

--- a/tests/utils-test.php
+++ b/tests/utils-test.php
@@ -19,7 +19,7 @@ class Utils_Test extends TestCase {
 	 * @param string $expected Expected output.
 	 */
 	public function test_flatten_version( $original, $expected ) {
-		$this->assertEquals( $expected, Utils::flatten_version( $original ) );
+		$this->assertSame( $expected, Utils::flatten_version( $original ) );
 	}
 
 	/**
@@ -48,7 +48,7 @@ class Utils_Test extends TestCase {
 	 * @param mixed $expected Expected output.
 	 */
 	public function test_addslashes_to_strings_only( $original, $expected ) {
-		$this->assertEquals( $expected, Utils::addslashes_to_strings_only( $original ) );
+		$this->assertSame( $expected, Utils::addslashes_to_strings_only( $original ) );
 	}
 
 	/**

--- a/tests/watchers/bulk-actions-watcher-test.php
+++ b/tests/watchers/bulk-actions-watcher-test.php
@@ -85,7 +85,7 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 			'wp-post-new-reload',
 		];
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'activate',
 				'activated',

--- a/tests/watchers/link-actions-watcher-test.php
+++ b/tests/watchers/link-actions-watcher-test.php
@@ -99,7 +99,7 @@ class Link_Actions_Watcher_Test extends TestCase {
 			'wp-post-new-reload',
 		];
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'activate',
 				'activated',

--- a/tests/watchers/republished-post-watcher-test.php
+++ b/tests/watchers/republished-post-watcher-test.php
@@ -187,7 +187,7 @@ class Republished_Post_Watcher_Test extends TestCase {
 			'wp-post-new-reload',
 		];
 
-		$this->assertEquals(
+		$this->assertSame(
 			[
 				'activate',
 				'activated',


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

Using strict assertions should always be preferred over loose type assertions. This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available has been extended hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.