### PR TITLE
Composer.json: add link to security policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 	"support": {
 		"issues": "https://github.com/Yoast/duplicate-post/issues",
 		"forum": "https://wordpress.org/support/plugin/duplicate-post",
-		"source": "https://github.com/Yoast/duplicate-post"
+		"source": "https://github.com/Yoast/duplicate-post",
+		"security": "https://yoast.com/security-program/"
 	},
 	"require": {
 		"php": "^7.2.5 || ^8.0",


### PR DESCRIPTION
## Context

* Improve discoverability of security policy

## Summary

This PR can be summarized in the following changelog entry:

* Improve discoverability of security policy

## Relevant technical choices:

This is a new feature available since Composer 2.6.0, which was released a little while ago.

When this key is added, it will also show a link to the security policy on Packagist.

Refs:
* https://github.com/composer/composer/releases/tag/2.6.0
* https://github.com/composer/composer/pull/11271
* https://github.com/composer/packagist/pull/1353

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_