### PR TITLE
Classic_Editor_Test: improve testing of expected output

### DIFF
--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -203,7 +203,10 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( static function () {} );
+		$this->expectOutputRegex(
+			'`\s*<div id="duplicate-action">\s+<a class="submitduplicate duplication"\s+href="[^"]+">Copy to a new draft\s+</a>\s+</div>`'
+		);
+
 		$this->instance->add_new_draft_post_button( $post );
 	}
 
@@ -236,7 +239,10 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( static function () {} );
+		$this->expectOutputRegex(
+			'`\s*<div id="duplicate-action">\s+<a class="submitduplicate duplication"\s+href="[^"]+">Copy to a new draft\s+</a>\s+</div>`'
+		);
+
 		$this->instance->add_new_draft_post_button();
 
 		// Clean up after the test.
@@ -331,7 +337,10 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( static function () {} );
+		$this->expectOutputRegex(
+			'`\s*<div id="rewrite-republish-action">\s+<a class="submitduplicate duplication" href="[^"]+">Rewrite & Republish\s+</a>\s+</div>`'
+		);
+
 		$this->instance->add_rewrite_and_republish_post_button( $post );
 	}
 
@@ -370,7 +379,10 @@ class Classic_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturn( $url );
 
-		$this->setOutputCallback( static function () {} );
+		$this->expectOutputRegex(
+			'`\s*<div id="rewrite-republish-action">\s+<a class="submitduplicate duplication" href="[^"]+">Rewrite & Republish\s+</a>\s+</div>`'
+		);
+
 		$this->instance->add_rewrite_and_republish_post_button();
 
 		// Clean up after the test.

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -264,7 +264,6 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_new_draft_link' )
 			->never();
 
-		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
 	}
@@ -295,7 +294,6 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_new_draft_link' )
 			->never();
 
-		$this->setOutputCallback( static function () {} );
 		$this->instance->add_new_draft_post_button( $post );
 	}
 
@@ -400,7 +398,6 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_rewrite_and_republish_link' )
 			->never();
 
-		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
 	}
@@ -437,7 +434,6 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_rewrite_and_republish_link' )
 			->never();
 
-		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button( $post );
 	}
 
@@ -466,7 +462,6 @@ class Classic_Editor_Test extends TestCase {
 			->expects( 'build_rewrite_and_republish_link' )
 			->never();
 
-		$this->setOutputCallback( static function () {} );
 		$this->instance->add_rewrite_and_republish_post_button();
 		$this->assertTrue( Monkey\Filters\applied( 'duplicate_post_show_link' ) === 0 );
 	}


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

### Classic_Editor_Test: remove redundant setOutputCallback() calls

Most tests in the `Classic_Editor_Test` would set an output callback to `$this->setOutputCallback( static function () {} );`.

For tests which do not produce output, this is redundant, so removing these.

### Classic_Editor_Test: replace remaining calls to setOutputCallback() with expectations

The remaining calls to `setOutputCallback()` were used to "silence" expected output.

Expected output should generally be tested, not silenced. With that in mind, the remaining calls to `setOutputCallback()` have been replaced with calls to `expectOutputRegex()` with a regex based on the output generated by the function under test.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.