### PR TITLE
Do fix worpdress org format

### DIFF
--- a/config/grunt/task-config/update-changelog-to-latest.js
+++ b/config/grunt/task-config/update-changelog-to-latest.js
@@ -11,12 +11,12 @@ module.exports = {
 			//
 			// Enhancements:
 			readmeFile: "./readme.txt",
-			releaseInChangelog: /[#] \d+\.\d+(\.\d+)?\n\n/g,
+			releaseInChangelog: /[=] \d+\.\d+(\.\d+)? =/g,
 			matchChangelogHeader: /[=]= Changelog ==\n\n/ig,
-			newHeadertemplate: "== Changelog ==\n\n" + "## " + "VERSIONNUMBER" + "\n\nRelease date: " + "DATESTRING"  + "\n",
-			matchCorrectHeader: "## " + "VERSIONNUMBER" + "(.|\\n)*?\\n(?=(\\n#### \\w\+?\\n|## \\d+[\.\\d]+|= Earlier versions =))",
-			matchCorrectLines: "## " + "VERSIONNUMBER" + "(.|\\n)*?(?=(\\n## \\d+[\.\\d]+|= Earlier versions =))",
-			matchCleanedChangelog: "## " + "VERSIONNUMBER" + "(.|\\n)*= Earlier versions =",
+			newHeadertemplate: "== Changelog ==\n\n" + "= " + "VERSIONNUMBER" + " =\n\nRelease date: " + "DATESTRING"  + "\n",
+			matchCorrectHeader: "= " + "VERSIONNUMBER" + " =(.|\\n)*?\\n(?=(\\n#### \\w\+?\\n|= \\d+[\.\\d]+|= Earlier versions =))",
+			matchCorrectLines: "= " + "VERSIONNUMBER" + " =(.|\\n)*?(?=(= \\d+[\.\\d]+ =|= Earlier versions =))",
+			matchCleanedChangelog: "= " + "VERSIONNUMBER" + "(.|\\n)*= Earlier versions =",
 			replaceCleanedChangelog: "= Earlier versions =",
 			pluginSlug: "duplicate-post",
 			defaultChangelogEntries: "",

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ If Duplicate Post is still in English, or if there are some untranslated strings
 
 == Changelog ==
 
-## 4.5
+= 4.5 =
 
 Release date: June 28th, 2022
 
@@ -87,7 +87,7 @@ Release date: June 28th, 2022
 
 * Sets the WordPress tested up to version to 6.0.
 
-## 4.4
+= 4.4 =
 
 Release date: January 25th, 2022
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* change ## 4.4 to = 4.4 = for wordpress.org

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* change ## 4.4 to = 4.4 = for wordpress.org

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
