### PR TITLE
DUPP-218 Always hide welcome notice to upgrading users

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -98,6 +98,10 @@ function duplicate_post_plugin_upgrade() {
 				$role->add_cap( 'copy_posts' );
 			}
 		}
+		add_option( 'duplicate_post_show_notice', 1 );
+	}
+	else {
+		update_option( 'duplicate_post_show_notice', 0 );
 	}
 
 	$show_links_in_defaults = [
@@ -137,7 +141,6 @@ function duplicate_post_plugin_upgrade() {
 		]
 	);
 	add_option( 'duplicate_post_show_link_in', $show_links_in_defaults );
-	add_option( 'duplicate_post_show_notice', 1 );
 
 	$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
 	if ( $taxonomies_blacklist === '' ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to hide the welcome notice to upgrading users, even if they have not dismissed the upgrade notice yet.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the welcome notice would be displayed to existing users who haven't dismissed the upgrade notice.

## Relevant technical choices:

* I failed to change the commit message so it's not meaningful. Sorry.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preparation
* install Local By Flywheel
* create two websites: one for a `New User`, another for an `Existing User`
* checkout this branch and create a ZIP with `grunt artifact`.

#### New user
* in the website for the `New User`, install the `artifact.zip` file you created
* activate the plugin
* check that you **can** see the Welcome notice in the Dashboard and in the Plugins page.

#### Existing user
* in the website for the `Existing User`, install the latest Yoast Duplicate Post version from WP.org
* activate the plugin
* you'll see the upgrade notice in the Dashboard and in the Plugins page. **Do not dismiss it**
* install the `artifact.zip` file you created to overwrite the existing version
* check that you **cannot** see the Welcome notice in the Dashboard and in the Plugins page.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-218]


[DUPP-218]: https://yoast.atlassian.net/browse/DUPP-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ