### PR TITLE
Fix deprecated notice when using PHP 8.1+

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -275,7 +275,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 	global $wpdb;
 	if ( isset( $wpdb->terms ) ) {
 		// Clear default category (added by wp_insert_post).
-		wp_set_object_terms( $new_id, null, 'category' );
+		wp_set_object_terms( $new_id, array(), 'category' );
 
 		$post_taxonomies = get_object_taxonomies( $post->post_type );
 		// Several plugins just add support to post-formats but don't register post_format taxonomy.

--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -187,7 +187,7 @@ class Post_Duplicator {
 	 */
 	public function copy_post_taxonomies( $new_id, $post, $options ) {
 		// Clear default category (added by wp_insert_post).
-		\wp_set_object_terms( $new_id, null, 'category' );
+		\wp_set_object_terms( $new_id, array(), 'category' );
 
 		$post_taxonomies = \get_object_taxonomies( $post->post_type );
 		// Several plugins just add support to post-formats but don't register post_format taxonomy.


### PR DESCRIPTION
## The issue
Running Duplicate Post with PHP 8.1 fires a deprecated notice:
```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /app/polylang/tmp/wordpress/wp-includes/taxonomy.php on line 2751
```

## How to test?

```php
			$post = self::factory()->post->create_and_get();
			duplicate_post_admin_init();
			$new_id = duplicate_post_create_duplicate( $post, 'draft' );
```

## How to fix
Pass `array()` instead of `null` as second param of `wp_set_object_terms()`.  
The reason is that `null` is transformed to [`array( null )`](https://github.com/WordPress/WordPress/blob/1bf93a87a449a9476d1efd93a0452d7d6ceb3808/wp-includes/taxonomy.php#L2728-L2730) and WP apples [`trim()`](https://github.com/WordPress/WordPress/blob/1bf93a87a449a9476d1efd93a0452d7d6ceb3808/wp-includes/taxonomy.php#L2751) to all items in this array.