### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/Unit/Admin/Options_Form_Generator_Test.php
+++ b/tests/Unit/Admin/Options_Form_Generator_Test.php
@@ -469,7 +469,7 @@ class Options_Form_Generator_Test extends TestCase {
 	 *
 	 * @return array The data to run the test against.
 	 */
-	public function is_checked_provider() {
+	public static function is_checked_provider() {
 		return [
 			[
 				'test_option',

--- a/tests/Unit/Permissions_Helper_Test.php
+++ b/tests/Unit/Permissions_Helper_Test.php
@@ -266,7 +266,7 @@ class Permissions_Helper_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function is_edit_post_screen_provider() {
+	public static function is_edit_post_screen_provider() {
 		return [
 			[
 				'original' => [
@@ -339,7 +339,7 @@ class Permissions_Helper_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function is_new_post_screen_provider() {
+	public static function is_new_post_screen_provider() {
 		return [
 			[
 				'original' => [
@@ -416,7 +416,7 @@ class Permissions_Helper_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function is_classic_editor_provider() {
+	public static function is_classic_editor_provider() {
 		return [
 			[
 				'original' => [
@@ -677,7 +677,7 @@ class Permissions_Helper_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function should_rewrite_and_republish_be_allowed_provider() {
+	public static function should_rewrite_and_republish_be_allowed_provider() {
 		return [
 			[
 				'original' => [
@@ -749,7 +749,7 @@ class Permissions_Helper_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function post_type_has_admin_bar_provider() {
+	public static function post_type_has_admin_bar_provider() {
 		return [
 			[
 				'original' => [
@@ -819,7 +819,7 @@ class Permissions_Helper_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function is_copy_allowed_to_be_republished_provider() {
+	public static function is_copy_allowed_to_be_republished_provider() {
 		return [
 			[
 				'post_status' => 'dp-rewrite-republish',

--- a/tests/Unit/Post_Duplicator_Test.php
+++ b/tests/Unit/Post_Duplicator_Test.php
@@ -85,7 +85,7 @@ class Post_Duplicator_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function generate_copy_title_provider() {
+	public static function generate_copy_title_provider() {
 		$data = [];
 
 		$data[] = [
@@ -186,7 +186,7 @@ class Post_Duplicator_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function generate_copy_status_provider() {
+	public static function generate_copy_status_provider() {
 		$data = [];
 
 		$data[] = [
@@ -290,7 +290,7 @@ class Post_Duplicator_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function generate_copy_author_provider() {
+	public static function generate_copy_author_provider() {
 		$data = [];
 
 		$data[] = [

--- a/tests/Unit/Post_Republisher_Test.php
+++ b/tests/Unit/Post_Republisher_Test.php
@@ -203,7 +203,7 @@ class Post_Republisher_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function change_post_copy_status_provider() {
+	public static function change_post_copy_status_provider() {
 		return [
 			[
 				[

--- a/tests/Unit/UI/Block_Editor_Test.php
+++ b/tests/Unit/UI/Block_Editor_Test.php
@@ -187,7 +187,7 @@ class Block_Editor_Test extends TestCase {
 	 *
 	 * @return array The test parameters.
 	 */
-	public function should_previously_used_keyword_assessment_run_provider() {
+	public static function should_previously_used_keyword_assessment_run_provider() {
 		return [
 			[
 				'original' => [

--- a/tests/Unit/Utils_Test.php
+++ b/tests/Unit/Utils_Test.php
@@ -27,7 +27,7 @@ class Utils_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function flatten_version_provider() {
+	public static function flatten_version_provider() {
 		return [
 			[ '3.0', '300' ],
 			[ '1.4', '140' ],
@@ -56,7 +56,7 @@ class Utils_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function addslashes_to_strings_only_provider() {
+	public static function addslashes_to_strings_only_provider() {
 		return [
 			[ "O'Reilly", "O\'Reilly" ],
 			[ 'A string with "quotes"', 'A string with \"quotes\"' ],


### PR DESCRIPTION
## Context

*

## Summary

This PR can be summarized in the following changelog entry:

* Tests: use static dataproviders

## Relevant technical choices:

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the builds pass, we're good.