### PR TITLE
Enqueue styles on Classic editor if links are visible

### DIFF
--- a/src/ui/classic-editor.php
+++ b/src/ui/classic-editor.php
@@ -68,7 +68,12 @@ class Classic_Editor {
 		\add_filter( 'post_updated_messages', [ $this, 'change_scheduled_notice_classic_editor' ], 10, 1 );
 
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_scripts' ] );
-		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_styles' ] );
+		if ( \intval( Utils::get_option( 'duplicate_post_show_link_in', 'submitbox' ) ) === 1 ) {
+			if ( \intval( Utils::get_option( 'duplicate_post_show_link', 'new_draft' ) ) === 1
+				|| \intval( Utils::get_option( 'duplicate_post_show_link', 'rewrite_republish' ) ) === 1 ) {
+				\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_styles' ] );
+			}
+		}
 
 		// Remove slug editing from Classic Editor.
 		\add_action( 'add_meta_boxes', [ $this, 'remove_slug_meta_box' ], 10, 2 );
@@ -102,7 +107,7 @@ class Classic_Editor {
 			$id   = \intval( \wp_unslash( $_GET['post'] ) );
 			$post = \get_post( $id );
 
-			if ( ! \is_null( $post ) && $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			if ( ! \is_null( $post ) && $this->permissions_helper->should_links_be_displayed( $post ) ) {
 				$this->asset_manager->enqueue_styles();
 			}
 		}

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -19,28 +19,28 @@ class Classic_Editor_Test extends TestCase {
 	/**
 	 * Holds the object to create the action link to duplicate.
 	 *
-	 * @var Link_Builder
+	 * @var Link_Builder|\Mockery\MockInterface
 	 */
 	protected $link_builder;
 
 	/**
 	 * Holds the permissions helper.
 	 *
-	 * @var Permissions_Helper
+	 * @var Permissions_Helper|\Mockery\MockInterface
 	 */
 	protected $permissions_helper;
 
 	/**
 	 * Holds the asset manager.
 	 *
-	 * @var Asset_Manager
+	 * @var Asset_Manager|\Mockery\MockInterface
 	 */
 	protected $asset_manager;
 
 	/**
 	 * The instance.
 	 *
-	 * @var Classic_Editor
+	 * @var Classic_Editor&\Mockery\MockInterface
 	 */
 	protected $instance;
 
@@ -93,12 +93,12 @@ class Classic_Editor_Test extends TestCase {
 
 		$utils->expects( 'get_option' )
 			->with( 'duplicate_post_show_link_in', 'submitbox' )
-			->once()
+			->twice()
 			->andReturn( '1' );
 
 		$utils->expects( 'get_option' )
 			->with( 'duplicate_post_show_link', 'new_draft' )
-			->once()
+			->twice()
 			->andReturn( '1' );
 
 		$utils->expects( 'get_option' )
@@ -154,7 +154,7 @@ class Classic_Editor_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the successful enqueue_classic_editor_scripts function.
+	 * Tests the successful enqueue_classic_editor_styles function.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::enqueue_classic_editor_styles
 	 */
@@ -169,7 +169,7 @@ class Classic_Editor_Test extends TestCase {
 			->with( 123 )
 			->andReturn( $post );
 
-		$this->permissions_helper->expects( 'is_rewrite_and_republish_copy' )
+		$this->permissions_helper->expects( 'should_links_be_displayed' )
 			->with( $post )
 			->andReturnTrue();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that the stylesheet is correctly enqueued in the Classic editor even when the Admin bar is disabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the button style would be broken  in the Classic Editor

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate WooCommerce
* visit the Duplicate Post settings:
  * in the second tab, enable the plugin for `Coupons`
  * in the third tab, disable the links for the Admin bar
  * save
* under `WooCommerce` > `Coupons`, create and publish a new coupon
  * check that on reload you can see the "Copy to a new draft" and "Rewrite & Republish" buttons and they are correctly spaced vertically
![index](https://user-images.githubusercontent.com/15989132/146901799-7d379fad-f42e-48d8-bf53-e58d466c18aa.png)
* edit a published post and check that the same happens

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-56]
