### PR TITLE
DUPP-52 improve gettext usage

### DIFF
--- a/src/ui/classic-editor.php
+++ b/src/ui/classic-editor.php
@@ -63,9 +63,8 @@ class Classic_Editor {
 			}
 		}
 
-		\add_filter( 'gettext', [ $this, 'change_republish_strings_classic_editor' ], 10, 2 );
-		\add_filter( 'gettext_with_context', [ $this, 'change_schedule_strings_classic_editor' ], 10, 3 );
-		\add_filter( 'post_updated_messages', [ $this, 'change_scheduled_notice_classic_editor' ], 10, 1 );
+		\add_action( 'load-post.php', [ $this, 'hook_translations' ] );
+		\add_filter( 'post_updated_messages', [ $this, 'change_scheduled_notice_classic_editor' ] );
 
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_classic_editor_scripts' ] );
 		if ( \intval( Utils::get_option( 'duplicate_post_show_link_in', 'submitbox' ) ) === 1 ) {
@@ -78,6 +77,16 @@ class Classic_Editor {
 		// Remove slug editing from Classic Editor.
 		\add_action( 'add_meta_boxes', [ $this, 'remove_slug_meta_box' ], 10, 2 );
 		\add_filter( 'get_sample_permalink_html', [ $this, 'remove_sample_permalink_slug_editor' ], 10, 5 );
+	}
+
+	/**
+	 * Hooks the functions to change the translations.
+	 *
+	 * @return void
+	 */
+	public function hook_translations() {
+			\add_filter( 'gettext', [ $this, 'change_republish_strings_classic_editor' ], 10, 3 );
+			\add_filter( 'gettext_with_context', [ $this, 'change_schedule_strings_classic_editor' ], 10, 4 );
 	}
 
 	/**
@@ -201,19 +210,23 @@ class Classic_Editor {
 	 *
 	 * @param string $translation The translated text.
 	 * @param string $text        The text to translate.
+	 * @param string $domain      The translation domain.
 	 *
 	 * @return string The to-be-used copy of the text.
 	 */
-	public function change_republish_strings_classic_editor( $translation, $text ) {
-		if ( $this->should_change_rewrite_republish_copy( \get_post() ) ) {
-			if ( $text === 'Publish' ) {
-				return \__( 'Republish', 'duplicate-post' );
-			}
+	public function change_republish_strings_classic_editor( $translation, $text, $domain ) {
+		if ( $domain !== 'default' ) {
+			return $translation;
+		}
 
-			if ( $text === 'Publish on: %s' ) {
-				/* translators: %s: Date on which the post is to be republished. */
-				return \__( 'Republish on: %s', 'duplicate-post' );
-			}
+		if ( $text === 'Publish'
+			&& $this->should_change_rewrite_republish_copy( \get_post() ) ) {
+				return \__( 'Republish', 'duplicate-post' );
+		}
+		elseif ( $text === 'Publish on: %s'
+			&& $this->should_change_rewrite_republish_copy( \get_post() ) ) {
+			/* translators: %s: Date on which the post is to be republished. */
+			return \__( 'Republish on: %s', 'duplicate-post' );
 		}
 
 		return $translation;
@@ -224,11 +237,18 @@ class Classic_Editor {
 	 *
 	 * @param string $translation The translated text.
 	 * @param string $text        The text to translate.
+	 * @param string $context     The translation context.
+	 * @param string $domain      The translation domain.
 	 *
 	 * @return string The to-be-used copy of the text.
 	 */
-	public function change_schedule_strings_classic_editor( $translation, $text ) {
-		if ( $this->should_change_rewrite_republish_copy( \get_post() ) && $text === 'Schedule' ) {
+	public function change_schedule_strings_classic_editor( $translation, $text, $context, $domain ) {
+		if ( $domain !== 'default' || $context !== 'post action/button label' ) {
+			return $translation;
+		}
+
+		if ( $text === 'Schedule'
+			&& $this->should_change_rewrite_republish_copy( \get_post() ) ) {
 			return \__( 'Schedule republish', 'duplicate-post' );
 		}
 

--- a/tests/ui/classic-editor-test.php
+++ b/tests/ui/classic-editor-test.php
@@ -123,6 +123,18 @@ class Classic_Editor_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the registration of the translation hooks.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::hook_translations
+	 */
+	public function test_hook_translations() {
+		$this->instance->hook_translations();
+
+		$this->assertNotFalse( \has_filter( 'gettext', [ $this->instance, 'change_republish_strings_classic_editor' ] ), 'Does not have expected gettext filter' );
+		$this->assertNotFalse( \has_filter( 'gettext_with_context', [ $this->instance, 'change_schedule_strings_classic_editor' ] ), 'Does not have expected gettext_with_context filter' );
+	}
+
+	/**
 	 * Tests the successful enqueue_classic_editor_scripts function.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::enqueue_classic_editor_scripts


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve how some labels are rewritten for the R&R feature using `gettext`, to avoid performance issues.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reduces the impact of the plugin on the performance of the site by avoding useless calls on the `gettext` filter.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

We should check that the labels are still rewritten, and that the number to the affecting methods is much lower.

#### Regression test
* install the Classic Editor plugin
* Choose a published post and create a R&R copy of that
* while editing the R&R copy in the Classic Editor, check that the button says "Republish" and the field where you set the date says "Republish on:" (the wrong margin is being fixed in #254)
![Screenshot 2022-06-10 at 09-49-52 Edit Post “Digitized didactic strategy” ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/173017531-9f679bf2-5a55-4a1e-bb93-d2a7285fd56d.png)
* change the date to a future date and check that the button now says "Schedule republish"
* save as draft and on reload check that the button is still "Schedule republish"
* **check the same for pages and custom post types.**

#### Check that we hook only in the edit screen
* install Query Monitor
* in QM, open Languages > Hooks in use:
![Screenshot 2022-06-10 at 10-10-48 Edit Post “Open-source 3rdgeneration protocol” ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/173021469-f7d36073-d529-4525-89ca-eb799684260a.png)
* visit different pages in the backend and see that `Yoast\W\D\U\Classic_Editor->change_republish_strings_classic_editor()` and `Yoast\W\D\U\Classic_Editor->change_schedule_strings_classic_editor()` are hooked only on the edit post/page screens


#### Check the performance improvement
this is not easy to check because it's visible in environments with plenty of content, but a possible way could be:
* set breakpoints on `Yoast\W\D\U\Classic_Editor->change_republish_strings_classic_editor()` and `Yoast\W\D\U\Classic_Editor->change_schedule_strings_classic_editor()`
* see that you hit the breakpoints only in the edit screen
* see that when you hit the breakpoints, you bail out early when the text domain/context or the strings are not the expected ones, so no call to `get_post()` is done in that case.

Another idea:
* install the Code Profiler plugin
* Run checks for Dashboard and for Posts screen as admin with and without this patch, and see that the times change clearly (e.g. 0.043s vs 0.126s on the Posts page, and 0.022s vs 0.08s on the Dashboard)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #185 [DUPP-52]


[DUPP-52]: https://yoast.atlassian.net/browse/DUPP-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ