### PR TITLE
DUPP-176 Prevent rendering of the script when the store is not available

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -126,6 +126,11 @@ class DuplicatePost {
 	 * @returns {JSX.Element} The rendered links.
 	 */
 	render() {
+		// Don't try to render anything if there is no store.
+		if ( !  select( 'core/editor' ) ) {
+			return null;
+		}
+
 		const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
 
 		return (

--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -127,7 +127,7 @@ class DuplicatePost {
 	 */
 	render() {
 		// Don't try to render anything if there is no store.
-		if ( !  select( 'core/editor' ) ) {
+		if ( ! select( 'core/editor' ) || ! ( wp.editPost && wp.editPost.PluginPostStatusInfo ) ) {
 			return null;
 		}
 

--- a/src/ui/block-editor.php
+++ b/src/ui/block-editor.php
@@ -119,6 +119,10 @@ class Block_Editor {
 	 * @return void
 	 */
 	public function enqueue_block_editor_scripts() {
+		if ( ! $this->permissions_helper->is_edit_post_screen() && ! $this->permissions_helper->is_new_post_screen() ) {
+			return;
+		}
+
 		$post = \get_post();
 
 		if ( ! $post instanceof WP_Post ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent a fatal error in the plugin's script for the Block Editor when it's executed where it's not supposed to.

A plugin or a theme may (wrongfully) set the global var `$post` in the Widgets screen. This, paired with the fact that the Widgets screen executes the `enqueue_block_editor_assets` even if there is no post to be edited, trigger the execution of out `duplicate-post-edit.js` script, which fails because there is no `core/editor` store or `PluginPostStatusInfo` component available.
With the FSE transition undergoing, this might happen even more frequently.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be triggered in the Widgets page.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the error
* build from `master` (or use any 4.* version)
* add this custom code to the end of your theme's `functions.php`:
```
function my_set_post() {
    global $post;
    $posts = get_posts();
    $post = $posts[0];
}
add_action( 'init', 'my_set_post' );
```
* visit `Appearance` > `Widgets`
* see that the page fails with a fatal error that can't be recovered

#### Test the fix
* Switch to this branch and build
* visit `Appearance` > `Widgets`
* see that the page doesn't fail anymore
* activate Yoast SEO (it's been found that it can enable certain conditions that we check)
* visit `Appearance` > `Widgets`
* see that the page doesn't fail anymore
* edit a published post with the Block editor and check that `Copy to a new draft` and `Rewrite & Republish` are visible in the `Status and visibility` section of the sidebar.
* create a new post with the Block editor and check that `Copy to a new draft` is visible in the `Status and visibility` section of the sidebar.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [DUPP-176]


[DUPP-176]: https://yoast.atlassian.net/browse/DUPP-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ