### PR TITLE
README: fix broken build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 [![WordPress Plugin Downloads](https://img.shields.io/wordpress/plugin/dt/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/advanced/)
 [![WordPress Plugin Rating](https://img.shields.io/wordpress/plugin/stars/duplicate-post.svg)](https://wordpress.org/support/plugin/duplicate-post/reviews/)
 [![GitHub](https://img.shields.io/github/license/Yoast/duplicate-post.svg)](https://github.com/Yoast/duplicate-post/blob/future/LICENSE)
-[![Build Status](https://travis-ci.org/Yoast/duplicate-post.svg?branch=develop)](https://travis-ci.org/Yoast/duplicate-post)
+
+[![CS](https://github.com/Yoast/duplicate-post/actions/workflows/cs.yml/badge.svg)](https://github.com/Yoast/duplicate-post/actions/workflows/cs.yml)
+[![Lint](https://github.com/Yoast/duplicate-post/actions/workflows/lint.yml/badge.svg)](https://github.com/Yoast/duplicate-post/actions/workflows/lint.yml)
+[![Test](https://github.com/Yoast/duplicate-post/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/duplicate-post/actions/workflows/test.yml)
+[![Deployment](https://github.com/Yoast/duplicate-post/actions/workflows/deploy.yml/badge.svg)](https://github.com/Yoast/duplicate-post/actions/workflows/deploy.yml)
 
 > Duplicate Post plugin for WordPress https://yoast.com/wordpress/plugins/duplicate-post/
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 ![Banner](svn-assets/banner-772x250.png)
 
-[![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/) ![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/duplicate-post.svg) [![WordPress Plugin Active Installs](https://img.shields.io/wordpress/plugin/installs/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/advanced/) [![WordPress Plugin Downloads](https://img.shields.io/wordpress/plugin/dt/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/advanced/) [![WordPress Plugin Rating](https://img.shields.io/wordpress/plugin/stars/duplicate-post.svg)](https://wordpress.org/support/plugin/duplicate-post/reviews/) [![GitHub](https://img.shields.io/github/license/Yoast/duplicate-post.svg)](https://github.com/Yoast/duplicate-post/blob/future/LICENSE) [![Build Status](https://travis-ci.org/Yoast/duplicate-post.svg?branch=develop)](https://travis-ci.org/Yoast/duplicate-post)
+[![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/)
+![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/duplicate-post.svg)
+[![WordPress Plugin Active Installs](https://img.shields.io/wordpress/plugin/installs/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/advanced/)
+[![WordPress Plugin Downloads](https://img.shields.io/wordpress/plugin/dt/duplicate-post.svg)](https://wordpress.org/plugins/duplicate-post/advanced/)
+[![WordPress Plugin Rating](https://img.shields.io/wordpress/plugin/stars/duplicate-post.svg)](https://wordpress.org/support/plugin/duplicate-post/reviews/)
+[![GitHub](https://img.shields.io/github/license/Yoast/duplicate-post.svg)](https://github.com/Yoast/duplicate-post/blob/future/LICENSE)
+[![Build Status](https://travis-ci.org/Yoast/duplicate-post.svg?branch=develop)](https://travis-ci.org/Yoast/duplicate-post)
 
-> Duplicate Post plugin for WordPress https://yoast.com/wordpress/plugins/duplicate-post/  
+> Duplicate Post plugin for WordPress https://yoast.com/wordpress/plugins/duplicate-post/
 
 This WordPress plugin allows users to clone posts of any type, or copy them to new drafts for further editing.
 


### PR DESCRIPTION
## Context

* Fix broken link in README.

## Summary

This PR can be summarized in the following changelog entry:

* Fix broken link in README.

## Relevant technical choices:

### README: improve maintainability of badges

### README: fix broken build status badge

... by replacing it with a group of badges referring to the status of the GH Actions workflows.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check the badges at the top of the README display and link to the correct place.


