### PR TITLE
DUPP-33 Fix scheduled republish bug

### DIFF
--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -326,7 +326,7 @@ class Post_Republisher {
 		$_POST['ID'] = $original_post->ID;
 
 		// Republish the original post.
-		$rewritten_post_id = \wp_update_post( \wp_slash( $post_to_be_rewritten ) );
+		$rewritten_post_id = \wp_update_post( $post_to_be_rewritten );
 
 		if ( $rewritten_post_id === 0 ) {
 			\wp_die( \esc_html__( 'An error occurred while republishing the post.', 'duplicate-post' ) );

--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -199,7 +199,9 @@ class Post_Republisher {
 			return;
 		}
 
+		\kses_remove_filters();
 		$this->republish( $copy, $original_post );
+		\kses_init_filters();
 		$this->delete_copy( $copy->ID, $original_post->ID );
 	}
 

--- a/tests/post-republisher-test.php
+++ b/tests/post-republisher-test.php
@@ -255,6 +255,9 @@ class Post_Republisher_Test extends TestCase {
 			->once()
 			->andReturn( $original );
 
+		Monkey\Functions\expect( 'kses_remove_filters' );
+		Monkey\Functions\expect( 'kses_init_filters' );
+
 		$this->instance->expects( 'republish' )->with( $copy, $original )->once();
 		$this->instance->expects( 'delete_copy' )->with( $copy->ID, $original->ID )->once();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug where HTML tags in a Custom HTML block are stripped away whem a R&R copy is republished.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where HTML tags in a Custom HTML block would be removed when republishing a scheduled Rewrite & Republish copy.

## Relevant technical choices:

* Also removes an unnecessary `wp_slash` call around a `WP_Post` object (`wp_update_post()` will take care of that)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post in the block editor
* add a `Custom HTML` block and insert some code with tags like `script` and `style`, e.g.:
```
<style>
.whatever {
   font-size: 35px;
}
</style>
<script>
alert(1);
</script>
```
* Publish the post 
  * visit it in the front end and check that you can see the tags in the source (if you use the example above you'll also get an alert)
* create a R&R copy from that post
  * change the title and something from the content, but don't change the `Custom HTML` block!
* schedule republish to 2 minutes in the future
* wait :hourglass_flowing_sand: 
* when the copy has been republished, check the original post
   * see that the changes have been applied
   * check that the tags have not been removed



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-33]


[DUPP-33]: https://yoast.atlassian.net/browse/DUPP-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ