### PR TITLE
Tests: fix PHP 8.2 compatibility

### DIFF
--- a/tests/admin/options-form-generator-test.php
+++ b/tests/admin/options-form-generator-test.php
@@ -5,6 +5,8 @@ namespace Yoast\WP\Duplicate_Post\Tests\Admin;
 use Brain\Monkey;
 use Mockery;
 use stdClass;
+use WP_Post_Type;
+use WP_Taxonomy;
 use Yoast\WP\Duplicate_Post\Admin\Options_Form_Generator;
 use Yoast\WP\Duplicate_Post\Admin\Options_Inputs;
 use Yoast\WP\Duplicate_Post\Tests\TestCase;
@@ -48,13 +50,13 @@ class Options_Form_Generator_Test extends TestCase {
 			'edit_posts' => 'edit_posts',
 		];
 
-		$post_type1          = Mockery::mock( 'WP_Post_Type' );
+		$post_type1          = Mockery::mock( WP_Post_Type::class );
 		$post_type1->name    = 'Books';
 		$post_type1->show_ui = true;
 		$post_type1->labels  = $labels;
 		$post_type1->cap     = (object) $caps;
 
-		$post_type2          = Mockery::mock( 'WP_Post_Type' );
+		$post_type2          = Mockery::mock( WP_Post_Type::class );
 		$post_type2->name    = 'Movies';
 		$post_type2->show_ui = true;
 		$post_type2->labels  = $labels;
@@ -304,22 +306,22 @@ class Options_Form_Generator_Test extends TestCase {
 		$labels4       = new stdClass();
 		$labels4->name = 'Bar';
 
-		$taxonomy1         = Mockery::mock( 'WP_Taxonomy' );
+		$taxonomy1         = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy1->name   = 'custom_taxonomy_public_1';
 		$taxonomy1->public = true;
 		$taxonomy1->labels = $labels1;
 
-		$taxonomy2         = Mockery::mock( 'WP_Taxonomy' );
+		$taxonomy2         = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy2->name   = 'custom_taxonomy_private_2';
 		$taxonomy2->public = false;
 		$taxonomy2->labels = $labels2;
 
-		$taxonomy3         = Mockery::mock( 'WP_Taxonomy' );
+		$taxonomy3         = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy3->name   = 'custom_taxonomy_public_2';
 		$taxonomy3->public = true;
 		$taxonomy3->labels = $labels3;
 
-		$taxonomy4         = Mockery::mock( 'WP_Taxonomy' );
+		$taxonomy4         = Mockery::mock( WP_Taxonomy::class );
 		$taxonomy4->name   = 'custom_taxonomy_private_1';
 		$taxonomy4->public = false;
 		$taxonomy4->labels = $labels4;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,3 +19,16 @@ if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 
 require_once __DIR__ . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';
+
+// Create the necessary test doubles for WP native classes on which properties are being set.
+Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
+	[
+		'WP_Post',
+		'WP_Post_Type',
+		'WP_Role',
+		'WP_Screen',
+		'WP_Taxonomy',
+		'WP_Term',
+		'WP_User',
+	]
+);

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WP_Role;
 use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
 /**
@@ -19,7 +20,7 @@ abstract class TestCase extends YoastTestCase {
 	protected function stub_wp_roles() {
 
 		// Mock roles to use across several tests.
-		$role1               = Mockery::mock( 'WP_Role' );
+		$role1               = Mockery::mock( WP_Role::class );
 		$role1->name         = 'Editor';
 		$role1->capabilities = [
 			'read'       => 'read',
@@ -34,7 +35,7 @@ abstract class TestCase extends YoastTestCase {
 			]
 		);
 
-		$role2               = Mockery::mock( 'WP_Role' );
+		$role2               = Mockery::mock( WP_Role::class );
 		$role2->name         = 'Administrator';
 		$role2->capabilities = [
 			'read'       => 'read',
@@ -49,7 +50,7 @@ abstract class TestCase extends YoastTestCase {
 			]
 		);
 
-		$role3               = Mockery::mock( 'WP_Role' );
+		$role3               = Mockery::mock( WP_Role::class );
 		$role3->name         = 'Subscriber';
 		$role3->capabilities = [];
 		$role3->allows(

--- a/tests/ui/admin-bar-test.php
+++ b/tests/ui/admin-bar-test.php
@@ -490,8 +490,13 @@ class Admin_Bar_Test extends TestCase {
 	 */
 	public function test_get_current_post_unsuccessful_frontend() {
 		global $wp_the_query;
-		$wp_the_query    = Mockery::mock( WP_Query::class );
-		$post            = Mockery::mock( WP_Term::class );
+		$wp_the_query = Mockery::mock( WP_Query::class );
+		$post         = Mockery::mock( WP_Term::class );
+
+		/*
+		 * Take note that the property being set is not a property declared on WP_Term,
+		 * it just needs to be set to test a specific edge-case.
+		 */
 		$post->post_type = 'post';
 
 		Monkey\Functions\expect( '\is_admin' )
@@ -511,6 +516,9 @@ class Admin_Bar_Test extends TestCase {
 
 		$this->permissions_helper
 			->expects( 'is_edit_post_screen' )
+			->never();
+
+		Monkey\Functions\expect( '\is_singular' )
 			->never();
 
 		$this->permissions_helper


### PR DESCRIPTION
## Context

* Make the test suite compatible with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Make the test suite compatible with PHP 8.2

## Relevant technical choices:

### Tests: use import use statements for all referenced WP native classes

### Tests: on the fly create test doubles of unavailable WP classes

### Admin_Bar_Test: minor test tweaks

Document why a non-existent property is being set on `WP_Term` and that this is intentional.

Includes adding a missing negative function call expectation.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* While on PHP 7.4, run `composer install` to update the test dependencies to a set which is compatible with PHP 8.2 (this repo does not have a committed `composer.lock` file, so this should work).
* On PHP 8.2, run the tests against `trunk` and see them fail.
* On PHP 8.2, run the tests against this branch and see them pass.