### PR TITLE
GH Actions: fix the deploy fail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,6 +162,7 @@ jobs:
           ref: ${{ env.DIST_DEFAULT_BRANCH }}
           # Personal Access Token for (push) access to the dist version of the repo.
           token: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
+          fetch-depth: 0
 
       - name: "Create branch/Switch to branch"
         if: ${{ steps.set_vars.outputs.BRANCH != env.DIST_DEFAULT_BRANCH }}


### PR DESCRIPTION
## Context

* Improve CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

By default the `actions/checkout` does a shallow clone. This means that other branches will not be known, so would always be created as new.
By setting `fetch-depth` to `0`, a complete clone will be made, including all tags and branches.

This will make the deploy slightly slower, but as the `dist` repos are nowhere near as huge as the `dev` repos, this should still be relatively limited.
If this at some point would become problematic, we can have a think about using a "sensible number" for `fetch-depth` (something like `1000` or so).

Refs:
* https://github.com/actions/checkout#usage
* https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This branch has been prefixed with `feature` to trigger the `deploy` workflow already. Check the branch as pushed to the `dist` repo to verify its okay (and delete it after that).
* The real test is merging this PR and then verifying that the push to `trunk` succeeds. If not, give me a shout and I'll have another look.

P.S.: the test branch from the previous PR also still needs to be deleted from `dist`.