### PR TITLE
Composer/Tests: update test dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "yoast/yoastcs": "^2.3.1",
-        "yoast/wp-test-utils": "^1.1.1",
+        "yoast/wp-test-utils": "^1.2.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -19,16 +19,3 @@ if ( file_exists( dirname( __DIR__, 2 ) . '/vendor/autoload.php' ) === false ) {
 
 require_once __DIR__ . '/../../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once __DIR__ . '/../../vendor/autoload.php';
-
-// Create the necessary test doubles for WP native classes on which properties are being set.
-Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses(
-	[
-		'WP_Post',
-		'WP_Post_Type',
-		'WP_Role',
-		'WP_Screen',
-		'WP_Taxonomy',
-		'WP_Term',
-		'WP_User',
-	]
-);


### PR DESCRIPTION
## Context

* Updated test dependencies

## Summary

This PR can be summarized in the following changelog entry:

* Updated test dependencies


## Relevant technical choices:

This updates the minimum version of the WP Test Utils dependency.

This also allows us to remove the work-around which was in place for Mockery not handling dynamic properties on mocked objects. This was fixed in Mockery 1.6.0, which will be used when running the tests against PHP 8.2+.

Note: PHPUnit Polyfills 1.1.0 includes a new polyfill for the `assertObject[Not]HasProperty()` methods. The assertions which these new assertions replace are not used in this test suite, so no test changes are needed.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.