### PR TITLE
update plugin-grunt-tasks to 2.4 and update date format in readme.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@wordpress/data": "^4.25.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
-    "@yoast/grunt-plugin-tasks": "^2.3",
+    "@yoast/grunt-plugin-tasks": "^2.4",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.1.0",
     "babel-loader": "7",
@@ -42,8 +42,8 @@
     "babelify": "^10.0.0",
     "case-sensitive-paths-webpack-plugin": "^2.3.0",
     "grunt": "^1.3.0",
-    "grunt-git": "^1.0.14",
     "grunt-contrib-clean": "^2.0.0",
+    "grunt-git": "^1.0.14",
     "grunt-shell": "^3.0.1",
     "grunt-webpack": "^4.0.2",
     "load-grunt-config": "^3.0.1",

--- a/readme.txt
+++ b/readme.txt
@@ -73,7 +73,7 @@ If Duplicate Post is still in English, or if there are some untranslated strings
 
 = 4.5 =
 
-Release date: June 28th, 2022
+Release date: 2022-06-28
 
 #### Enhancements
 
@@ -89,7 +89,7 @@ Release date: June 28th, 2022
 
 = 4.4 =
 
-Release date: January 25th, 2022
+Release date: 2022-01-25
 
 #### Enhancements
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,10 +1122,10 @@
   resolved "https://registry.yarnpkg.com/@yoast/browserslist-config/-/browserslist-config-1.2.2.tgz#ebe69768f5b352b5814111cb010867a024667d69"
   integrity sha512-ri5c2daBpAiKhN5pgcylw8rYWu1MGK+Uz6h/DtqqZEjE6rEjHxdPGv+0hL88is1HEdubyhZTcK9Y5gzcnY6f8A==
 
-"@yoast/grunt-plugin-tasks@^2.3":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-2.3.0.tgz#9dcefbd64fd3a301fbb9ab55307e1b48f232bbd9"
-  integrity sha512-1NudJYAKOaGKveLYv3axZ+ecCrL1gSikkZZynev7m//dCEt+WhuX0wzimGBGiwrHtkbMGPKBFjBS+CFhPM3jIA==
+"@yoast/grunt-plugin-tasks@^2.4":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-2.4.0.tgz#3aa8984bc11bc44d1e62119dd7c16888f25cccd2"
+  integrity sha512-CcCwpyWqMxNkDAPeSrNbYW/JjrOGFg1AzG7NEAwkQY3BD6RDqh93z7ALKhQyeLPhL3KjQGkZOCYboSqY1jgwvw==
   dependencies:
     "@yoast/browserslist-config" "^1.0.0"
     autoprefixer "^9.7.2"
@@ -1145,7 +1145,7 @@
     grunt-contrib-uglify "^4.0.1"
     grunt-contrib-watch "^1.0.0"
     grunt-eslint "^21.0.0"
-    grunt-glotpress "https://github.com/Yoast/grunt-glotpress.git#master"
+    grunt-glotpress "https://github.com/Yoast/grunt-glotpress.git#main"
     grunt-postcss "^0.9.0"
     grunt-replace "^1.0.1"
     grunt-rtlcss "^2.0.2"
@@ -5085,9 +5085,9 @@ grunt-git@^1.0.14:
   dependencies:
     flopmang "^1.0.0"
 
-"grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
+"grunt-glotpress@git+https://github.com/Yoast/grunt-glotpress.git#main":
   version "0.3.0"
-  resolved "https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
+  resolved "git+https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
   dependencies:
     request "^2.88.0"
     request-promise-native "^1.0.7"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Update plugin-grunt-tasks 2.3 => 2.4
* this will change the initial date format (to yyyy-mm-dd) used when creating a new RC,
* updated a dependancy from master to main
* updates the date format in readme.txt


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the `grunt-plugin-tasks` dependency to 2.4 ( this will change the initial date format to yyyy-mm-dd when creating a new RC).
* Updates the date format in README.md.
* Updates a dependency from `master` to `main`.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* verify the readme.txt

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
