### PR TITLE
Dupp 177 welcome notice

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -163,7 +163,6 @@ function duplicate_post_plugin_upgrade() {
 	}
 	update_option( 'duplicate_post_blacklist', implode( ',', $meta_blacklist ) );
 
-
 	if ( version_compare( $installed_version, '4.0.0' ) < 0 ) {
 		// Migrate the 'Show links in' options to the new array-based structure.
 		duplicate_post_migrate_show_links_in_options( $show_links_in_defaults );
@@ -216,43 +215,21 @@ function duplicate_post_show_update_notice() {
 		return;
 	}
 
-	$class   = 'notice is-dismissible';
-	$message = '<p><strong>' . sprintf(
-		/* translators: %s: Yoast Duplicate Post version. */
-		__( "What's new in Yoast Duplicate Post version %s:", 'duplicate-post' ),
-		DUPLICATE_POST_CURRENT_VERSION
-	) . '</strong> ';
-	$message .= __( 'improved compatibility with PHP 8.0 and fixes for some bugs regarding translations and the Rewrite & Republish feature.', 'duplicate-post' )
-		. ' ';
-
-	$message .= '<a href="https://wordpress.org/plugins/duplicate-post/#developers">'
-				. sprintf(
-					/* translators: %s: Yoast Duplicate Post version. */
-					__( 'Read the changelog', 'duplicate-post' ),
-					DUPLICATE_POST_CURRENT_VERSION
-				)
-				. '</a></p>';
-
-	$message .= '<p>%%SIGNUP_FORM%%</p>';
-
-	$allowed_tags = [
-		'a'      => [
-			'href'  => [],
-		],
-		'br'     => [],
-		'p'      => [],
-		'strong' => [],
-	];
-
-	$sanitized_message = wp_kses( $message, $allowed_tags );
-	$sanitized_message = str_replace( '%%SIGNUP_FORM%%', Newsletter::newsletter_signup_form(), $sanitized_message );
+	$title = sprintf(
+		/* translators: %s: Yoast Duplicate Post. */
+		esc_html__( 'You\'ve successfully installed %s!', 'duplicate-post' ),
+		'Yoast Duplicate Post'
+	);
 
 	$img_path = plugins_url( '/duplicate_post_yoast_icon-125x125.png', __FILE__ );
 
-	echo '<div id="duplicate-post-notice" class="' . esc_attr( $class ) . '" style="display: flex; align-items: flex-start;">
-			<img src="' . esc_url( $img_path ) . '" alt="" style="margin: 1.5em 0.5em 1.5em 0;"/>
-			<div style="margin: 0.5em">' . $sanitized_message // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: escaped properly above.
-			. '</div></div>';
+	echo '<div id="duplicate-post-notice" class="notice is-dismissible" style="display: flex; align-items: flex-start;">
+			<img src="' . esc_url( $img_path ) . '" alt="" style="margin: 1em 1em 1em 0; width: 130px; align-self: center;"/>
+			<div stle="margin: 0.5em">
+				<h1 style="font-size: 14px; color: #a4286a; font-weight: 600; margin-top: 8px;">' . $title . '</h1>' // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: escaped properly above.
+				. Newsletter::newsletter_signup_form() // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: escaped in newsletter.php.
+			. '</div>
+		</div>';
 
 	echo "<script>
 			function duplicate_post_dismiss_notice(){

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -163,10 +163,6 @@ function duplicate_post_plugin_upgrade() {
 	}
 	update_option( 'duplicate_post_blacklist', implode( ',', $meta_blacklist ) );
 
-	delete_option( 'duplicate_post_show_notice' );
-	if ( version_compare( $installed_version, '4.2.0' ) < 0 ) {
-		update_site_option( 'duplicate_post_show_notice', 1 );
-	}
 
 	if ( version_compare( $installed_version, '4.0.0' ) < 0 ) {
 		// Migrate the 'Show links in' options to the new array-based structure.

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -137,6 +137,7 @@ function duplicate_post_plugin_upgrade() {
 		]
 	);
 	add_option( 'duplicate_post_show_link_in', $show_links_in_defaults );
+	add_option( 'duplicate_post_show_notice', 1 );
 
 	$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
 	if ( $taxonomies_blacklist === '' ) {

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -26,7 +26,17 @@ class Newsletter {
 			'Yoast'
 		);
 
-		$email_label = \esc_html__( 'Email Address', 'duplicate-post' );
+		$email_label = \esc_html__( 'Email address', 'duplicate-post' );
+
+		$copy_privacy_policy = sprintf(
+		// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
+			\esc_html__(
+				'Yoast respects your privacy. Read %1$sour privacy policy%2$s on how we handle your personal information.',
+				'duplicate-post'
+			),
+			'<a href=https://yoa.st/4jf">',
+			'</a>'
+		);
 
 		$response_html = '';
 		if ( \is_array( $newsletter_form_response ) ) {
@@ -41,10 +51,13 @@ class Newsletter {
 		<form method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" novalidate>
 		' . \wp_nonce_field( 'newsletter', 'newsletter_nonce' ) . '
 		<p>' . $copy . '</p>
-		<div class="newsletter-field-group" style="display: flex; align-items: center;">
-			<label for="newsletter-email" style="margin-right: 4px;"><strong>' . $email_label . '</strong></label>
-			<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email" style="margin-right: 4px;">
-			<input type="submit" value="' . \esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
+		<div class="newsletter-field-group" style="display: flex; flex-direction: column">
+			<label for="newsletter-email" style="margin: 0 0 4px 0;"><strong>' . $email_label . '</strong></label>
+			<div>
+				<input type="email" value="" name="EMAIL" class="required email" id="newsletter-email" style="margin-right: 4px;">
+				<input type="submit" value="' . \esc_attr__( 'Subscribe', 'duplicate-post' ) . '" name="subscribe" id="newsletter-subscribe" class="button">
+			</div>
+			<p style="font-size: 10px;">' . $copy_privacy_policy . '</p>
 		</div>
 		' . $response_html . '
 		</form>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

We want the upgrade notice in Duplicate Post to become a "welcome" notice for first time users.

Implementation approved by UX (Corey), see [slack](https://yoast.slack.com/archives/C02GZJ2UFJ6/p1639994567313800?thread_ts=1639738929.266600&cid=C02GZJ2UFJ6). 
<img width="900" alt="Screenshot 2021-12-20 at 11 01 48" src="https://user-images.githubusercontent.com/43582255/146751414-879d60d6-a517-4d07-b475-8c63cffd5f4e.png">

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Converts the upgrade notice into a welcome notice for first-time users.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use a fresh install of the Yoast Duplicate Post plugin, or delete the `duplicate_post_show_notice` option in the `_options` table 
* Activate Yoast Duplicate Post.
* You should see a notice that matches the screenshot (see summary above).
* Dismiss the notice.
* Make sure it does not reappear when refreshing the page.
* Deactivate and activate Yoast Duplicate Post, the notice should NOT reappear. 
* Upgrade the plugin: either change the `duplicate_post_version` option in `_options` to a previous version, or checkout a `4.1.*` tag from `master`.
* Refresh the plugins page,  the notice should NOT reappear. 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use a fresh install of the Yoast Duplicate Post plugin, or delete the `duplicate_post_show_notice` option in the `_options` table.
* Activate Yoast Duplicate Post.
* You should see a notice that matches the screenshot (see summary above).
* Dismiss the notice.
* Make sure it does not reappear when refreshing the page.
* Deactivate and activate Yoast Duplicate Post, the notice should NOT reappear. 

_Upgrade_
* Install an old version on a clean environment and make sure you get the (old) `What's new` notice.
* Dismiss the notice.
* Upgrade to the latest version.
* The `You've successfully installed` notice should NOT appear. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-177]


[DUPP-177]: https://yoast.atlassian.net/browse/DUPP-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ