### PR TITLE
CS/QA: use `printf()`, not `echo sprintf()`

### DIFF
--- a/src/handlers/check-changes-handler.php
+++ b/src/handlers/check-changes-handler.php
@@ -106,7 +106,7 @@ class Check_Changes_Handler {
 		<div class="wrap">
 			<h1 class="long-header">
 			<?php
-				echo \sprintf(
+				\printf(
 					/* translators: %s: original item link (to view or edit) or title. */
 					\esc_html__( 'Compare changes of duplicated post with the original (&#8220;%s&#8221;)', 'duplicate-post' ),
 					Utils::get_edit_or_view_link( $this->original ) // phpcs:ignore WordPress.Security.EscapeOutput

--- a/src/ui/column.php
+++ b/src/ui/column.php
@@ -94,7 +94,7 @@ class Column {
 
 				$column_content = Utils::get_edit_or_view_link( $original_item );
 			}
-			echo \sprintf(
+			\printf(
 				'<span class="duplicate_post_original_link"%s>%s</span>',
 				$data_attr, // phpcs:ignore WordPress.Security.EscapeOutput
 				$column_content // phpcs:ignore WordPress.Security.EscapeOutput


### PR DESCRIPTION
## Context

* Code QA/consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code QA/consistency

## Relevant technical choices:

*

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ No functional changes.