### PR TITLE
Allow `use_filters` change when creating post

### DIFF
--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -157,7 +157,7 @@ class Post_Duplicator {
 			'copy_excerpt'    => true,
 			'copy_author'     => true,
 			'copy_menu_order' => true,
-			'use_filters'     => false,
+			'use_filters'     => true,
 		];
 		$defaults = $this->get_default_options();
 		$options  = \wp_parse_args( $options, $defaults );

--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -157,7 +157,7 @@ class Post_Duplicator {
 			'copy_excerpt'    => true,
 			'copy_author'     => true,
 			'copy_menu_order' => true,
-			'use_filters'     => true,
+			'use_filters'     => \apply_filters( 'duplicate_post_create_duplicate_use_filters', false ),
 		];
 		$defaults = $this->get_default_options();
 		$options  = \wp_parse_args( $options, $defaults );

--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -157,7 +157,15 @@ class Post_Duplicator {
 			'copy_excerpt'    => true,
 			'copy_author'     => true,
 			'copy_menu_order' => true,
-			'use_filters'     => \apply_filters( 'duplicate_post_create_duplicate_use_filters', false ),
+			/**
+			 * Filters the option `use_filters` during post duplicate creation for rewrite and
+			 * republish.
+			 *
+			 * @param bool $use_filters Default is false.
+			 *
+			 * @return bool
+			 */
+			'use_filters' => \apply_filters( 'duplicate_post_create_duplicate_use_filters', false ),
 		];
 		$defaults = $this->get_default_options();
 		$options  = \wp_parse_args( $options, $defaults );


### PR DESCRIPTION
## Context
This was an issue encountered while using the Distributor plugin, but fixing it can allow for greater compatibility with other plugins. When duplicating a post provide a way to enable filtering the original data that gets copied (post data, meta values and terms).

We opted not to include all instances of `use_filters` because one was already addressed in #244, even though the filter's name might need some adjusting.

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
Adds a new filter `duplicate_post_create_duplicate_use_filters` to enable filtering the original data that gets copied (post data, meta values and terms).

*

## Relevant technical choices:

The prefix for the filter name was kept consistent with the rest of the plugin, while adding specific details with function and property being filtered.

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
- Enable data filtering on create:
```php
// Uses WordPress' global functions.
add_filter( 'duplicate_post_create_duplicate_use_filters', '__return_true' );
```
- Add some meta to be excluded
```php
public function exclude_meta_keys( array $meta_keys ) : array {
	// Replace this meta key according to your setup.
	$meta_keys[] = 'excluded_meta_key';
	return $meta_keys;
}

add_filter( 'duplicate_post_excludelist_filter', 'exclude_meta_keys' );
```
- Duplicate and check that the `'excluded_meta_key'` is not present in the new post.

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
	<!--
	If you have checked any of the above cases, please add some context about the reason, what to check in the console,
	which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
	-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #204 
