### PR TITLE
Check_Changes_Handler_Test: fix bug

### DIFF
--- a/tests/handlers/check-changes-handler-test.php
+++ b/tests/handlers/check-changes-handler-test.php
@@ -88,6 +88,7 @@ class Check_Changes_Handler_Test extends TestCase {
 		$original->post_excerpt = 'Original excerpt';
 		$post_link              = 'https://yoa.st/wp-admin/post.php?id=123';
 		$original_link          = '<a href="https://yoa.st/wp-admin/post.php?id=100">Unchanged Title</a>';
+		$GLOBALS['wp_version']  = '5.6';
 
 		Monkey\Functions\expect( '\check_admin_referer' )
 			->with( 'duplicate_post_check_changes_123' );
@@ -145,7 +146,7 @@ class Check_Changes_Handler_Test extends TestCase {
 		$this->instance->check_changes_action_handler();
 
 		// Clean up after the test.
-		unset( $_GET['post'], $_REQUEST['action'] );
+		unset( $_GET['post'], $_REQUEST['action'], $GLOBALS['wp_version'] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Bug fix in test

## Summary

This PR can be summarized in the following changelog entry:

* Bug fix in test

## Relevant technical choices:

This bug was exposed by PHP 8.1.

The `Check_Changes_Handler::check_changes_action_handler()` expects a global `$wp_version` variable to be available, but this variable was not created for the test, leading to a "Deprecated: version_compare(): Passing null to parameter #1 ($version1) of type string is deprecated" deprecation notices in PHP 8.1.

Fixed by improving the test.

Note: the value now chosen, maintains the existing behaviour of this test as `null` would have been regarded as "less than 5.7".
See: https://3v4l.org/Upb1h

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
