### PR TITLE
CS/QA: rename function parameters

### DIFF
--- a/src/ui/asset-manager.php
+++ b/src/ui/asset-manager.php
@@ -99,11 +99,11 @@ class Asset_Manager {
 	/**
 	 * Enqueues the script for the Block editor and passes object via localization.
 	 *
-	 * @param array $object The object to pass to the script.
+	 * @param array $data_object The object to pass to the script.
 	 *
 	 * @return void
 	 */
-	public function enqueue_edit_script( $object = [] ) {
+	public function enqueue_edit_script( $data_object = [] ) {
 		$handle = 'duplicate_post_edit_script';
 		\wp_enqueue_script( $handle );
 		\wp_add_inline_script(
@@ -114,24 +114,24 @@ class Asset_Manager {
 		\wp_localize_script(
 			$handle,
 			'duplicatePost',
-			$object
+			$data_object
 		);
 	}
 
 	/**
 	 * Enqueues the script for the Javascript strings and passes object via localization.
 	 *
-	 * @param array $object The object to pass to the script.
+	 * @param array $data_object The object to pass to the script.
 	 *
 	 * @return void
 	 */
-	public function enqueue_strings_script( $object = [] ) {
+	public function enqueue_strings_script( $data_object = [] ) {
 		$handle = 'duplicate_post_strings';
 		\wp_enqueue_script( $handle );
 		\wp_localize_script(
 			$handle,
 			'duplicatePostStrings',
-			$object
+			$data_object
 		);
 	}
 
@@ -156,11 +156,11 @@ class Asset_Manager {
 	/**
 	 * Enqueues the script for the Elementor plugin.
 	 *
-	 * @param array $object The object to pass to the script.
+	 * @param array $data_object The object to pass to the script.
 	 *
 	 * @return void
 	 */
-	public function enqueue_elementor_script( $object = [] ) {
+	public function enqueue_elementor_script( $data_object = [] ) {
 		$flattened_version = Utils::flatten_version( \DUPLICATE_POST_CURRENT_VERSION );
 		$handle            = 'duplicate_post_elementor_script';
 
@@ -175,7 +175,7 @@ class Asset_Manager {
 		\wp_localize_script(
 			$handle,
 			'duplicatePost',
-			$object
+			$data_object
 		);
 	}
 }

--- a/src/ui/classic-editor.php
+++ b/src/ui/classic-editor.php
@@ -312,7 +312,7 @@ class Classic_Editor {
 	/**
 	 * Removes the sample permalink slug editor in the Classic Editor when the post is a Rewrite & Republish copy.
 	 *
-	 * @param string  $return    Sample permalink HTML markup.
+	 * @param string  $html      Sample permalink HTML markup.
 	 * @param int     $post_id   Post ID.
 	 * @param string  $new_title New sample permalink title.
 	 * @param string  $new_slug  New sample permalink slug.
@@ -320,15 +320,15 @@ class Classic_Editor {
 	 *
 	 * @return string The filtered HTML of the sample permalink slug editor.
 	 */
-	public function remove_sample_permalink_slug_editor( $return, $post_id, $new_title, $new_slug, $post ) {
+	public function remove_sample_permalink_slug_editor( $html, $post_id, $new_title, $new_slug, $post ) {
 		if ( ! $post instanceof WP_Post ) {
-			return $return;
+			return $html;
 		}
 
 		if ( $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
 			return '';
 		}
 
-		return $return;
+		return $html;
 	}
 }

--- a/tests/ui/block-editor-test.php
+++ b/tests/ui/block-editor-test.php
@@ -720,8 +720,8 @@ class Block_Editor_Test extends TestCase {
 
 		Monkey\Functions\expect( '\admin_url' )
 			->andReturnUsing(
-				static function ( $string ) {
-					return 'http://basic.wordpress.test/wp-admin/' . $string;
+				static function ( $query_string ) {
+					return 'http://basic.wordpress.test/wp-admin/' . $query_string;
 				}
 			);
 
@@ -731,12 +731,12 @@ class Block_Editor_Test extends TestCase {
 
 		Monkey\Functions\expect( '\add_query_arg' )
 			->andReturnUsing(
-				static function ( $array, $string ) {
-					foreach ( $array as $key => $value ) {
-						$string .= '&' . $key . '=' . $value;
+				static function ( $arguments, $query_string ) {
+					foreach ( $arguments as $key => $value ) {
+						$query_string .= '&' . $key . '=' . $value;
 					}
 
-					return $string;
+					return $query_string;
 				}
 			);
 

--- a/tests/ui/link-builder-test.php
+++ b/tests/ui/link-builder-test.php
@@ -129,8 +129,8 @@ class Link_Builder_Test extends TestCase {
 
 		Monkey\Functions\expect( '\admin_url' )
 			->andReturnUsing(
-				static function ( $string ) {
-					return 'http://basic.wordpress.test/wp-admin/' . $string;
+				static function ( $query_string ) {
+					return 'http://basic.wordpress.test/wp-admin/' . $query_string;
 				}
 			);
 
@@ -160,8 +160,8 @@ class Link_Builder_Test extends TestCase {
 
 		Monkey\Functions\expect( '\admin_url' )
 			->andReturnUsing(
-				static function ( $string ) {
-					return 'http://basic.wordpress.test/wp-admin/' . $string;
+				static function ( $query_string ) {
+					return 'http://basic.wordpress.test/wp-admin/' . $query_string;
 				}
 			);
 


### PR DESCRIPTION


## Context

* Improved compatibility for PHP 8.0.

## Summary


This PR can be summarized in the following changelog entry:

* Improved compatibility for PHP 8.0.

## Relevant technical choices:

### CS/QA: rename a function parameter

... to prevent using reserved keywords as a parameter names.

While this isn't forbidden, in PHP 8.0+ with named parameters, this can lead to very confusing code, so better to use another name.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This PR does not contain functional changes. If the build passes, we're good.
