### PR TITLE
Improvement on some gettext filter uses, to improve performance

### DIFF
--- a/src/ui/classic-editor.php
+++ b/src/ui/classic-editor.php
@@ -63,9 +63,11 @@ class Classic_Editor {
 			}
 		}
 
-		\add_filter( 'gettext', [ $this, 'change_republish_strings_classic_editor' ], 10, 2 );
-		\add_filter( 'gettext_with_context', [ $this, 'change_schedule_strings_classic_editor' ], 10, 3 );
-		\add_filter( 'post_updated_messages', [ $this, 'change_scheduled_notice_classic_editor' ], 10, 1 );
+		if ( \is_admin() && \current_user_can( 'edit_posts' ) ) {
+			\add_filter( 'gettext', [ $this, 'change_republish_strings_classic_editor' ], 10, 2 );
+			\add_filter( 'gettext_with_context', [ $this, 'change_schedule_strings_classic_editor' ], 10, 3 );
+			\add_filter( 'post_updated_messages', [ $this, 'change_scheduled_notice_classic_editor' ], 10, 1 );
+		}
 
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_scripts' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_styles' ] );
@@ -200,6 +202,10 @@ class Classic_Editor {
 	 * @return string The to-be-used copy of the text.
 	 */
 	public function change_republish_strings_classic_editor( $translation, $text ) {
+		if ( ! \in_array( $text, [ 'Publish', 'Publish on: %s' ], true ) ) {
+			return $translation;
+		}
+
 		if ( $this->should_change_rewrite_republish_copy( \get_post() ) ) {
 			if ( $text === 'Publish' ) {
 				return \__( 'Republish', 'duplicate-post' );
@@ -223,7 +229,7 @@ class Classic_Editor {
 	 * @return string The to-be-used copy of the text.
 	 */
 	public function change_schedule_strings_classic_editor( $translation, $text ) {
-		if ( $this->should_change_rewrite_republish_copy( \get_post() ) && $text === 'Schedule' ) {
+		if ( $text === 'Schedule' && $this->should_change_rewrite_republish_copy( \get_post() ) ) {
 			return \__( 'Schedule republish', 'duplicate-post' );
 		}
 

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -106,6 +106,14 @@ class Classic_Editor_Test extends TestCase {
 			->once()
 			->andReturn( '1' );
 
+		Monkey\Functions\expect( '\is_admin' )
+			->andReturn( true );
+
+		Monkey\Functions\expect( '\current_user_can' )
+			->with( 'edit_posts' )
+			->once()
+			->andReturnTrue();
+
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( \has_action( 'post_submitbox_start', [ $this->instance, 'add_new_draft_post_button' ] ), 'Does not have expected post_submitbox_start action' );


### PR DESCRIPTION
Added: condition to only hook into the filter if we are in wp-admin, and only if the user is likely to see this change at all.
Added: an early bail out for the filter function
Changed: swapped conditions to have the cheaper condition first

Update classic-editor.php

## Context
This code takes care of the feature request/improvement ticket #185 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* changelog: enhancement

## Relevant technical choices:

* nothing special

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check if the button labels are still "Republish"/"Republish on: %s" for editors in the backend.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* none that i'm aware of

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
