### PR TITLE
Tests: consistency in terminology

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
           COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}
         run: php-coveralls -v -x build/logs/clover.xml
 
-  integration-test:
+  wp-test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -169,7 +169,7 @@ jobs:
             multisite: true
             coverage: true
 
-    name: "Integration Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }}${{ matrix.multisite == true && ' (+ ms)' || '' }}"
+    name: "WP Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }}${{ matrix.multisite == true && ' (+ ms)' || '' }}"
 
     # Allow builds to fail on as-of-yet unreleased WordPress versions.
     continue-on-error: ${{ matrix.wp_version == 'trunk' }}
@@ -208,23 +208,23 @@ jobs:
         shell: bash
         run: config/scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1:3306 ${{ matrix.wp_version }}
 
-      - name: Run integration tests - single site
+      - name: Run WP tests - single site
         if: ${{ matrix.coverage == false }}
-        run: composer integration-test
+        run: composer test-wp
 
-      - name: Run integration tests - multisite
+      - name: Run WP tests - multisite
         if: ${{ matrix.multisite == true && matrix.coverage == false }}
-        run: composer integration-test
+        run: composer test-wp
         env:
           WP_MULTISITE: 1
 
-      - name: Run integration tests with code coverage - single site
+      - name: Run WP tests with code coverage - single site
         if: ${{ matrix.coverage == true }}
-        run: composer integration-coverage
+        run: composer coverage-wp
 
-      - name: Run integration tests with code coverage - multisite
+      - name: Run WP tests with code coverage - multisite
         if: ${{ matrix.multisite == true && matrix.coverage == true }}
-        run: composer integration-coverage -- --coverage-clover build/logs/clover-integration-ms.xml
+        run: composer coverage-wp -- --coverage-clover build/logs/clover-wp-ms.xml
         env:
           WP_MULTISITE: 1
 
@@ -246,19 +246,19 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: intgr-php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}
-        run: php-coveralls -v -x build/logs/clover-integration.xml
+          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}
+        run: php-coveralls -v -x build/logs/clover-wp.xml
 
       - name: Upload coverage results to Coveralls - multisite
         if: ${{ success() && matrix.multisite == true && matrix.coverage == true }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: intgr-php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}-ms
-        run: php-coveralls -v -x build/logs/clover-integration-ms.xml
+          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}-ms
+        run: php-coveralls -v -x build/logs/clover-wp-ms.xml
 
   coveralls-finish:
-    needs: [unit-test, integration-test]
+    needs: [unit-test, wp-test]
     runs-on: ubuntu-latest
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -57,11 +57,17 @@
         "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
         ],
-        "integration-test": [
+        "test-wp": [
             "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-wp.xml.dist --no-coverage"
         ],
-        "integration-coverage": [
+        "coverage-wp": [
             "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-wp.xml.dist"
+        ],
+        "integration-test": [
+            "@test-wp"
+        ],
+        "integration-coverage": [
+            "@coverage-wp"
         ]
     },
     "config": {

--- a/phpunit-wp.xml.dist
+++ b/phpunit-wp.xml.dist
@@ -37,7 +37,7 @@
 
 	<logging>
 		<log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
-		<log type="coverage-clover" target="build/logs/clover-integration.xml"/>
+		<log type="coverage-clover" target="build/logs/clover-wp.xml"/>
 	</logging>
 
 </phpunit>


### PR DESCRIPTION
## Context

* Improve consistency in terminology used.

## Summary

This PR can be summarized in the following changelog entry:

* Improve consistency in terminology used.

## Relevant technical choices:

Related to/follow up on #313

The "integration" tests are being renamed to "WP (unit) tests".

This commit updates the references to these tests in the Composer scripts and the GH Actions workflows to follow the new terminology.

Note: the "old" `integration-test` and `integration-coverage` Composer scripts will still be available for the time being to facilitate the switch over and give the teams a little time to get used to the new script names.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check if the GH actions builds run correctly
* Check if code coverage is correctly uploaded and recorded.
* Locally check the new scripts (and the old) work correctly.