### PR TITLE
GH Actions: run workflows more selectively

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,11 +1,55 @@
 name: CS
 
 on:
-  # Run on all pushes (except to main) and on all pull requests.
+  # Run on all relevant pushes (except to main) and on all relevant pull requests.
   push:
     branches-ignore:
       - 'main'
+    paths-ignore:
+      - '**.css'
+      - '**.js'
+      - '**.md'
+      - '**.png'
+      - '**.txt'
+      - '.babelrc'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CHANGELOG'
+      - 'LICENSE'
+      - 'package.json'
+      - 'phpunit.xml.dist'
+      - 'yarn.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/lint.yml'
+      - '.github/workflows/test.yml'
+      - 'config/**'
+      - 'css/**'
+      - 'js/**'
   pull_request:
+    paths-ignore:
+      - '**.css'
+      - '**.js'
+      - '**.md'
+      - '**.png'
+      - '**.txt'
+      - '.babelrc'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CHANGELOG'
+      - 'LICENSE'
+      - 'package.json'
+      - 'phpunit.xml.dist'
+      - 'yarn.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/lint.yml'
+      - '.github/workflows/test.yml'
+      - 'config/**'
+      - 'css/**'
+      - 'js/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 on:
-  # Run on pushes to select branches and on all pull requests.
+  # Run on relevant pushes to select branches and on all relevant pull requests.
   push:
     branches:
       - main
@@ -9,7 +9,55 @@ on:
       - 'release/**'
       - 'hotfix/[0-9]+.[0-9]+*'
       - 'feature/**'
+    paths-ignore:
+      - '**.css'
+      - '**.js'
+      - '**.md'
+      - '**.png'
+      - '**.txt'
+      - '.babelrc'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CHANGELOG'
+      - 'LICENSE'
+      - 'package.json'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - 'phpunit.xml.dist'
+      - 'yarn.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/cs.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/test.yml'
+      - 'config/**'
+      - 'css/**'
+      - 'js/**'
   pull_request:
+    paths-ignore:
+      - '**.css'
+      - '**.js'
+      - '**.md'
+      - '**.png'
+      - '**.txt'
+      - '.babelrc'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CHANGELOG'
+      - 'LICENSE'
+      - 'package.json'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - 'phpunit.xml.dist'
+      - 'yarn.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/cs.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/test.yml'
+      - 'config/**'
+      - 'css/**'
+      - 'js/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  # Run on pushes to select branches and on all pull requests.
+  # Run on relevant pushes to select branches and on all relevant pull requests.
   push:
     branches:
       - main
@@ -9,7 +9,53 @@ on:
       - 'release/**'
       - 'hotfix/[0-9]+.[0-9]+*'
       - 'feature/**'
+    paths-ignore:
+      - '**.css'
+      - '**.js'
+      - '**.md'
+      - '**.png'
+      - '**.txt'
+      - '.babelrc'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CHANGELOG'
+      - 'LICENSE'
+      - 'package.json'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - 'yarn.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/cs.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/lint.yml'
+      - 'config/**'
+      - 'css/**'
+      - 'js/**'
   pull_request:
+    paths-ignore:
+      - '**.css'
+      - '**.js'
+      - '**.md'
+      - '**.png'
+      - '**.txt'
+      - '.babelrc'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CHANGELOG'
+      - 'LICENSE'
+      - 'package.json'
+      - '.phpcs.xml.dist'
+      - 'phpcs.xml.dist'
+      - 'yarn.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/cs.yml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/lint.yml'
+      - 'config/**'
+      - 'css/**'
+      - 'js/**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

Only run the workflows when there is a chance that the result of the workflow run will be different from before.

The path selection is set up to cast a wide net to make the risk of the workflows not running when the build could potentially break as small as possible.

This means that, aside from files of the type being checked in the workflow changing, the workflow will also run when:
* The configuration used changes.
* Dependencies used in the workflow may potentially have changed.
* Composer scripts used in the workflow may potentially have changed.
* Shell scripts used in the workflow have changed.
* The workflow itself changes.
* Miscellaneous related files have changed.

Note: the lists of files _may_ include some files which don't currently exist in the repo (like `.eslintignore`) for consistency across workflows and to prevent issues if/when such file(s) would be introduced to the repo.

Also note that, as this repo does not contain a committed `composer.lock` file, the path selection is done via `paths-ignore` instead of via `paths`!

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_