### PR TITLE
Travis: various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,13 +71,7 @@ jobs:
 
 before_install:
   - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
-  - |
-    if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
-      travis_retry composer install --ignore-platform-reqs
-    else
-      travis_retry composer install
-    fi
-
+  - travis_retry composer install
 
 before_script:
 - export -f travis_fold

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ jobs:
       env: SNIFF=1 PHPUNIT=1
     - php: '8.0'
       env: LINT=1 PHPUNIT=1
-    - php: "nightly"
-      env: LINT=1 PHPUNIT=1
     - stage: 🚀 deployment
       name: "Deploy to Yoast-dist"
       php: 7.2
@@ -70,9 +68,6 @@ jobs:
         on:
           repo: $TRAVIS_REPO_SLUG
           all_branches: true
-
-  allow_failures:
-    - php: "nightly"
 
 before_install:
   - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi


### PR DESCRIPTION
## Context

* Update CI

## Summary

This PR can be summarized in the following changelog entry:

* Update CI

## Relevant technical choices:


### Travis: remove nightly

At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
    * Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
    * The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
        I've tested to see if that image is available on Travis, but unfortunately, no luck there either.

### Travis: minor tweaks

The `composer.json` file does not fix the PHP version via a `config - platform - php` setting and there are currently no dependencies which would not allow installation on PHP 8.0, so this condition is redundant.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ if the build passes, we're good