### PR TITLE
Composer: update to YoastCS 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,7 @@
         "composer/installers": "^1.9.0"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.2",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/yoastcs": "^2.1",
+        "yoast/yoastcs": "^2.2.0",
         "yoast/wp-test-utils": "^0.2.1"
     },
     "autoload": {


### PR DESCRIPTION
## Context

* Update dev tools

## Summary

This PR can be summarized in the following changelog entry:

* Update dev tools

## Relevant technical choices:

Composer: update to YoastCS 2.2.0

... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

Refs:
* https://github.com/Yoast/yoastcs/releases
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ if the build passes we're good.
