### PR TITLE
Mark translations that are only for screen readers

### DIFF
--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -97,6 +97,7 @@ function duplicate_post_plugin_actions( $actions ) {
 		'settings' => sprintf(
 			'<a href="%1$s" %2$s>%3$s</a>',
 			menu_page_url( 'duplicatepost', false ),
+			/* translators: Hidden accessibility text. */
 			'aria-label="' . __( 'Settings for Duplicate Post', 'duplicate-post' ) . '"',
 			esc_html__( 'Settings', 'duplicate-post' )
 		),

--- a/src/admin/views/options.php
+++ b/src/admin/views/options.php
@@ -17,8 +17,12 @@ if ( ! \defined( 'DUPLICATE_POST_CURRENT_VERSION' ) ) {
 	<form id="duplicate_post_settings_form" method="post" action="options.php" style="clear: both">
 		<?php \settings_fields( 'duplicate_post_group' ); ?>
 
-		<header role="tablist" aria-label="<?php \esc_attr_e( 'Settings sections', 'duplicate-post' ); ?>"
-				class="nav-tab-wrapper">
+		<header role="tablist" aria-label="
+		<?php
+			/* translators: Hidden accessibility text. */
+			\esc_attr_e( 'Settings sections', 'duplicate-post' );
+		?>
+		" class="nav-tab-wrapper">
 			<button
 					type="button"
 					role="tab"

--- a/src/ui/row-actions.php
+++ b/src/ui/row-actions.php
@@ -81,7 +81,7 @@ class Row_Actions {
 
 		$actions['clone'] = '<a href="' . $this->link_builder->build_clone_link( $post->ID )
 			. '" aria-label="' . \esc_attr(
-				/* translators: %s: Post title. */
+				/* translators: Hidden accessibility text; %s: Post title. */
 				\sprintf( \__( 'Clone &#8220;%s&#8221;', 'duplicate-post' ), $title )
 			) . '">'
 			. \esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
@@ -108,7 +108,7 @@ class Row_Actions {
 
 		$actions['edit_as_new_draft'] = '<a href="' . $this->link_builder->build_new_draft_link( $post->ID )
 			. '" aria-label="' . \esc_attr(
-				/* translators: %s: Post title. */
+				/* translators: Hidden accessibility text; %s: Post title. */
 				\sprintf( \__( 'New draft of &#8220;%s&#8221;', 'duplicate-post' ), $title )
 			) . '">'
 			. \esc_html__( 'New Draft', 'duplicate-post' )
@@ -139,7 +139,7 @@ class Row_Actions {
 
 		$actions['rewrite'] = '<a href="' . $this->link_builder->build_rewrite_and_republish_link( $post->ID )
 			. '" aria-label="' . \esc_attr(
-				/* translators: %s: Post title. */
+				/* translators: Hidden accessibility text; %s: Post title. */
 				\sprintf( \__( 'Rewrite & Republish &#8220;%s&#8221;', 'duplicate-post' ), $title )
 			) . '">'
 			. \esc_html_x( 'Rewrite & Republish', 'verb', 'duplicate-post' ) . '</a>';

--- a/src/utils.php
+++ b/src/utils.php
@@ -118,7 +118,7 @@ class Utils {
 			return \sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
 				\esc_url( \get_edit_post_link( $post->ID ) ),
-				/* translators: %s: post title */
+				/* translators: Hidden accessibility text; %s: post title */
 				\esc_attr( \sprintf( \__( 'Edit &#8220;%s&#8221;', 'duplicate-post' ), $title ) ),
 				$title
 			);
@@ -130,7 +130,7 @@ class Utils {
 					return \sprintf(
 						'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
 						\esc_url( $preview_link ),
-						/* translators: %s: post title */
+						/* translators: Hidden accessibility text; %s: post title */
 						\esc_attr( \sprintf( \__( 'Preview &#8220;%s&#8221;', 'duplicate-post' ), $title ) ),
 						$title
 					);
@@ -140,7 +140,7 @@ class Utils {
 				return \sprintf(
 					'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
 					\esc_url( \get_permalink( $post->ID ) ),
-					/* translators: %s: post title */
+					/* translators: Hidden accessibility text; %s: post title */
 					\esc_attr( \sprintf( \__( 'View &#8220;%s&#8221;', 'duplicate-post' ), $title ) ),
 					$title
 				);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve translator context by adding a `Hidden accessibility text.` comment whenever translations are _only_ used in either screen reader texts or aria labels. To be clear: this means searching for the same translation in the same text domain, if it is used in any other context than screen reader/aria label that means no comment should be there. This is due comments appearing above _all_ the references.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds mark above translations that are used only for screen readers.

## Relevant technical choices:

* It would be nice to have a search yourself, to see if I missed any instances?
  * Note that I intentionally ignored where the variable was used in more than just the screen reader, or in apps, or deprecated. Or when the same translation was used in a non screen reader capacity elsewhere.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not testable, since its only code comments.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19854
