### PR TITLE
PLAT 907 Duplicate Post: replace MailChimp integration with MailBlue

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -254,7 +254,7 @@ function duplicate_post_show_update_notice() {
 	$img_path = plugins_url( '/duplicate_post_yoast_icon-125x125.png', __FILE__ );
 
 	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '" style="display: flex; align-items: flex-start;">
-			<img src="' . esc_url( $img_path ) . '" alt="" style="margin: 1.5em 0.5em 0 0;"/>
+			<img src="' . esc_url( $img_path ) . '" alt="" style="margin: 1.5em 0.5em 1.5em 0;"/>
 			<div style="margin: 0.5em">' . $sanitized_message // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: escaped properly above.
 			. '</div></div>';
 

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -10,6 +10,8 @@ if ( ! is_admin() ) {
 	return;
 }
 
+use Yoast\WP\Duplicate_Post\UI\Newsletter;
+
 require_once DUPLICATE_POST_PATH . 'options.php';
 
 require_once DUPLICATE_POST_PATH . 'compat/wpml-functions.php';
@@ -247,7 +249,7 @@ function duplicate_post_show_update_notice() {
 	];
 
 	$sanitized_message = wp_kses( $message, $allowed_tags );
-	$sanitized_message = str_replace( '%%SIGNUP_FORM%%', duplicate_post_newsletter_signup_form(), $sanitized_message );
+	$sanitized_message = str_replace( '%%SIGNUP_FORM%%', Newsletter::newsletter_signup_form(), $sanitized_message );
 
 	$img_path = plugins_url( '/duplicate_post_yoast_icon-125x125.png', __FILE__ );
 
@@ -777,46 +779,4 @@ function duplicate_post_add_plugin_links( $links, $file ) {
 		$links[] = '<a href="https://yoast.com/wordpress/plugins/duplicate-post">' . esc_html__( 'Documentation', 'duplicate-post' ) . '</a>';
 	}
 	return $links;
-}
-
-/**
- * Renders the newsletter signup form.
- *
- * @return string The HTML of the newsletter signup form (escaped).
- */
-function duplicate_post_newsletter_signup_form() {
-	$copy = sprintf(
-		/* translators: 1: Yoast */
-		esc_html__(
-			'If you want to stay up to date about all the exciting developments around Duplicate Post, subscribe to the %1$s newsletter!',
-			'duplicate-post'
-		),
-		'Yoast'
-	);
-
-	$email_label = esc_html__( 'Email Address', 'duplicate-post' );
-
-	$html = '
-<!-- Begin Mailchimp Signup Form -->
-<div id="mc_embed_signup">
-<form action="https://yoast.us1.list-manage.com/subscribe/post?u=ffa93edfe21752c921f860358&amp;id=972f1c9122" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-	<div id="mc_embed_signup_scroll">
-	' . $copy . '
-<div class="mc-field-group" style="margin-top: 8px;">
-	<label for="mce-EMAIL">' . $email_label . '</label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-	<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="mc-embedded-subscribe" class="button">
-</div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-	<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
-	</div>
-</form>
-</div>
-<!--End mc_embed_signup-->
-';
-
-	return $html;
 }

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -253,8 +253,8 @@ function duplicate_post_show_update_notice() {
 
 	$img_path = plugins_url( '/duplicate_post_yoast_icon-125x125.png', __FILE__ );
 
-	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '" style="display: flex; align-items: center;">
-			<img src="' . esc_url( $img_path ) . '" alt=""/>
+	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '" style="display: flex; align-items: flex-start;">
+			<img src="' . esc_url( $img_path ) . '" alt="" style="margin: 1.5em 0.5em 0 0;"/>
 			<div style="margin: 0.5em">' . $sanitized_message // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: escaped properly above.
 			. '</div></div>';
 

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -9,6 +9,74 @@ class Newsletter {
 	}
 
 	/**
+	 * Renders the newsletter signup form.
+	 *
+	 * @return string The HTML of the newsletter signup form (escaped).
+	 */
+	public static function newsletter_signup_form() {
+
+		$newsletter_form_response = self::newsletter_handle_form();
+
+
+		$copy = sprintf(
+		/* translators: 1: Yoast */
+			esc_html__(
+				'If you want to stay up to date about all the exciting developments around Duplicate Post, subscribe to the %1$s newsletter!',
+				'duplicate-post'
+			),
+			'Yoast'
+		);
+
+		$email_label = esc_html__( 'Email Address', 'duplicate-post' );
+
+		$response_html = '';
+		if(is_array($newsletter_form_response)) {
+			$response_message = $newsletter_form_response['message'];
+
+			$response_html = '<div class="newsletter-response clear" id="newsletter-response" style="margin-top: 6px;">' . $response_message . '</div>';
+		}
+
+		$html = '
+		<!-- Begin Newsletter Signup Form -->
+		<div>
+		<form  method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" class="validate" novalidate>
+		<p>' . $copy . '</p>
+		<div class="newsletter-field-group" style="margin-top: 8px;">
+			<label for="newsletter-email" style="display: block; margin-bottom: 8px;"><strong>' . $email_label . '</strong></label>
+			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email">
+			<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
+		</div>
+		' . $response_html . '
+			<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
+		</form>
+		</div>
+		<!--End Newsletter Signup Form-->
+		';
+
+		return $html;
+	}
+
+	/**
+	 * Handles and validates Newsletter form.
+	 *
+	 * @return null|array
+	 */
+	private static function newsletter_handle_form() {
+		if (! isset($_POST['EMAIL']) || $_POST['EMAIL'] === '') {
+			return null;
+		}
+
+		if (! is_email($_POST['EMAIL'])) {
+			return [
+				'status'	=> 'error',
+				'message'	=> esc_html__('Please enter valid e-mail address.', 'duplicate-post'),
+			];
+		}
+
+		return self::newsletter_subscribe_to_mailblue('https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
+	}
+
+	/**
 	 * Handles subscription request.
 	 *
 	 * @param $url API endpoint.
@@ -41,77 +109,7 @@ class Newsletter {
 
 		return [
 			'status'	=> 'success',
-			'message'	=> esc_html__('You have successfully subscribed to the newsletter. Please check your inbox to confirm.', 'duplicate-post'),
+			'message'	=> esc_html__('You have successfully subscribed to the newsletter. Please check your inbox.', 'duplicate-post'),
 		];
-	}
-
-	/**
-	 * Renders the newsletter signup form.
-	 *
-	 * @return string The HTML of the newsletter signup form (escaped).
-	 */
-	public static function newsletter_signup_form() {
-
-		$newsletter_form_response = self::newsletter_handle_form();
-
-		$response_html = '';
-		if(is_array($newsletter_form_response)) {
-			$response_message = $newsletter_form_response['message'];
-
-			$response_html = '
-			<div id="newsletter-responses" class="clear">
-				<div class="newsletter-response" id="newsletter-response">' . $response_message . '</div>
-			</div>
-			';
-		}
-
-		$copy = sprintf(
-		/* translators: 1: Yoast */
-			esc_html__(
-				'If you want to stay up to date about all the exciting developments around Duplicate Post, subscribe to the %1$s newsletter!',
-				'duplicate-post'
-			),
-			'Yoast'
-		);
-
-		$email_label = esc_html__( 'Email Address', 'duplicate-post' );
-
-		$html = '
-		<!-- Begin Newsletter Signup Form -->
-		<div>
-		<form  method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" class="validate" novalidate>
-		<p>' . $copy . '</p>
-		<div class="newsletter-field-group" style="margin-top: 8px;">
-			<label for="newsletter-email" style="display: block; margin-bottom: 8px;"><strong>' . $email_label . '</strong></label>
-			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email">
-			<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
-		</div>
-		' . $response_html . '
-			<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
-		</form>
-		</div>
-		<!--End Newsletter Signup Form-->
-		';
-
-
-
-		return $html;
-	}
-
-	/**
-	 * Handles and validates Newsletter form.
-	 *
-	 * @returns null|array
-	 */
-	private static function newsletter_handle_form() {
-		if (! isset($_POST['EMAIL']) || $_POST['EMAIL'] === '') {
-			return null;
-		}
-
-		if (! is_email($_POST['EMAIL'])) {
-			return null;
-		}
-
-		return self::newsletter_subscribe_to_mailblue('https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
 	}
 }

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -68,19 +68,20 @@ class Newsletter {
 	 */
 	private static function newsletter_handle_form() {
 
-		if ( ! isset( $_POST['newsletter_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['newsletter_nonce'] ) ), 'newsletter' ) ) {
+		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Already sanitized.
+		if ( isset( $_POST['newsletter_nonce'] ) && ! wp_verify_nonce( wp_unslash( $_POST['newsletter_nonce'] ), 'newsletter' ) ) {
 			return [
 				'status'    => 'error',
-				'message'   => esc_html__( 'Something went wrong. Please try again later.', 'duplicate-post' ),
+				'message'   => esc_html__( 'Something went wrong. Please try again later. test', 'duplicate-post' ),
 			];
 		}
 
-		$email = '';
+		$email = null;
 		if ( isset( $_POST['EMAIL'] ) ) {
 			$email = sanitize_email( wp_unslash( $_POST['EMAIL'] ) );
 		}
 
-		if ( $email === '' ) {
+		if ( $email === null ) {
 			return null;
 		}
 
@@ -120,7 +121,7 @@ class Newsletter {
 		if ( $wp_remote_retrieve_response_code < 201 || $wp_remote_retrieve_response_code >= 300 ) {
 			return [
 				'status'    => 'error',
-				'message'   => esc_html__( 'Something went wrong. Please try again later.', 'duplicate-post' ),
+				'message'   => esc_html__( 'Something went wrong. Please try again later. test', 'duplicate-post' ),
 			];
 		}
 

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -9,14 +9,14 @@ class Newsletter {
 	}
 
 	/**
-	 * Handles subscription request
+	 * Handles subscription request.
 	 *
 	 * @param $url API endpoint.
 	 * @param $email Subscriber email.
 	 *
-	 * @return void.
+	 * @return array Feedback response.
 	 */
-	public static function newsletter_subscribe_to_mailblue($url, $email) {
+	private static function newsletter_subscribe_to_mailblue($url, $email) {
 		$response = wp_remote_post(
 			$url,
 			[
@@ -30,7 +30,19 @@ class Newsletter {
 			]
 		);
 
-		print_r(wp_remote_retrieve_body($response));
+		$wp_remote_retrieve_response_code = wp_remote_retrieve_response_code($response);
+
+		if($wp_remote_retrieve_response_code < 201 || $wp_remote_retrieve_response_code >= 300) {
+			return [
+				'status'	=> 'error',
+				'message'	=> esc_html__('Something went wrong. Please try again later.', 'duplicate-post'),
+			];
+		}
+
+		return [
+			'status'	=> 'success',
+			'message'	=> esc_html__('You have successfully subscribed to the newsletter. Please check your inbox to confirm.', 'duplicate-post'),
+		];
 	}
 
 	/**
@@ -40,8 +52,18 @@ class Newsletter {
 	 */
 	public static function newsletter_signup_form() {
 
-		self::newsletter_handle_form();
+		$newsletter_form_response = self::newsletter_handle_form();
 
+		$response_html = '';
+		if(is_array($newsletter_form_response)) {
+			$response_message = $newsletter_form_response['message'];
+
+			$response_html = '
+			<div id="newsletter-responses" class="clear">
+				<div class="newsletter-response" id="newsletter-response">' . $response_message . '</div>
+			</div>
+			';
+		}
 
 		$copy = sprintf(
 		/* translators: 1: Yoast */
@@ -54,42 +76,42 @@ class Newsletter {
 
 		$email_label = esc_html__( 'Email Address', 'duplicate-post' );
 
-		//3. form output
 		$html = '
 		<!-- Begin Newsletter Signup Form -->
 		<div>
 		<form  method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" class="validate" novalidate>
-			<p>' . $copy . '</p>
+		<p>' . $copy . '</p>
 		<div class="newsletter-field-group" style="margin-top: 8px;">
-			<label for="newsletter-EMAIL" style="display: block; margin-bottom: 8px;"><strong>' . $email_label . '</strong></label>
-			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-EMAIL">
+			<label for="newsletter-email" style="display: block; margin-bottom: 8px;"><strong>' . $email_label . '</strong></label>
+			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email">
 			<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
 		</div>
-			<div id="newsletter-responses" class="clear">
-				<div class="newsletter-response" id="newsletter-error-response" style="display: none;"></div>
-				<div class="newsletter-response" id="newsletter-success-response" style="display: none;"></div>
-			</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+		' . $response_html . '
 			<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
 		</form>
 		</div>
 		<!--End Newsletter Signup Form-->
 		';
 
+
+
 		return $html;
 	}
 
 	/**
 	 * Handles and validates Newsletter form.
+	 *
+	 * @returns null|array
 	 */
 	private static function newsletter_handle_form() {
 		if (! isset($_POST['EMAIL']) || $_POST['EMAIL'] === '') {
-			return;
+			return null;
 		}
 
 		if (! is_email($_POST['EMAIL'])) {
-			return;
+			return null;
 		}
 
-		self::newsletter_subscribe_to_mailblue('https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
+		return self::newsletter_subscribe_to_mailblue('https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
 	}
 }

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -16,7 +16,7 @@ class Newsletter {
 	 *
 	 * @return void.
 	 */
-	public function newsletter_subscribe_to_mailblue($url, $email) {
+	public static function newsletter_subscribe_to_mailblue($url, $email) {
 		$response = wp_remote_post(
 			$url,
 			[
@@ -39,6 +39,10 @@ class Newsletter {
 	 * @return string The HTML of the newsletter signup form (escaped).
 	 */
 	public static function newsletter_signup_form() {
+
+		self::newsletter_handle_form();
+
+
 		$copy = sprintf(
 		/* translators: 1: Yoast */
 			esc_html__(
@@ -50,34 +54,42 @@ class Newsletter {
 
 		$email_label = esc_html__( 'Email Address', 'duplicate-post' );
 
-		//https://staging-platform-my.yoast.com/api/Mailing-list/subscribe
-
+		//3. form output
 		$html = '
-<!-- Begin Mailchimp Signup Form -->
-<div id="mc_embed_signup">
-<form method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-	<div id="mc_embed_signup_scroll">
-	' . $copy . '
-<div class="mc-field-group" style="margin-top: 8px;">
-	<label for="mce-EMAIL">' . $email_label . '</label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-	<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="mc-embedded-subscribe" class="button">
-</div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-	<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
-	</div>
-</form>
-</div>
-<!--End mc_embed_signup-->
-';
-
-		if(isset($_POST['EMAIL']) && $_POST['EMAIL'] !== '') {
-			call_user_func(__NAMESPACE__ . 'Newsletter::newsletter_subscribe_to_mailblue','https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
-		}
+		<!-- Begin Newsletter Signup Form -->
+		<div>
+		<form  method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" class="validate" novalidate>
+			<p>' . $copy . '</p>
+		<div class="newsletter-field-group" style="margin-top: 8px;">
+			<label for="newsletter-EMAIL" style="display: block; margin-bottom: 8px;"><strong>' . $email_label . '</strong></label>
+			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-EMAIL">
+			<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
+		</div>
+			<div id="newsletter-responses" class="clear">
+				<div class="newsletter-response" id="newsletter-error-response" style="display: none;"></div>
+				<div class="newsletter-response" id="newsletter-success-response" style="display: none;"></div>
+			</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+			<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
+		</form>
+		</div>
+		<!--End Newsletter Signup Form-->
+		';
 
 		return $html;
+	}
+
+	/**
+	 * Handles and validates Newsletter form.
+	 */
+	private static function newsletter_handle_form() {
+		if (! isset($_POST['EMAIL']) || $_POST['EMAIL'] === '') {
+			return;
+		}
+
+		if (! is_email($_POST['EMAIL'])) {
+			return;
+		}
+
+		self::newsletter_subscribe_to_mailblue('https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
 	}
 }

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -8,13 +8,6 @@ namespace Yoast\WP\Duplicate_Post\UI;
 class Newsletter {
 
 	/**
-	 * Register hooks.
-	 */
-	public function register_hooks() {
-		add_action( 'admin_init', [ $this, 'newsletter_signup_form' ] );
-	}
-
-	/**
 	 * Renders the newsletter signup form.
 	 *
 	 * @return string The HTML of the newsletter signup form (escaped).
@@ -72,7 +65,7 @@ class Newsletter {
 		if ( isset( $_POST['newsletter_nonce'] ) && ! wp_verify_nonce( wp_unslash( $_POST['newsletter_nonce'] ), 'newsletter' ) ) {
 			return [
 				'status'    => 'error',
-				'message'   => esc_html__( 'Something went wrong. Please try again later. test', 'duplicate-post' ),
+				'message'   => esc_html__( 'Something went wrong. Please try again later.', 'duplicate-post' ),
 			];
 		}
 
@@ -110,6 +103,7 @@ class Newsletter {
 				'body'        => [
 					'customerDetails' => [
 						'email' => $email,
+						'firstName' => '',
 					],
 					'list'            => 'Yoast newsletter',
 				],
@@ -121,7 +115,7 @@ class Newsletter {
 		if ( $wp_remote_retrieve_response_code < 201 || $wp_remote_retrieve_response_code >= 300 ) {
 			return [
 				'status'    => 'error',
-				'message'   => esc_html__( 'Something went wrong. Please try again later. test', 'duplicate-post' ),
+				'message'   => esc_html__( 'Something went wrong. Please try again later.', 'duplicate-post' ),
 			];
 		}
 

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -102,7 +102,7 @@ class Newsletter {
 				'method'      => 'POST',
 				'body'        => [
 					'customerDetails' => [
-						'email' => $email,
+						'email'     => $email,
 						'firstName' => '',
 					],
 					'list'            => 'Yoast newsletter',

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -112,7 +112,7 @@ class Newsletter {
 
 		$wp_remote_retrieve_response_code = wp_remote_retrieve_response_code( $response );
 
-		if ( $wp_remote_retrieve_response_code < 201 || $wp_remote_retrieve_response_code >= 300 ) {
+		if ( $wp_remote_retrieve_response_code <= 200 || $wp_remote_retrieve_response_code >= 300 ) {
 			return [
 				'status'    => 'error',
 				'message'   => esc_html__( 'Something went wrong. Please try again later.', 'duplicate-post' ),

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Yoast\WP\Duplicate_Post\UI;
+
+class Newsletter {
+	public function register_hooks()
+	{
+		add_action('admin_init', [$this, 'newsletter_signup_form']);
+	}
+
+	/**
+	 * Handles subscription request
+	 *
+	 * @param $url API endpoint.
+	 * @param $email Subscriber email.
+	 *
+	 * @return void.
+	 */
+	public function newsletter_subscribe_to_mailblue($url, $email) {
+		$response = wp_remote_post(
+			$url,
+			[
+				'method'      => 'POST',
+				'body'        => [
+					'customerDetails' => [
+						'email' => $email,
+					],
+					'list'			 => 'Newsletter staging test'
+				],
+			]
+		);
+
+		print_r(wp_remote_retrieve_body($response));
+	}
+
+	/**
+	 * Renders the newsletter signup form.
+	 *
+	 * @return string The HTML of the newsletter signup form (escaped).
+	 */
+	public static function newsletter_signup_form() {
+		$copy = sprintf(
+		/* translators: 1: Yoast */
+			esc_html__(
+				'If you want to stay up to date about all the exciting developments around Duplicate Post, subscribe to the %1$s newsletter!',
+				'duplicate-post'
+			),
+			'Yoast'
+		);
+
+		$email_label = esc_html__( 'Email Address', 'duplicate-post' );
+
+		//https://staging-platform-my.yoast.com/api/Mailing-list/subscribe
+
+		$html = '
+<!-- Begin Mailchimp Signup Form -->
+<div id="mc_embed_signup">
+<form method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+	<div id="mc_embed_signup_scroll">
+	' . $copy . '
+<div class="mc-field-group" style="margin-top: 8px;">
+	<label for="mce-EMAIL">' . $email_label . '</label>
+	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+	<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="mc-embedded-subscribe" class="button">
+</div>
+	<div id="mce-responses" class="clear">
+		<div class="response" id="mce-error-response" style="display:none"></div>
+		<div class="response" id="mce-success-response" style="display:none"></div>
+	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+	<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
+	</div>
+</form>
+</div>
+<!--End mc_embed_signup-->
+';
+
+		if(isset($_POST['EMAIL']) && $_POST['EMAIL'] !== '') {
+			call_user_func(__NAMESPACE__ . 'Newsletter::newsletter_subscribe_to_mailblue','https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
+		}
+
+		return $html;
+	}
+}

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -31,25 +31,23 @@ class Newsletter {
 
 		$response_html = '';
 		if(is_array($newsletter_form_response)) {
+			$response_status = $newsletter_form_response['status'];
 			$response_message = $newsletter_form_response['message'];
 
-			$response_html = '<div class="newsletter-response clear" id="newsletter-response" style="margin-top: 6px;">' . $response_message . '</div>';
+			$response_html = '<div class="newsletter-response-' . $response_status . ' clear" id="newsletter-response" style="margin-top: 6px;">' . $response_message . '</div>';
 		}
 
 		$html = '
 		<!-- Begin Newsletter Signup Form -->
-		<div>
-		<form  method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" class="validate" novalidate>
+		<form method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" novalidate>
 		<p>' . $copy . '</p>
-		<div class="newsletter-field-group" style="margin-top: 8px;">
-			<label for="newsletter-email" style="display: block; margin-bottom: 8px;"><strong>' . $email_label . '</strong></label>
-			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email">
+		<div class="newsletter-field-group" style="display: flex; align-items: center;">
+			<label for="newsletter-email" style="margin-right: 4px;"><strong>' . $email_label . '</strong></label>
+			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email" style="margin-right: 4px;">
 			<input type="submit" value="' . esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
 		</div>
 		' . $response_html . '
-			<div class="screen-reader-text" aria-hidden="true"><input type="text" name="b_ffa93edfe21752c921f860358_972f1c9122" tabindex="-1" value=""></div>
 		</form>
-		</div>
 		<!--End Newsletter Signup Form-->
 		';
 
@@ -73,27 +71,26 @@ class Newsletter {
 			];
 		}
 
-		return self::newsletter_subscribe_to_mailblue('https://staging-platform-my.yoast.com/api/Mailing-list/subscribe', $_POST['EMAIL']);
+		return self::newsletter_subscribe_to_mailblue($_POST['EMAIL']);
 	}
 
 	/**
-	 * Handles subscription request.
+	 * Handles subscription request and provides feedback response.
 	 *
-	 * @param $url API endpoint.
 	 * @param $email Subscriber email.
 	 *
 	 * @return array Feedback response.
 	 */
-	private static function newsletter_subscribe_to_mailblue($url, $email) {
+	private static function newsletter_subscribe_to_mailblue($email) {
 		$response = wp_remote_post(
-			$url,
+			'https://my.yoast.com/api/Mailing-list/subscribe',
 			[
 				'method'      => 'POST',
 				'body'        => [
 					'customerDetails' => [
 						'email' => $email,
 					],
-					'list'			 => 'Newsletter staging test'
+					'list'			 => 'Yoast newsletter',
 				],
 			]
 		);

--- a/src/ui/user-interface.php
+++ b/src/ui/user-interface.php
@@ -119,7 +119,6 @@ class User_Interface {
 		$this->bulk_actions->register_hooks();
 		$this->column->register_hooks();
 		$this->metabox->register_hooks();
-		$this->newsletter->register_hooks();
 		$this->post_states->register_hooks();
 		$this->classic_editor->register_hooks();
 		$this->row_actions->register_hooks();

--- a/src/ui/user-interface.php
+++ b/src/ui/user-interface.php
@@ -109,7 +109,7 @@ class User_Interface {
 		$this->bulk_actions   = new Bulk_Actions( $this->permissions_helper );
 		$this->column         = new Column( $this->permissions_helper, $this->asset_manager );
 		$this->metabox        = new Metabox( $this->permissions_helper );
-		$this->newsletter	  = new Newsletter();
+		$this->newsletter     = new Newsletter();
 		$this->post_states    = new Post_States( $this->permissions_helper );
 		$this->classic_editor = new Classic_Editor( $this->link_builder, $this->permissions_helper, $this->asset_manager );
 		$this->row_actions    = new Row_Actions( $this->link_builder, $this->permissions_helper );

--- a/src/ui/user-interface.php
+++ b/src/ui/user-interface.php
@@ -66,6 +66,13 @@ class User_Interface {
 	protected $metabox;
 
 	/**
+	 * Newsletter object.
+	 *
+	 * @var Newsletter
+	 */
+	protected $newsletter;
+
+	/**
 	 * Column object.
 	 *
 	 * @var Column
@@ -102,6 +109,7 @@ class User_Interface {
 		$this->bulk_actions   = new Bulk_Actions( $this->permissions_helper );
 		$this->column         = new Column( $this->permissions_helper, $this->asset_manager );
 		$this->metabox        = new Metabox( $this->permissions_helper );
+		$this->newsletter	  = new Newsletter();
 		$this->post_states    = new Post_States( $this->permissions_helper );
 		$this->classic_editor = new Classic_Editor( $this->link_builder, $this->permissions_helper, $this->asset_manager );
 		$this->row_actions    = new Row_Actions( $this->link_builder, $this->permissions_helper );
@@ -111,6 +119,7 @@ class User_Interface {
 		$this->bulk_actions->register_hooks();
 		$this->column->register_hooks();
 		$this->metabox->register_hooks();
+		$this->newsletter->register_hooks();
 		$this->post_states->register_hooks();
 		$this->classic_editor->register_hooks();
 		$this->row_actions->register_hooks();


### PR DESCRIPTION
## Context
Replaced MailChimp form with MailBlue form and integration.
Added `ui/newsletter.php` class which handles all of the `mailblue` newsletter integration and logic. Implemented some styling refinement.

## Summary

This PR can be summarized in the following changelog entry:

* Replaces Mailchimp with MailBlue newsletter integration.

## Relevant technical choices:
1. Newsletter subscription request is going to live API Url. Reason: Inability to automatically check for environment. Behavior of form stays the same.
2. User is subscribed to [Yoast newsletter](https://mbyoastbv.activehosted.com/app/contacts?limit=100&listid=6&status=1) list.

## Test instructions
1. Enable `Duplicate post` plugin notice [here](http://basic.wordpress.test/wp-admin/options-general.php?page=duplicatepost), if not enabled.
1. Go to [plugins](http://basic.wordpress.test/wp-admin/plugins.php) dashboard page or [home](http://basic.wordpress.test/wp-admin/index.php) dashboard page.
1. Enter valid email and submit. Expected result: User is subscribed and form is validated with success message.
1. Enter invalid email and submit. Expected result: User is not subscribed and form is validated with error message.
1. Do not enter anything and submit. Expected result: User is not subscribed and form is validated with error message.

NOTE: Please remember to remove subscribed email from [Yoast newsletter](https://mbyoastbv.activehosted.com/app/contacts?limit=100&listid=6&status=1) list.

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes PLAT-907
