### PR TITLE
Add Rewrite & Republish hooks

### DIFF
--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -162,13 +162,14 @@ class Post_Duplicator {
 		$defaults = $this->get_default_options();
 		$options  = \wp_parse_args( $options, $defaults );
 
-		$new_post_id = $this->create_duplicate( $post, $options );
+		$new_post_id     = $this->create_duplicate( $post, $options );
+		$new_post_status = $this->generate_copy_status( $post, $options );
 
 		if ( ! \is_wp_error( $new_post_id ) ) {
 			if ( $post->post_type === 'page' || is_post_type_hierarchical( $post->post_type ) ) {
-				do_action( 'dp_duplicate_page', $new_post_id, $post, $post->post_status );
+				do_action( 'dp_duplicate_page', $new_post_id, $post, $new_post_status );
 			} else {
-				do_action( 'dp_duplicate_post', $new_post_id, $post, $post->post_status );
+				do_action( 'dp_duplicate_post', $new_post_id, $post, $new_post_status );
 			}
 
 			$this->copy_post_taxonomies( $new_post_id, $post, $options );
@@ -186,7 +187,7 @@ class Post_Duplicator {
 		 * @param WP_Post      $post        The original post object.
 		 * @param bool         $status      The intended destination status.
 		 */
-		do_action( 'duplicate_rewrite_and_republish_post_copy', $new_post_id, $post, $post->post_status );
+		do_action( 'duplicate_rewrite_and_republish_post_copy', $new_post_id, $post, $new_post_status );
 
 		return $new_post_id;
 	}

--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -165,6 +165,12 @@ class Post_Duplicator {
 		$new_post_id = $this->create_duplicate( $post, $options );
 
 		if ( ! \is_wp_error( $new_post_id ) ) {
+			if ( $post->post_type === 'page' || is_post_type_hierarchical( $post->post_type ) ) {
+				do_action( 'dp_duplicate_page', $new_post_id, $post, $post->post_status );
+			} else {
+				do_action( 'dp_duplicate_post', $new_post_id, $post, $post->post_status );
+			}
+
 			$this->copy_post_taxonomies( $new_post_id, $post, $options );
 			$this->copy_post_meta_info( $new_post_id, $post, $options );
 
@@ -172,6 +178,15 @@ class Post_Duplicator {
 			\update_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', $new_post_id );
 			\update_post_meta( $new_post_id, '_dp_creation_date_gmt', \current_time( 'mysql', 1 ) );
 		}
+
+		/**
+		 * Fires after duplicating a post.
+		 *
+		 * @param int|WP_Error $new_post_id The new post id or WP_Error object on error.
+		 * @param WP_Post      $post        The original post object.
+		 * @param bool         $status      The intended destination status.
+		 */
+		do_action( 'duplicate_rewrite_and_republish_post_copy', $new_post_id, $post, $post->post_status );
 
 		return $new_post_id;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

This PR adds the same `dp_duplicate_post` and `dp_duplicate_page` actions when a post is duplicated for Rewrite & Republish that are fired when when a post is cloned. Without these hooks, we can't hook into the Rewrite & Republish process the way we can with the other copy processes.

## Summary

This PR can be summarized in the following changelog entry:

* Added hooks when a post is duplicated for Rewrite & Republish to align with the hooks already present when a post is just copied.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a duplicate of a post for Rewrite & Republish
* If the post type is hierarchical or in the Pages post type, verify the `dp_duplicate_page` hook is fired and includes the duplicate post's ID, the WP_Post object representing the original post, and the status of the new post.
* If the post type is not hierarchical or in the Pages post type, verify the `dp_duplicate_post` hook is fired and includes the duplicate post's ID, the WP_Post object representing the original post, and the status of the new post.
* Verify the `duplicate_rewrite_and_republish_post_copy` hook is fired and includes the duplicate post's ID, the WP_Post object representing the original post, and the status of the new post.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/post types
* [x] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Since this PR adds the `dp_duplicate_post` and `dp_duplicate_page` actions to the Rewrite & Republish process, verify the setting to copy children works since it relies on those actions.
* Also need to verify the `dp_duplicate_page` and `dp_duplicate_post` hooks aren't fired multiple times when duplicating a post for Rewrite & Republish

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
