### PR TITLE
Tests: stub the `esc_html_e()` function

### DIFF
--- a/tests/handlers/check-changes-handler-test.php
+++ b/tests/handlers/check-changes-handler-test.php
@@ -117,7 +117,7 @@ class Check_Changes_Handler_Test extends TestCase {
 			'		<div class="wrap">
 			<h1 class="long-header">
 			Compare changes of duplicated post with the original (&#8220;<a href="https://yoa.st/wp-admin/post.php?id=100">Unchanged Title</a>&#8221;)				</h1>
-			<a href="https://yoa.st/wp-admin/post.php?id=123"></a>
+			<a href="https://yoa.st/wp-admin/post.php?id=123">&larr; Return to editor</a>
 			<div class="revisions">
 				<div class="revisions-control-frame">
 					<div class="revisions-controls"></div>

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -115,6 +115,8 @@ abstract class TestCase extends BaseTestCase {
 				},
 			]
 		);
+
+		Monkey\Functions\when( 'esc_html_e' )->echoArg();
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

Stub the `esc_html_e()` function and adjust the expected output in one test.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.