### PR TITLE
Composer/PHPCS: update to YoastCS 3.0.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -26,6 +26,7 @@ on:
       - '.github/workflows/lint.yml'
       - '.github/workflows/test.yml'
       - 'config/**'
+      - '!config/composer/actions.php'
       - 'css/**'
       - 'js/**'
   pull_request:
@@ -50,6 +51,7 @@ on:
       - '.github/workflows/lint.yml'
       - '.github/workflows/test.yml'
       - 'config/**'
+      - '!config/composer/actions.php'
       - 'css/**'
       - 'js/**'
   # Allow manually triggering the workflow.
@@ -69,6 +71,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Determine the base branch for the file diff
+        id: base_branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "NAME=$BASE_REF" >> $GITHUB_OUTPUT
+            echo "REF=origin/$BASE_REF" >> $GITHUB_OUTPUT
+          else
+            echo 'NAME=trunk' >> $GITHUB_OUTPUT
+            echo "REF=origin/trunk" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=1 origin ${{ steps.base_branch.outputs.NAME }}
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -90,12 +108,18 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # Check the codestyle of the files.
-      # The results of the CS check will be shown inline in the PR via the CS2PR tool.
+      # Check the codestyle of the files against a threshold of expected errors and warnings.
+      - name: Check PHP code style against the thresholds
+        run: composer check-cs-thresholds
+
+      # Check the codestyle only of the files which were changed in the current branch.
+      # This step will only be executed if the threshold check exited with a failure status.
+      # The results of this CS check will be shown inline in the PR via the CS2PR tool.
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
-      - name: Check PHP code style
+      - name: Check PHP code style for the changes made in the branch only
+        if: ${{ failure() }}
         id: phpcs
-        run: composer check-cs-warnings -- --no-cache --report-full --report-checkstyle=./phpcs-report.xml
+        run: composer check-branch-cs -- ${{ steps.base_branch.outputs.REF }}
 
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,7 +8,7 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	#############################################################################
 	-->
 
@@ -39,9 +39,9 @@
 	<rule ref="Yoast">
 		<properties>
 			<!-- Set the custom test class list for all sniffs which use it in one go.
-				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+				 Ref: https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
 			-->
-			<property name="custom_test_class_whitelist" type="array">
+			<property name="custom_test_classes" type="array">
 				<element value="Yoast\WP\Duplicate_Post\Tests\Unit\TestCase"/>
 			</property>
 
@@ -51,10 +51,20 @@
 				<element value="duplicate_post"/>
 				<element value="dp_"/>
 			</property>
+
+			<property name="psr4_paths" type="array">
+				<element key="Yoast\WP\Duplicate_Post\Tests\\" value="tests/"/>
+			</property>
 		</properties>
 
 		<!-- This plugin is not dependent on YoastSEO, so the replacement function will not be available. -->
-		<exclude name="Yoast.Yoast.AlternativeFunctions.json_encode_wp_json_encode"/>
+		<exclude name="Yoast.Yoast.JsonEncodeAlternative"/>
+	</rule>
+
+	<!-- Enforce PSR1 compatible namespaces. -->
+	<rule ref="PSR1.Classes.ClassDeclaration">
+		<!-- YoastCS only applies this rule to test files. Overrule it to apply to all files. -->
+		<include-pattern>*\.php</include-pattern>
 	</rule>
 
 
@@ -98,6 +108,15 @@
 		</properties>
 	</rule>
 
+	<!-- Make sure custom capabilities are recognized. -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="copy_posts"/>
+			</property>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################
@@ -110,17 +129,7 @@
 
 	<!-- Valid usage: For testing purposes, some non-prefixed global constants are being created, which is fine. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
-	</rule>
-
-	<!-- Test code does not go into production, so security is not an issue. -->
-	<rule ref="WordPress.Security">
-		<exclude-pattern>/tests/*</exclude-pattern>
-	</rule>
-
-	<!-- These tests are not run within the context of a WP install, so overwriting globals is fine. -->
-	<rule ref="WordPress.WP.GlobalVariablesOverride">
-		<exclude-pattern>/tests/*</exclude-pattern>
+		<exclude-pattern>/tests/*/bootstrap\.php$</exclude-pattern>
 	</rule>
 
 
@@ -130,13 +139,6 @@
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################
 	-->
-
-	<!-- Temporary exclude due to a bug in YoastCS.
-		 The bug has already been fixed and this exclude can be removed once YoastCS 2.2.0
-		 has been released. -->
-	<rule ref="Yoast.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>/src/duplicate-post\.php$</exclude-pattern>
-	</rule>
 
 	<!-- The renaming of the hooks to use the namespace-like prefix is
 		 a breaking change and will be planned in to be actioned
@@ -154,21 +156,12 @@
 		<exclude-pattern>/src/handlers/save-post-handler\.php$</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.Security.NonceVerification.Recommended">
-		<exclude-pattern>/compat/gutenberg-functions\.php$</exclude-pattern>
 		<exclude-pattern>/src/post-republisher\.php$</exclude-pattern>
 		<exclude-pattern>/src/admin/options-page\.php$</exclude-pattern>
 		<exclude-pattern>/src/ui/bulk-actions\.php$</exclude-pattern>
 		<exclude-pattern>/src/ui/classic-editor\.php$</exclude-pattern>
 		<exclude-pattern>/src/watchers/(bulk|link)-actions-watcher\.php$</exclude-pattern>
 		<exclude-pattern>/src/watchers/republished-post-watcher\.php$</exclude-pattern>
-	</rule>
-
-	<!-- The below two issues will be fixed in YoastCS 3.0, after which these excludes can be removed. -->
-	<rule ref="Yoast.Commenting.FileComment.Unnecessary">
-		<exclude-pattern>/tests/*/bootstrap\.php$</exclude-pattern>
-	</rule>
-	<rule ref="Yoast.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=0",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=69",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=0",
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"roave/security-advisories": "dev-master",
 		"yoast/wp-test-utils": "^1.2.0",
-		"yoast/yoastcs": "^2.3.1"
+		"yoast/yoastcs": "^3.0"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
## Context

* CI/QA update introducing YoastCS 3.0

## Summary

This PR can be summarized in the following changelog entry:

* CI/QA update introducing YoastCS 3.0

## Relevant technical choices:

### Composer/PHPCS: update to YoastCS 3.0.0

YoastCS 3.0.0 has been released and is based on WordPressCS 3.0.0.

This commit makes the necessary updates for that:
* Composer: update the requirements.
* PHPCS ruleset:
    - Update a few sniff/property names for new names in WordPressCS 3.0.
    - Enforce strict PSR-4 for the tests.
    - Add configuration for the new `WordPress.WP.Capabilities` sniff.
    - Remove a few exclusions which are no longer needed.
    - Add a few selective exclusions for specific situations.
* GHA CS workflow: run the CS check on the latest PHP version.
        No need to run on PHP 7.4 any more as the deprecations previously encountered were all fixed.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.0.0
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0

### GH Action/cs: use the threshold/branch report

... instead of a full scan.

As there are some YoastCS 3.0 issues which still need to be solved by the teams, this changes the CS workflow to use the threshold report instead of expecting a 100% clean code base.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* If the build runs correctly and passes, we're good.