### PR TITLE
Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ composer.lock
 .phpcs.xml
 phpcs.xml
 .cache/phpcs.cache
+phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ jobs:
     - php: '7.4'
       env: SNIFF=1 PHPUNIT=1
     - php: '8.0'
-      env: LINT=1
+      env: LINT=1 PHPUNIT=1
     - php: "nightly"
-      env: LINT=1
+      env: LINT=1 PHPUNIT=1
 
   allow_failures:
     - php: "nightly"

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ],
         "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+        ],
+        "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,10 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "brain/monkey": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/yoastcs": "^2.1"
+        "yoast/yoastcs": "^2.1",
+        "yoast/wp-test-utils": "^0.2.1"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	forceCoversAnnotation="true"
 	processIsolation="false"
 	stopOnError="false"
 	stopOnFailure="false"
@@ -17,13 +18,13 @@
 	verbose="true"
 	>
 	<testsuites>
-		<testsuite name="main">
+		<testsuite name="duplicatepost">
 			<directory suffix="-test.php">./tests/</directory>
 		</testsuite>
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<directory>./src</directory>
 		</whitelist>
 	</filter>

--- a/tests/admin/options-form-generator-test.php
+++ b/tests/admin/options-form-generator-test.php
@@ -31,8 +31,8 @@ class Options_Form_Generator_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options_inputs = Mockery::mock( Options_Inputs::class )->makePartial();
 		$this->instance       = Mockery::mock( Options_Form_Generator::class, [ $this->options_inputs ] )->makePartial();

--- a/tests/admin/options-form-generator-test.php
+++ b/tests/admin/options-form-generator-test.php
@@ -359,6 +359,8 @@ class Options_Form_Generator_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_generate_roles_permission_list() {
+		$this->stub_wp_roles();
+
 		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$utils
 			->expects( 'get_roles' )

--- a/tests/admin/options-form-generator-test.php
+++ b/tests/admin/options-form-generator-test.php
@@ -78,7 +78,10 @@ class Options_Form_Generator_Test extends TestCase {
 	public function test_constructor() {
 		$this->instance->__construct( $this->options_inputs );
 
-		$this->assertAttributeInstanceOf( Options_Inputs::class, 'options_inputs', $this->instance );
+		$this->assertInstanceOf(
+			Options_Inputs::class,
+			$this->getPropertyValue( $this->instance, 'options_inputs' )
+		);
 	}
 
 	/**

--- a/tests/admin/options-form-generator-test.php
+++ b/tests/admin/options-form-generator-test.php
@@ -34,6 +34,8 @@ class Options_Form_Generator_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->options_inputs = Mockery::mock( Options_Inputs::class )->makePartial();
 		$this->instance       = Mockery::mock( Options_Form_Generator::class, [ $this->options_inputs ] )->makePartial();
 

--- a/tests/admin/options-inputs-test.php
+++ b/tests/admin/options-inputs-test.php
@@ -25,6 +25,8 @@ class Options_Inputs_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = Mockery::mock( Options_Inputs::class )->makePartial();
 	}
 

--- a/tests/admin/options-inputs-test.php
+++ b/tests/admin/options-inputs-test.php
@@ -22,8 +22,8 @@ class Options_Inputs_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Options_Inputs::class )->makePartial();
 	}

--- a/tests/admin/options-page-test.php
+++ b/tests/admin/options-page-test.php
@@ -158,6 +158,8 @@ class Options_Page_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_register_roles() {
+		$this->stub_wp_roles();
+
 		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 
 		Monkey\Functions\expect( '\current_user_can' )

--- a/tests/admin/options-page-test.php
+++ b/tests/admin/options-page-test.php
@@ -46,8 +46,8 @@ class Options_Page_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options        = Mockery::mock( Options::class )->makePartial();
 		$this->form_generator = Mockery::mock( Options_Form_Generator::class )->makePartial();

--- a/tests/admin/options-page-test.php
+++ b/tests/admin/options-page-test.php
@@ -67,8 +67,15 @@ class Options_Page_Test extends TestCase {
 	public function test_constructor() {
 		$this->instance->__construct( $this->options, $this->form_generator, $this->asset_manager );
 
-		$this->assertAttributeInstanceOf( Options::class, 'options', $this->instance );
-		$this->assertAttributeInstanceOf( Options_Form_Generator::class, 'generator', $this->instance );
+		$this->assertInstanceOf(
+			Options::class,
+			$this->getPropertyValue( $this->instance, 'options' )
+		);
+
+		$this->assertInstanceOf(
+			Options_Form_Generator::class,
+			$this->getPropertyValue( $this->instance, 'generator' )
+		);
 	}
 
 	/**

--- a/tests/admin/options-page-test.php
+++ b/tests/admin/options-page-test.php
@@ -128,6 +128,8 @@ class Options_Page_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Admin\Options_Page::register_menu
 	 */
 	public function test_register_menu() {
+		$this->stubTranslationFunctions();
+
 		Monkey\Functions\expect( '\add_options_page' )
 			->with(
 				[

--- a/tests/admin/options-test.php
+++ b/tests/admin/options-test.php
@@ -29,8 +29,8 @@ class Options_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fake_options = [
 			'option_1' => [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,15 +5,6 @@
  * @package Yoast\WP\Duplicate_Post\Tests
  */
 
-define( 'ABSPATH', true );
-
-define( 'MINUTE_IN_SECONDS', 60 );
-define( 'HOUR_IN_SECONDS', 3600 );
-define( 'DAY_IN_SECONDS', 86400 );
-define( 'WEEK_IN_SECONDS', 604800 );
-define( 'MONTH_IN_SECONDS', 2592000 );
-define( 'YEAR_IN_SECONDS', 31536000 );
-
 define( 'OBJECT', 'OBJECT' );
 define( 'ARRAY_A', 'ARRAY_A' );
 define( 'ARRAY_N', 'ARRAY_N' );
@@ -21,13 +12,10 @@ define( 'ARRAY_N', 'ARRAY_N' );
 define( 'DUPLICATE_POST_FILE', '/var/www/html/wp-content/plugins/duplicate-post/duplicate-post.php' );
 define( 'DUPLICATE_POST_CURRENT_VERSION', '4.0' );
 
-if ( function_exists( 'opcache_reset' ) ) {
-	opcache_reset();
-}
-
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }
 
+require_once __DIR__ . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/handlers/check-changes-handler-test.php
+++ b/tests/handlers/check-changes-handler-test.php
@@ -31,8 +31,8 @@ class Check_Changes_Handler_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 

--- a/tests/handlers/check-changes-handler-test.php
+++ b/tests/handlers/check-changes-handler-test.php
@@ -48,7 +48,10 @@ class Check_Changes_Handler_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Handlers\Check_Changes_Handler::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/handlers/check-changes-handler-test.php
+++ b/tests/handlers/check-changes-handler-test.php
@@ -34,6 +34,9 @@ class Check_Changes_Handler_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 
 		$this->instance = Mockery::mock( Check_Changes_Handler::class, [ $this->permissions_helper ] )->makePartial();

--- a/tests/permissions-helper-test.php
+++ b/tests/permissions-helper-test.php
@@ -24,8 +24,8 @@ class Permissions_Helper_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Permissions_Helper::class )->makePartial();
 	}

--- a/tests/post-duplicator-test.php
+++ b/tests/post-duplicator-test.php
@@ -7,11 +7,12 @@ use Mockery;
 use WP_Post;
 use WP_User;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
+use Yoast\WPTestUtils\BrainMonkey\TestCase as BMTestCase;
 
 /**
  * Test the Post_Duplicator class.
  */
-class Post_Duplicator_Test extends TestCase {
+class Post_Duplicator_Test extends BMTestCase {
 
 	/**
 	 * The instance.
@@ -23,8 +24,8 @@ class Post_Duplicator_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Post_Duplicator();
 	}

--- a/tests/post-duplicator-test.php
+++ b/tests/post-duplicator-test.php
@@ -7,12 +7,11 @@ use Mockery;
 use WP_Post;
 use WP_User;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
-use Yoast\WPTestUtils\BrainMonkey\TestCase as BMTestCase;
 
 /**
  * Test the Post_Duplicator class.
  */
-class Post_Duplicator_Test extends BMTestCase {
+class Post_Duplicator_Test extends TestCase {
 
 	/**
 	 * The instance.
@@ -77,11 +76,6 @@ class Post_Duplicator_Test extends BMTestCase {
 	public function test_generate_copy_title( $original, $expected ) {
 		$post             = Mockery::mock( WP_Post::class );
 		$post->post_title = 'Title';
-
-		Monkey\Functions\expect( '\sanitize_text_field' )
-			->withAnyArgs()
-			->twice()
-			->andReturnFirstArg();
 
 		$this->assertSame( $expected, $this->instance->generate_copy_title( $post, $original ) );
 	}

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -146,6 +146,8 @@ class Post_Republisher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::register_post_statuses
 	 */
 	public function test_register_post_statuses() {
+		$this->stubTranslationFunctions();
+
 		$options = [
 			'label'                     => 'Republish',
 			'public'                    => true,

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -56,8 +56,15 @@ class Post_Republisher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Post_Duplicator::class, 'post_duplicator', $this->instance );
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Post_Duplicator::class,
+			$this->getPropertyValue( $this->instance, 'post_duplicator' )
+		);
+
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -38,8 +38,8 @@ class Post_Republisher_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->post_duplicator    = Mockery::mock( Post_Duplicator::class );
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );

--- a/tests/revisions-migrator-test.php
+++ b/tests/revisions-migrator-test.php
@@ -22,8 +22,8 @@ class Revisions_Migrator_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Revisions_Migrator();
 	}

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Tests;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
@@ -12,18 +12,11 @@ use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 abstract class TestCase extends YoastTestCase {
 
 	/**
-	 * Holds an array of dummy roles.
+	 * Mock various roles as WP_Role objects and stub the get_roles() function.
 	 *
-	 * @var array
+	 * @return void
 	 */
-	protected $roles;
-
-	/**
-	 * Test setup.
-	 */
-	protected function set_up() {
-
-		parent::set_up();
+	protected function stub_wp_roles() {
 
 		// Mock roles to use across several tests.
 		$role1               = Mockery::mock( 'WP_Role' );
@@ -73,9 +66,7 @@ abstract class TestCase extends YoastTestCase {
 			'subscriber'    => $role3,
 		];
 
-		$this->roles = $role_objects;
-
-		Monkey\Functions\stubs(
+		Functions\stubs(
 			[
 				'get_role' => static function ( $name ) use ( $role_objects ) {
 					return $role_objects[ $name ];

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -4,12 +4,12 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey;
 use Mockery;
-use PHPUnit\Framework\TestCase as BaseTestCase;
+use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
 /**
  * TestCase base class.
  */
-abstract class TestCase extends BaseTestCase {
+abstract class TestCase extends YoastTestCase {
 
 	/**
 	 * Holds an array of dummy roles.
@@ -21,10 +21,12 @@ abstract class TestCase extends BaseTestCase {
 	/**
 	 * Test setup.
 	 */
-	protected function setUp() {
+	protected function set_up() {
 
-		parent::setUp();
-		Monkey\setUp();
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
 
 		// Mock roles to use across several tests.
 		$role1               = Mockery::mock( 'WP_Role' );
@@ -78,52 +80,10 @@ abstract class TestCase extends BaseTestCase {
 
 		Monkey\Functions\stubs(
 			[
-				// Passing "null" makes the function return its first argument.
-				'esc_attr'       => null,
-				'esc_html'       => null,
-				'esc_textarea'   => null,
-				'__'             => null,
-				'_n'             => static function ( $single, $plural, $number ) {
-					if ( $number === 1 ) {
-						return $single;
-					}
-
-					return $plural;
-				},
-				'_x'             => null,
-				'esc_html__'     => null,
-				'esc_html_x'     => null,
-				'esc_html_e'     => null,
-				'esc_attr__'     => null,
-				'esc_attr_x'     => null,
-				'esc_url'        => null,
-				'esc_url_raw'    => null,
-				'is_multisite'   => false,
-				'site_url'       => 'https://www.example.org',
-				'wp_slash'       => null,
-				'wp_unslash'     => static function ( $value ) {
-					return \is_string( $value ) ? \stripslashes( $value ) : $value;
-				},
-				'absint'         => static function ( $value ) {
-					return \abs( \intval( $value ) );
-				},
-				'wp_parse_args'  => static function ( $settings, $defaults ) {
-					return \array_merge( $defaults, $settings );
-				},
-				'get_role'       => static function ( $name ) use ( $role_objects ) {
+				'get_role' => static function ( $name ) use ( $role_objects ) {
 					return $role_objects[ $name ];
 				},
 			]
 		);
-
-		Monkey\Functions\when( 'esc_html_e' )->echoArg();
-	}
-
-	/**
-	 * Test tear down.
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -25,9 +25,6 @@ abstract class TestCase extends YoastTestCase {
 
 		parent::set_up();
 
-		$this->stubEscapeFunctions();
-		$this->stubTranslationFunctions();
-
 		// Mock roles to use across several tests.
 		$role1               = Mockery::mock( 'WP_Role' );
 		$role1->name         = 'Editor';

--- a/tests/ui/admin-bar-test.php
+++ b/tests/ui/admin-bar-test.php
@@ -108,6 +108,8 @@ class Admin_Bar_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_admin_bar_render_successful_both() {
+		$this->stubTranslationFunctions();
+
 		global $wp_admin_bar;
 		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class );
 		$post              = Mockery::mock( WP_Post::class );
@@ -164,6 +166,8 @@ class Admin_Bar_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_admin_bar_render_successful_one() {
+		$this->stubTranslationFunctions();
+
 		global $wp_admin_bar;
 		$wp_admin_bar      = Mockery::mock( WP_Admin_Bar::class );
 		$post              = Mockery::mock( WP_Post::class );

--- a/tests/ui/admin-bar-test.php
+++ b/tests/ui/admin-bar-test.php
@@ -73,9 +73,20 @@ class Admin_Bar_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Admin_Bar::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Link_Builder::class, 'link_builder', $this->instance );
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Asset_Manager::class, 'asset_manager', $this->instance );
+		$this->assertInstanceOf(
+			Link_Builder::class,
+			$this->getPropertyValue( $this->instance, 'link_builder' )
+		);
+
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
+
+		$this->assertInstanceOf(
+			Asset_Manager::class,
+			$this->getPropertyValue( $this->instance, 'asset_manager' )
+		);
 	}
 
 	/**

--- a/tests/ui/admin-bar-test.php
+++ b/tests/ui/admin-bar-test.php
@@ -50,8 +50,8 @@ class Admin_Bar_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->link_builder       = Mockery::mock( Link_Builder::class );
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );

--- a/tests/ui/asset-manager-test.php
+++ b/tests/ui/asset-manager-test.php
@@ -22,8 +22,8 @@ class Asset_Manager_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Asset_Manager::class )->makePartial();
 	}

--- a/tests/ui/block-editor-test.php
+++ b/tests/ui/block-editor-test.php
@@ -47,8 +47,8 @@ class Block_Editor_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->link_builder       = Mockery::mock( Link_Builder::class );
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );

--- a/tests/ui/block-editor-test.php
+++ b/tests/ui/block-editor-test.php
@@ -70,8 +70,15 @@ class Block_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Link_Builder::class, 'link_builder', $this->instance );
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Link_Builder::class,
+			$this->getPropertyValue( $this->instance, 'link_builder' )
+		);
+
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/ui/bulk-actions-test.php
+++ b/tests/ui/bulk-actions-test.php
@@ -30,8 +30,8 @@ class Bulk_Actions_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 		$this->instance           = Mockery::mock( Bulk_Actions::class, [ $this->permissions_helper ] )->makePartial();

--- a/tests/ui/bulk-actions-test.php
+++ b/tests/ui/bulk-actions-test.php
@@ -139,6 +139,8 @@ class Bulk_Actions_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_register_bulk_action() {
+		$this->stubTranslationFunctions();
+
 		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 
 		$utils->expects( 'get_option' )

--- a/tests/ui/bulk-actions-test.php
+++ b/tests/ui/bulk-actions-test.php
@@ -43,7 +43,10 @@ class Bulk_Actions_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Bulk_Actions::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -181,6 +181,9 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_successful() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
 		$url             = 'http://basic.wordpress.test/wp-admin/admin.php?action=duplicate_post_new_draft&post=201&_wpnonce=94038b7dee';
@@ -216,6 +219,9 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_new_draft_post_button
 	 */
 	public function test_add_new_draft_post_button_successful_post_from_GET() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_GET['post']    = '123';
 		$post            = Mockery::mock( WP_Post::class );
 		$post->post_type = 'post';
@@ -309,6 +315,9 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_successful() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
 		$post->post_status = 'publish';
@@ -350,6 +359,9 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::add_rewrite_and_republish_post_button
 	 */
 	public function test_add_rewrite_and_republish_post_button_post_from_GET() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_GET['post']      = '123';
 		$post              = Mockery::mock( WP_Post::class );
 		$post->post_type   = 'post';
@@ -484,6 +496,8 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_republish_strings_classic_editor
 	 */
 	public function test_should_change_republish_strings_date_label() {
+		$this->stubTranslationFunctions();
+
 		$text = 'Publish on: %s';
 
 		$post            = Mockery::mock( WP_Post::class );
@@ -507,6 +521,8 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_republish_strings_classic_editor
 	 */
 	public function test_should_change_republish_strings() {
+		$this->stubTranslationFunctions();
+
 		$text = 'Publish';
 
 		$post            = Mockery::mock( WP_Post::class );
@@ -579,6 +595,8 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_schedule_strings_classic_editor
 	 */
 	public function test_should_change_schedule_strings() {
+		$this->stubTranslationFunctions();
+
 		$text = 'Schedule';
 
 		$post            = Mockery::mock( WP_Post::class );
@@ -651,6 +669,8 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
 	 */
 	public function test_should_change_scheduled_notice_post() {
+		$this->stubTranslationFunctions();
+
 		$post             = Mockery::mock( WP_Post::class );
 		$post->post_type  = 'post';
 		$post->post_title = 'example_post';
@@ -763,6 +783,8 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
 	 */
 	public function test_should_change_scheduled_notice_page() {
+		$this->stubTranslationFunctions();
+
 		$post             = Mockery::mock( WP_Post::class );
 		$post->post_type  = 'page';
 		$post->post_title = 'example_page';

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -47,8 +47,8 @@ class Classic_Editor_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->link_builder       = Mockery::mock( Link_Builder::class );
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -70,8 +70,15 @@ class Classic_Editor_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Link_Builder::class, 'link_builder', $this->instance );
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Link_Builder::class,
+			$this->getPropertyValue( $this->instance, 'link_builder' )
+		);
+
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/ui/column-test.php
+++ b/tests/ui/column-test.php
@@ -38,8 +38,8 @@ class Column_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 		$this->asset_manager      = Mockery::mock( Asset_Manager::class );

--- a/tests/ui/column-test.php
+++ b/tests/ui/column-test.php
@@ -91,6 +91,8 @@ class Column_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Column::add_original_column
 	 */
 	public function test_add_original_column_action() {
+		$this->stubTranslationFunctions();
+
 		$array = [
 			'cb'         => '<input type="checkbox" />',
 			'title'      => 'Title',

--- a/tests/ui/column-test.php
+++ b/tests/ui/column-test.php
@@ -53,8 +53,15 @@ class Column_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Column::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Asset_Manager::class, 'asset_manager', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
+
+		$this->assertInstanceOf(
+			Asset_Manager::class,
+			$this->getPropertyValue( $this->instance, 'asset_manager' )
+		);
 	}
 
 	/**

--- a/tests/ui/link-builder-test.php
+++ b/tests/ui/link-builder-test.php
@@ -23,8 +23,8 @@ class Link_Builder_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Link_Builder::class )->makePartial();
 	}

--- a/tests/ui/metabox-test.php
+++ b/tests/ui/metabox-test.php
@@ -74,6 +74,8 @@ class Metabox_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_add_custom_metabox() {
+		$this->stubTranslationFunctions();
+
 		$utils              = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$enabled_post_types = [ 'post', 'page' ];
 		$post               = Mockery::mock( WP_Post::class );

--- a/tests/ui/metabox-test.php
+++ b/tests/ui/metabox-test.php
@@ -48,7 +48,10 @@ class Metabox_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Metabox::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/ui/metabox-test.php
+++ b/tests/ui/metabox-test.php
@@ -31,8 +31,8 @@ class Metabox_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 

--- a/tests/ui/post-states-test.php
+++ b/tests/ui/post-states-test.php
@@ -45,7 +45,10 @@ class Post_States_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Post_States::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/ui/post-states-test.php
+++ b/tests/ui/post-states-test.php
@@ -31,8 +31,8 @@ class Post_States_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 

--- a/tests/ui/post-states-test.php
+++ b/tests/ui/post-states-test.php
@@ -67,6 +67,8 @@ class Post_States_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_show_original_in_post_states_successful() {
+		$this->stubTranslationFunctions();
+
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$post        = Mockery::mock( WP_Post::class );
 		$original    = Mockery::mock( WP_Post::class );
@@ -145,6 +147,8 @@ class Post_States_Test extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_show_original_in_rewrite_republish_post_successful() {
+		$this->stubTranslationFunctions();
+
 		$utils       = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$post        = Mockery::mock( WP_Post::class );
 		$original    = Mockery::mock( WP_Post::class );

--- a/tests/ui/row-actions-test.php
+++ b/tests/ui/row-actions-test.php
@@ -39,8 +39,8 @@ class Row_Actions_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->link_builder       = Mockery::mock( Link_Builder::class );
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );

--- a/tests/ui/row-actions-test.php
+++ b/tests/ui/row-actions-test.php
@@ -55,8 +55,15 @@ class Row_Actions_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Row_Actions::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Link_Builder::class, 'link_builder', $this->instance );
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Link_Builder::class,
+			$this->getPropertyValue( $this->instance, 'link_builder' )
+		);
+
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/ui/row-actions-test.php
+++ b/tests/ui/row-actions-test.php
@@ -105,6 +105,9 @@ class Row_Actions_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Row_Actions::add_clone_action_link
 	 */
 	public function test_add_clone_action_link_successful() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$actions          = [
 			'edit'                 => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=edit" aria-label="Edit &#8220;Title&#8221;">Edit</a>',
 			'inline hide-if-no-js' => '<button type="button" class="button-link editinline" aria-label="Quick edit &#8220;Title&#8221; inline" aria-expanded="false">Quick&nbsp;Edit</button>',
@@ -190,6 +193,9 @@ class Row_Actions_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Row_Actions::add_new_draft_action_link
 	 */
 	public function test_add_new_draft_action_link_successful() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$actions          = [
 			'edit'                 => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=edit" aria-label="Edit &#8220;Title&#8221;">Edit</a>',
 			'inline hide-if-no-js' => '<button type="button" class="button-link editinline" aria-label="Quick edit &#8220;Title&#8221; inline" aria-expanded="false">Quick&nbsp;Edit</button>',
@@ -275,6 +281,9 @@ class Row_Actions_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Row_Actions::add_rewrite_and_republish_action_link
 	 */
 	public function test_add_rewrite_and_republish_action_link_successful() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$actions           = [
 			'edit'                 => '<a href="http://basic.wordpress.test/wp-admin/post.php?post=464&amp;action=edit" aria-label="Edit &#8220;Title&#8221;">Edit</a>',
 			'inline hide-if-no-js' => '<button type="button" class="button-link editinline" aria-label="Quick edit &#8220;Title&#8221; inline" aria-expanded="false">Quick&nbsp;Edit</button>',

--- a/tests/watchers/bulk-actions-watcher-test.php
+++ b/tests/watchers/bulk-actions-watcher-test.php
@@ -126,6 +126,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Bulk_Actions_Watcher::add_bulk_clone_admin_notice
 	 */
 	public function test_add_bulk_clone_admin_notice_1() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['bulk_cloned'] = '1';
 
 		$this->instance->add_bulk_clone_admin_notice();
@@ -142,6 +145,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Bulk_Actions_Watcher::add_bulk_clone_admin_notice
 	 */
 	public function test_add_bulk_clone_admin_notice_2() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['bulk_cloned'] = '2';
 
 		$this->instance->add_bulk_clone_admin_notice();
@@ -158,6 +164,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Bulk_Actions_Watcher::add_bulk_rewrite_and_republish_admin_notice
 	 */
 	public function test_add_bulk_rewrite_and_republish_admin_notice_1() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['bulk_rewriting'] = '1';
 
 		$this->instance->add_bulk_rewrite_and_republish_admin_notice();
@@ -174,6 +183,9 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Bulk_Actions_Watcher::add_bulk_rewrite_and_republish_admin_notice
 	 */
 	public function test_add_bulk_rewrite_and_republish_admin_notice_2() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['bulk_rewriting'] = '2';
 
 		$this->instance->add_bulk_rewrite_and_republish_admin_notice();

--- a/tests/watchers/bulk-actions-watcher-test.php
+++ b/tests/watchers/bulk-actions-watcher-test.php
@@ -21,8 +21,8 @@ class Bulk_Actions_Watcher_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Bulk_Actions_Watcher::class )->makePartial();
 	}

--- a/tests/watchers/copied-post-watcher-test.php
+++ b/tests/watchers/copied-post-watcher-test.php
@@ -48,7 +48,10 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/watchers/copied-post-watcher-test.php
+++ b/tests/watchers/copied-post-watcher-test.php
@@ -31,8 +31,8 @@ class Copied_Post_Watcher_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 

--- a/tests/watchers/copied-post-watcher-test.php
+++ b/tests/watchers/copied-post-watcher-test.php
@@ -69,6 +69,8 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text_not_scheduled() {
+		$this->stubTranslationFunctions();
+
 		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
@@ -93,6 +95,8 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text_scheduled() {
+		$this->stubTranslationFunctions();
+
 		$post = Mockery::mock( WP_Post::class );
 		$copy = Mockery::mock( WP_Post::class );
 
@@ -126,6 +130,8 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text_copy_in_the_trash() {
+		$this->stubTranslationFunctions();
+
 		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper
@@ -149,6 +155,8 @@ class Copied_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_classic() {
+		$this->stubEscapeFunctions();
+
 		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper

--- a/tests/watchers/link-actions-watcher-test.php
+++ b/tests/watchers/link-actions-watcher-test.php
@@ -47,7 +47,10 @@ class Link_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Link_Actions_Watcher::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/watchers/link-actions-watcher-test.php
+++ b/tests/watchers/link-actions-watcher-test.php
@@ -30,8 +30,8 @@ class Link_Actions_Watcher_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 

--- a/tests/watchers/link-actions-watcher-test.php
+++ b/tests/watchers/link-actions-watcher-test.php
@@ -140,6 +140,9 @@ class Link_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Link_Actions_Watcher::add_clone_admin_notice
 	 */
 	public function test_add_clone_admin_notice_classic() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['cloned'] = '1';
 
 		$this->permissions_helper
@@ -180,6 +183,8 @@ class Link_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Link_Actions_Watcher::add_rewrite_and_republish_admin_notice
 	 */
 	public function test_add_rewrite_and_republish_admin_notice_classic() {
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['rewriting'] = '1';
 
 		$this->permissions_helper
@@ -220,6 +225,8 @@ class Link_Actions_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Link_Actions_Watcher::add_rewrite_and_republish_block_editor_notice
 	 */
 	public function test_add_rewrite_and_republish_block_editor_notice() {
+		$this->stubTranslationFunctions();
+
 		$_REQUEST['rewriting'] = '1';
 
 		$notice = [

--- a/tests/watchers/original-post-watcher-test.php
+++ b/tests/watchers/original-post-watcher-test.php
@@ -48,7 +48,10 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Original_Post_Watcher::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 	}
 
 	/**

--- a/tests/watchers/original-post-watcher-test.php
+++ b/tests/watchers/original-post-watcher-test.php
@@ -31,8 +31,8 @@ class Original_Post_Watcher_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 

--- a/tests/watchers/original-post-watcher-test.php
+++ b/tests/watchers/original-post-watcher-test.php
@@ -69,6 +69,8 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Original_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text() {
+		$this->stubTranslationFunctions();
+
 		$this->assertSame(
 			'The original post has been edited in the meantime. If you click "Republish", this rewritten post will replace the original post.',
 			$this->instance->get_notice_text()
@@ -81,6 +83,8 @@ class Original_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Original_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_classic() {
+		$this->stubEscapeFunctions();
+
 		$post = Mockery::mock( WP_Post::class );
 
 		$this->permissions_helper

--- a/tests/watchers/republished-post-watcher-test.php
+++ b/tests/watchers/republished-post-watcher-test.php
@@ -47,7 +47,10 @@ class Republished_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Republished_Post_Watcher::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Permissions_Helper::class, 'permissions_helper', $this->instance );
+		$this->assertInstanceOf(
+			Permissions_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+		);
 
 		$this->instance->expects( 'register_hooks' )->once();
 		$this->instance->__construct( $this->permissions_helper );

--- a/tests/watchers/republished-post-watcher-test.php
+++ b/tests/watchers/republished-post-watcher-test.php
@@ -72,6 +72,8 @@ class Republished_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Republished_Post_Watcher::get_notice_text
 	 */
 	public function test_get_notice_text() {
+		$this->stubTranslationFunctions();
+
 		$this->assertSame(
 			'Your original post has been replaced with the rewritten post. You are now viewing the (rewritten) original post.',
 			$this->instance->get_notice_text()
@@ -84,6 +86,8 @@ class Republished_Post_Watcher_Test extends TestCase {
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Republished_Post_Watcher::add_admin_notice
 	 */
 	public function test_add_admin_notice_classic() {
+		$this->stubEscapeFunctions();
+
 		$this->permissions_helper
 			->expects( 'is_classic_editor' )
 			->andReturnTrue();

--- a/tests/watchers/republished-post-watcher-test.php
+++ b/tests/watchers/republished-post-watcher-test.php
@@ -30,8 +30,8 @@ class Republished_Post_Watcher_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->permissions_helper = Mockery::mock( Permissions_Helper::class );
 


### PR DESCRIPTION
## Context

* Safeguard compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* Safeguard compatibility with PHP 8

## Relevant technical choices:

👉 **Pro-tip**: this PR will be easiest to review by going through each commit individually.

### Composer: require Yoast/wp-test-utils

* Adds a dev dependency to the `yoast/wp-test-utils` package, which will also make the PHPUnit Polyfills available.
* As that package already requires and manages the installable versions for BrainMonkey and PHPUnit, remove these as explicit requirements from `require-dev` in favour of letting the WP Test Utils package manage the versions.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test cases for use by the plugins.

Refs:
* https://github.com/Yoast/wp-test-utils
* https://github.com/Yoast/PHPUnit-Polyfills/

### .gitignore: ignore some phpunit related files

* Adds `phpunit.xml` to the `.gitignore` file so overload files from individual developers do not get committed.
* PHPUnit 8 introduces a form of caching to PHPUnit, so adding this cache file to the .gitignore file as well.

### Tests: use the bootstrap file from WP Test Utils

... and remove everything which is already done within that file.

### Tests: switch over to the Yoast\WPTestUtils\BrainMonkey\YoastTestCase

All test classes for the BrainMonkey based unit tests in the Duplicate Post test suite have a Duplicate Post native `TestCase` as a parent class.

This switches the parent of that `TestCase` from the PHPUnit native TestCase to the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase`.

The `YoastTestCase`:
* Inherits PHPUnit cross-version compatibility from the PHPUnit Polyfills TestCase.
* Inherits the BrainMonkey set up and teardown and Mockery expectation counting as assertions from the BrainMonkey TestCase.
* And natively adds a number of stubs for commonly used WP functions.

This switch over includes:
* Removing the addition of function stubs which are already added via the `YoastTestCase` class.
* Removing the `tearDown()` method. This will be inherited from the `YoastTestCase` now.
* Renaming the `setUp()` method to `set_up()` in various test classes for PHPUnit cross-version compatibility.
* Makes the `set_up()` methods `protected` to match the visibility in PHPUnit itself.

There is one "exception", which is the `Post_Duplicator_Test` class.
Various tests in that class set expectations for the WP `sanitize_text_field()` function, which is stubbed in the `YoastTestCase` and as a function can't be both stubbed as well as have expectations set for it, this would lead to failing tests.
So for that particular class, the parent class is switched over to the more generic `Yoast\WPTestUtils\BrainMonkey\TestCase` class, which has the same features as the `YoastTestCase`, with the exception of the additional stubs.

### TestCase: remove the generic stubbing of the translation and escaping functions

Only a limited number of tests - 66 out of 282 - need these stubs, so we may as well only load them if and when needed.

BrainMonkey offers a `stubTranslationFunctions()` function which stubs all nearly translation functions and includes escaping for the "translate and escape" functions.
Similarly, it contains a `stubEscapeFunctions()` function.

The WP Test Utils base class for BrainMonkey offers an alternative implementation for both of these, which doesn't do any escaping, but will always return the original value unchanged.

For each of the 66 tests which actually need either the translation functions or the escaping functions, or both, a call to one or both of the wholesale stubbing functions has been put in place.

As a rule of thumb, these function calls have been added to a test `set_up()` method if more than half the tests in the class need these functions.

Otherwise, the function call(s) have been added to the individual test.

### TestCase: move WP_Role mocking/stubbing to separate function

The mocking of the WP_Role objects and the stubbing of the `get_role()` function is only used by a few tests, so instead of of setting these up for every single test being run, only set these up selectively for those tests which actually use this functionality.

Includes removing the `$roles` property which is unused.

### Tests: remove use of `assertAttributeInstanceOf()` assertions

The `assertAttribute*()` assertion methods were deprecated in PHPUnit 8.x and removed in PHPUnit 9.

The reasoning for that was that `protected` and `private` properties are implementation details and should not be tested directly, but via the methods in the class.

For now, I've elected to maintain the existing test behaviour, while making it work in a PHPUnit cross-version compatible manner.

This is done by:
1. Using a test helper method introduced provided via PHPUnit Polyfills (0.2.0) to get the value of a non-public property.
2. Changing the assertions for the tests from `assertAttribute*()` to `assert*()`

At a later point in time, it should be re-examined whether these implementation details should be tested in this way, if at all.

### Travis: run the tests against PHP 8/nightly

Now the tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

### PHPUnit config: improve code coverage configuration

* Rename the testsuite to use a more descriptive name.
* Improve the code coverage configuration:
    - Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
    - Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.
* Add a separate command in the Composer scripts to run the tests with code coverage.
    Notes:
    - Xdebug with code coverage needs to be enabled for running code coverage.
    - The log preferences will still need to be passed either on the command-line or via a dev-local `phpunit.xml` file for the coverage logging to work.

Based on this configuration, the strict code coverage for this testsuite is currently **59.76%**.

### 🆕 Post_Duplicator_Test: remove expectation for sanitize_text_field() 🆕 

... and extend the normal "base" `TestCase` instead.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Run `composer update`.
2. Run `composer test` on any PHP version below 8.0 - as this project has no `composer.lock` anymore, probably best to run this initial test run with a low PHP version (5.6/7.0).
    See the tests pass, including a more accurate assertion count (961 compared to 289 previously, due to Mockery expectations now being counted).
    This confirms that the changes to the `TestCase` and the assertion updates to use PHPUnit 9.x syntax works correctly cross-version as on low PHP versions PHPUnit 5.x will be used.
3. Switch to PHP 8.
4. Run `composer update`
5. Run `composer test` to see the tests running and passing on PHP 8 in combination with PHPUnit 9.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 9.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage as noted above is only ~60%.

