### PR TITLE
Various small bug fixes

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -153,9 +153,6 @@ function duplicate_post_plugin_upgrade() {
 	}
 
 	$meta_blacklist = explode( ',', get_option( 'duplicate_post_blacklist' ) );
-	if ( $meta_blacklist === '' ) {
-		$meta_blacklist = [];
-	}
 	$meta_blacklist = array_map( 'trim', $meta_blacklist );
 	if ( in_array( '_wp_page_template', $meta_blacklist, true ) ) {
 		update_option( 'duplicate_post_copytemplate', 0 );

--- a/src/ui/column.php
+++ b/src/ui/column.php
@@ -49,7 +49,7 @@ class Column {
 					\add_filter( "manage_{$enabled_post_type}_posts_columns", [ $this, 'add_original_column' ] );
 					\add_action( "manage_{$enabled_post_type}_posts_custom_column", [ $this, 'show_original_item' ], 10, 2 );
 				}
-				\add_action( 'quick_edit_custom_box', [ $this, 'quick_edit_remove_original' ], 10, 2 );
+				\add_action( 'quick_edit_custom_box', [ $this, 'quick_edit_remove_original' ] );
 				\add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 				\add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_styles' ] );
 			}

--- a/src/ui/newsletter.php
+++ b/src/ui/newsletter.php
@@ -49,7 +49,7 @@ class Newsletter {
 		$html = '
 		<!-- Begin Newsletter Signup Form -->
 		<form method="post" id="newsletter-subscribe-form" name="newsletter-subscribe-form" novalidate>
-		' . \wp_nonce_field( 'newsletter', 'newsletter_nonce' ) . '
+		' . \wp_nonce_field( 'newsletter', 'newsletter_nonce', true, false ) . '
 		<p>' . $copy . '</p>
 		<div class="newsletter-field-group" style="display: flex; flex-direction: column">
 			<label for="newsletter-email" style="margin: 0 0 4px 0;"><strong>' . $email_label . '</strong></label>


### PR DESCRIPTION
## Context

*

## Summary

This PR can be summarized in the following changelog entry:

* Range of small bug fixes

## Relevant technical choices:

### Column::register_hooks(): bug fix

The `Column::quick_edit_remove_original()` method only expects one parameter, so no need to ask WP for 2.

### Newsletter::newsletter_signup_form(): bug fix

The `wp_nonce_field()` function by default _displays_ the field.

This means that, as things were, the nonce field would be echo'd out when the function was called + would add a `1` to the `$html` string being created.
The resulting `$html` string would not contain the nonce field and the nonce field would not be between the `<form>` tags.

Fixed by setting the `$display` parameter to `false`.

Ref: https://developer.wordpress.org/reference/functions/wp_nonce_field/

### QA: remove redundant code

The `explode()` function will always return an array, so strict comparing the return value with an empty string will never result in a passing condition.

Ref: https://www.php.net/manual/en/function.explode.php

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check that the newsletter form still works as expected
* In the plugin settings, `Display` tab, section `Show original item`, enable `In a column in the Post list` and save
* clone a post in the post list
* quick edit the copy and check that you can see `Delete reference to original item. The original item this was copied from is: <title of the original post>`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
