### PR TITLE
Fix bug in test

### DIFF
--- a/tests/admin/options-page-test.php
+++ b/tests/admin/options-page-test.php
@@ -144,7 +144,7 @@ class Options_Page_Test extends TestCase {
 					\__( 'Duplicate Post', 'duplicate-post' ),
 					'manage_options',
 					'duplicatepost',
-					[ $this, 'generate_page' ],
+					[ $this->instance, 'generate_page' ],
 				]
 			)
 			->once()


### PR DESCRIPTION
## Context

* Improve validity of the tests

## Summary

This PR can be summarized in the following changelog entry:

* Improve validity of the tests

## Relevant technical choices:

The `Options_Page_Test::generate_page()` method does not exist. The `Options_Page::generate_page()` method does.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the tests pass, we're good.