### PR TITLE
DUPP-217 Fix welcome notice

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -199,7 +199,7 @@ function duplicate_post_migrate_show_links_in_options( $defaults ) {
 }
 
 /**
- * Shows the update notice.
+ * Shows the welcome notice.
  *
  * @global string $wp_version The WordPress version string.
  */

--- a/src/admin/options.php
+++ b/src/admin/options.php
@@ -259,7 +259,7 @@ class Options {
 			'duplicate_post_show_notice'                  => [
 				'tab'   => 'display',
 				'type'  => 'checkbox',
-				'label' => \__( 'Show update notice', 'duplicate-post' ),
+				'label' => \__( 'Show welcome notice', 'duplicate-post' ),
 				'value' => 1,
 			],
 			'duplicate_post_show_link'                    => [

--- a/src/admin/views/options.php
+++ b/src/admin/views/options.php
@@ -233,7 +233,7 @@ if ( ! \defined( 'DUPLICATE_POST_CURRENT_VERSION' ) ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><?php \esc_html_e( 'Update notice', 'duplicate-post' ); ?></th>
+					<th scope="row"><?php \esc_html_e( 'Welcome notice', 'duplicate-post' ); ?></th>
 					<td>
 						<?php
 						// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -34,7 +34,7 @@ class Newsletter {
 				'Yoast respects your privacy. Read %1$sour privacy policy%2$s on how we handle your personal information.',
 				'duplicate-post'
 			),
-			'<a href="https://yoa.st/4jf">',
+			'<a href="https://yoa.st/4jf" target="_blank">',
 			'</a>'
 		);
 

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -34,7 +34,7 @@ class Newsletter {
 				'Yoast respects your privacy. Read %1$sour privacy policy%2$s on how we handle your personal information.',
 				'duplicate-post'
 			),
-			'<a href=https://yoa.st/4jf">',
+			'<a href="https://yoa.st/4jf">',
 			'</a>'
 		);
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the link in the welcome notice, and change copy references to update notice → welcome notice

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the link to the privacy policy was broken.

## Relevant technical choices:

* We also fixed the labels in the settings to refer to the welcome notice and not to update notice anymore

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install on a clean environment
* see the welcome notice, click on the "Privacy policy" link
   * you should arrive to the page with URL https://yoast.com/privacy-policy/
* visit Settings > Duplicate Post
* navigate to the third tab "Display"
* check that the last checkbox has labels referring to `Welcome notice` and not to `Update notice` anymore:
![Screenshot 2022-01-13 at 12-40-43 Duplicate Post Options ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/149323961-19f00d9a-6b89-40e4-9b7d-e6a58b5e4d95.png)



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-217]


[DUPP-217]: https://yoast.atlassian.net/browse/DUPP-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ