### PR TITLE
Drop compatibility with PHP 5.6, 7.0 and 7.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 5.6
+          php-version: 7.2
           coverage: none
 
       # This action also handles the caching of the Yarn dependencies.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['5.6', '7.0', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['7.2', '7.4', '8.0', '8.1', '8.2']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/Yoast/duplicate-post"
     },
     "require": {
-        "php": ">=5.6",
+        "php": "^7.2.5 || ^8.0",
         "composer/installers": "^1.12.0"
     },
     "require-dev": {
@@ -59,6 +59,9 @@
         ]
     },
     "config": {
+        "platform": {
+          "php": "7.2.5"
+        },
         "classmap-authoritative": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -13,6 +13,8 @@
  * Author:      Enrico Battocchi & Team Yoast
  * Author URI:  https://yoast.com
  * Text Domain: duplicate-post
+ * Requires at least: 6.0
+ * Requires PHP: 7.2.5
  *
  * Copyright 2020-2022 Yoast BV (email : info@yoast.com)
  *

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: 				duplicate post, copy, clone
 Requires at least: 	6.0
 Tested up to: 		6.1
 Stable tag: 		4.5
-Requires PHP:		5.6.20
+Requires PHP:		7.2.5
 License: 			GPLv2 or later
 License URI: 		http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Drops compatibility with PHP 5.6, 7.0 and 7.1.


## Relevant technical choices:
 
* Note that Yoast SEO is not required to run Yoast Duplicate Post, the latter is not an addon.
* Also note that `composer.lock` is not committed to the repo by design.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the GH actions pass
* install on a PHP 5.6 environment
* visit the Plugins page
* see that you get the same message and you can't activate the plugin, as it happens here for Free and Premium:
![Screenshot 2023-03-03 at 13-28-32 Plugins ‹ rodeo-polo-nimi instawp xyz — WordPress](https://user-images.githubusercontent.com/15989132/222720342-ef651e58-de59-4cca-a2f0-60671cb87429.png)
* the same should happen with 7.0 and 7.1

**note**: the above may be tricky to test. I can see 5.6 as a choice in Local by Flywheel, but I know it's not the case for others (and I can see 7.0 an 7.1 are not available - neither 7.2 actually)
I tried on Instawp, where you have the full choice of PHP versions, but when uploading the artifact I got:
![Screenshot 2023-03-03 at 11-27-45 Upload Plugin ‹ rodeo-polo-nimi instawp xyz — WordPress](https://user-images.githubusercontent.com/15989132/222696992-5ba1bf92-2cb5-42cb-a19c-a98a01024141.png)
which is also a nice thing to check, actually.

So a way could be:
- start a 7.2 site on instawp
- upload the artifact but  **don't activate it**
- switch to 5.6
- check that  you get the same message above and you can't activate the plugin
- switch to 7.0 an 7.1
- the same should happen

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #https://github.com/Yoast/wordpress-seo/issues/19801
