### PR TITLE
DUPP-32 Set `dp-rewrite-republish` as `'public' => false`

### DIFF
--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -81,7 +81,6 @@ class Post_Republisher {
 	public function register_post_statuses() {
 		$options = [
 			'label'                     => \__( 'Republish', 'duplicate-post' ),
-			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => false,
 			'show_in_admin_status_list' => false,

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -17,7 +17,7 @@ class Post_Republisher_Test extends TestCase {
 	/**
 	 * The instance.
 	 *
-	 * @var Post_Republisher
+	 * @var Post_Republisher|\Mockery\Mock
 	 */
 	protected $instance;
 
@@ -31,7 +31,7 @@ class Post_Republisher_Test extends TestCase {
 	/**
 	 * Holds the permissions helper.
 	 *
-	 * @var Permissions_Helper
+	 * @var Permissions_Helper|\Mockery\Mock
 	 */
 	protected $permissions_helper;
 
@@ -157,7 +157,6 @@ class Post_Republisher_Test extends TestCase {
 
 		$options = [
 			'label'                     => 'Republish',
-			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => false,
 			'show_in_admin_status_list' => false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid that posts with `dp-rewrite-republish` status are being displayed or even queried for in the front-end. Closes #211 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where Rewrite & Republish copies could be displayed and queried in the front end.

## Relevant technical choices:

* Also fixing some CS warnings in related test.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* visit the frontend with Debug Bar and/or Query Monitor installed and configured
* check that the main query does not have `OR $prefix.post_status = 'dp-rewrite-republish'` in the `WHERE`
* check that the R&R feature still works:
  * create a R&R copy from a published post, change something and republish it (check the logs that everything goes right)
  * create a R&R copy from a published post, change something, schedule its republishing 2 minutes in the future, wait to see everything goes right.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-32]


[DUPP-32]: https://yoast.atlassian.net/browse/DUPP-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ