### PR TITLE
QA: fix incorrect escaping function

### DIFF
--- a/src/admin/views/options.php
+++ b/src/admin/views/options.php
@@ -244,7 +244,7 @@ if ( ! \defined( 'DUPLICATE_POST_CURRENT_VERSION' ) ) {
 			</table>
 		</section>
 		<p class="submit">
-			<input type="submit" class="button button-primary" value="<?php \esc_html_e( 'Save changes', 'duplicate-post' ); ?>"/>
+			<input type="submit" class="button button-primary" value="<?php \esc_attr_e( 'Save changes', 'duplicate-post' ); ?>"/>
 		</p>
 	</form>
 </div>


### PR DESCRIPTION
## Context

* Plugin security

## Summary

This PR can be summarized in the following changelog entry:

* Minor security improvement

## Relevant technical choices:

`esc_attr*()` should be used for values in HTML attributes.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ Functionally, there should be no noticeable difference