### PR TITLE
Composer: allow composer installers 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "composer/installers": "^1.12.0"
+        "composer/installers": "^1.12.0 || ^2.0"
     },
     "require-dev": {
         "yoast/yoastcs": "^2.3.1",


### PR DESCRIPTION
## Context

* Users requiring this package via [WP]Packagist can now use the `composer/installers` v2.

## Summary

This PR can be summarized in the following changelog entry:

* Users requiring this package via [WP]Packagist can now use the `composer/installers` v2.

## Relevant technical choices:

While the latest version of the `composer/installers` package is `2.2`, I'm explicitly setting the version constraint to a lenient one as this is a non-`dev` requirement, which comes into play when people use a [WP]Packagist based site setup.

If we set the requirement very strictly, it could conflict with other plugins with different constraints and it is not as if any of the 2.x releases have touched the WordPress installer, so setting it to `|| 2.0` should be fine.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_