### PR TITLE
Composer: normalize the file, add script descriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,80 +1,80 @@
 {
-    "name": "yoast/duplicate-post",
-    "description": "The go-to tool for cloning posts and pages, including the powerful Rewrite & Republish feature.",
-    "keywords": [
-        "wordpress",
-        "post",
-        "copy",
-        "clone"
-    ],
-    "homepage": "https://wordpress.org/plugins/duplicate-post/",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "Enrico Battocchi & Team Yoast",
-            "email": "support@yoast.com",
-            "homepage": "https://yoast.com"
-        }
-    ],
-    "type": "wordpress-plugin",
-    "support": {
-        "issues": "https://github.com/Yoast/duplicate-post/issues",
-        "forum": "https://wordpress.org/support/plugin/duplicate-post",
-        "source": "https://github.com/Yoast/duplicate-post"
-    },
-    "require": {
-        "php": "^7.2.5 || ^8.0",
-        "composer/installers": "^1.12.0 || ^2.0"
-    },
-    "require-dev": {
-        "yoast/yoastcs": "^2.3.1",
-        "yoast/wp-test-utils": "^1.2.0",
-        "roave/security-advisories": "dev-master"
-    },
-    "autoload": {
-        "classmap": [
-            "src/"
-        ]
-    },
-    "autoload-dev": {
-        "classmap": [
-            "tests/"
-        ]
-    },
-    "scripts": {
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
-        ],
-        "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
-        ],
-        "fix-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-        ],
-        "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-        ],
-        "coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
-        ],
-        "test-wp": [
-            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-wp.xml.dist --no-coverage"
-        ],
-        "coverage-wp": [
-            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-wp.xml.dist"
-        ],
-        "integration-test": [
-            "@test-wp"
-        ],
-        "integration-coverage": [
-            "@coverage-wp"
-        ]
-    },
-    "config": {
-        "classmap-authoritative": true,
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true
-        }
-    }
+	"name": "yoast/duplicate-post",
+	"description": "The go-to tool for cloning posts and pages, including the powerful Rewrite & Republish feature.",
+	"license": "GPL-2.0-or-later",
+	"type": "wordpress-plugin",
+	"keywords": [
+		"wordpress",
+		"post",
+		"copy",
+		"clone"
+	],
+	"authors": [
+		{
+			"name": "Enrico Battocchi & Team Yoast",
+			"email": "support@yoast.com",
+			"homepage": "https://yoast.com"
+		}
+	],
+	"homepage": "https://wordpress.org/plugins/duplicate-post/",
+	"support": {
+		"issues": "https://github.com/Yoast/duplicate-post/issues",
+		"forum": "https://wordpress.org/support/plugin/duplicate-post",
+		"source": "https://github.com/Yoast/duplicate-post"
+	},
+	"require": {
+		"php": "^7.2.5 || ^8.0",
+		"composer/installers": "^1.12.0 || ^2.0"
+	},
+	"require-dev": {
+		"roave/security-advisories": "dev-master",
+		"yoast/wp-test-utils": "^1.2.0",
+		"yoast/yoastcs": "^2.3.1"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"autoload-dev": {
+		"classmap": [
+			"tests/"
+		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/installers": true
+		},
+		"classmap-authoritative": true
+	},
+	"scripts": {
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
+		],
+		"check-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit"
+		],
+		"test-wp": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-wp.xml.dist --no-coverage"
+		],
+		"coverage-wp": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-wp.xml.dist"
+		],
+		"integration-test": [
+			"@test-wp"
+		],
+		"integration-coverage": [
+			"@coverage-wp"
+		]
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -76,5 +76,16 @@
 		"integration-coverage": [
 			"@coverage-wp"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Check the PHP files for parse errors.",
+		"check-cs": "Check the PHP files for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage.",
+		"test-wp": "Run the WP unit tests without code coverage.",
+		"coverage-wp": "Run the WP unit tests with code coverage.",
+		"integration-test": "Deprecated. Alias for the \"test-wp\" script.",
+		"integration-coverage": "Deprecated. Alias for the \"coverage-wp\" script."
 	}
 }


### PR DESCRIPTION
## Context

* Tidy up `composer.json` file and improve usability of scripts

## Summary

This PR can be summarized in the following changelog entry:

* Tidy up `composer.json` file and improve usability of scripts

## Relevant technical choices:

### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_