### PR TITLE
Fix Possible NULL Value of `duplicate_post_taxonomies_blacklist`

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -293,7 +293,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 			$post_taxonomies[] = 'post_format';
 		}
 
-		$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
+		$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist', [] );
 		if ( empty( $taxonomies_blacklist ) ) {
 			$taxonomies_blacklist = [];
 		}

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -155,6 +155,9 @@ function duplicate_post_plugin_upgrade() {
 	if ( empty( $taxonomies_blacklist ) ) {
 		$taxonomies_blacklist = [];
 	}
+	elseif ( ! is_array( $taxonomies_blacklist ) ) {
+		$taxonomies_blacklist = [ $taxonomies_blacklist ];
+	}
 	if ( in_array( 'post_format', $taxonomies_blacklist, true ) ) {
 		update_option( 'duplicate_post_copyformat', 0 );
 		$taxonomies_blacklist = array_diff( $taxonomies_blacklist, [ 'post_format' ] );
@@ -296,6 +299,9 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 		$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist', [] );
 		if ( empty( $taxonomies_blacklist ) ) {
 			$taxonomies_blacklist = [];
+		}
+		elseif ( ! is_array( $taxonomies_blacklist ) ) {
+			$taxonomies_blacklist = [ $taxonomies_blacklist ];
 		}
 		if ( intval( get_option( 'duplicate_post_copyformat' ) ) === 0 ) {
 			$taxonomies_blacklist[] = 'post_format';

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -294,7 +294,7 @@ function duplicate_post_copy_post_taxonomies( $new_id, $post ) {
 		}
 
 		$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
-		if ( $taxonomies_blacklist === '' ) {
+		if ( empty( $taxonomies_blacklist ) ) {
 			$taxonomies_blacklist = [];
 		}
 		if ( intval( get_option( 'duplicate_post_copyformat' ) ) === 0 ) {

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -151,8 +151,8 @@ function duplicate_post_plugin_upgrade() {
 	);
 	add_option( 'duplicate_post_show_link_in', $show_links_in_defaults );
 
-	$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist' );
-	if ( $taxonomies_blacklist === '' ) {
+	$taxonomies_blacklist = get_option( 'duplicate_post_taxonomies_blacklist', [] );
+	if ( empty( $taxonomies_blacklist ) ) {
 		$taxonomies_blacklist = [];
 	}
 	if ( in_array( 'post_format', $taxonomies_blacklist, true ) ) {


### PR DESCRIPTION
## Context

Cloning a post can cause a critical error due to the type of `get_option( 'duplicate_post_taxonomies_blacklist' )` which can be a `NULL` value.

Related Issues:
1. https://wordpress.org/support/topic/taxonomies-are-not-copied-because-duplicate_post_taxonomies_blacklist-is-null/
2. https://github.com/Yoast/duplicate-post/issues/263

<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix `duplicate_post_taxonomies_blacklist` option causing cloning errors due to inconsistent output type (array, empty string, null)

![Screenshot 2024-02-07 at 4 50 17 pm](https://github.com/Yoast/duplicate-post/assets/75835774/6222a134-6865-4f6c-80ee-d3ee4acaffc9)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error could be thrown when cloning a post because of a wrong type for the `duplicate_post_taxonomies_blacklist` option. Props to @michael-sumner.

## Relevant technical choices:

* I added some more checks, reprising some unfinished work that never made it to a PR:
  *  covering the case where the value is a string
  * covering also the upgrade routine where the same option is checked

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

It's a bit tricky to reproduce the problem because it looks like it can be caused by caching, or by pathological situations where the option value has been stored in the wrong way. We'll need to use filters to emulate those cases.

#### Reproduce the issue with NULL value

* use a clean env where Duplicate Post has never been active (otherwise, delete all the `duplicate_post_*` rows in `wp_options`)
* install the latest release (4.5)
* edit your theme's `functions.php` and add this snippet:  `add_filter( 'option_duplicate_post_taxonomies_blacklist', '__return_null' );`
* activate Duplicate Post
* see that you get `Fatal error: Uncaught Error: in_array(): Argument #2 ($haystack) must be of type array, null given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 149`
* comment out the line in `functions.php`
* visit the post list
* re-add the line to `functions.php`
* choose a post and click on "Clone"
* see that you get `Fatal error: Uncaught Error: array_diff(): Argument #2 must be of type array, null given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 303`
* comment out the line in `functions.php` before proceeding

#### Reproduce the issue with a string  value

* use a clean env where Duplicate Post has never been active (otherwise, delete all the `duplicate_post_*` rows in `wp_options`)
* install the latest release (4.5)
* edit your theme's `functions.php` and add this snippet:  `add_filter( 'option_duplicate_post_taxonomies_blacklist', function(){ return 'foo'; } );`
* activate Duplicate Post
* see that you get `Fatal error: Uncaught Error: in_array(): Argument #2 ($haystack) must be of type array, string given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 149`
* comment out the line in `functions.php`
* visit the post list
* re-add the line to `functions.php`
* choose a post and click on "Clone"
* see that you get `Fatal error: Uncaught Error: array_diff(): Argument #2 must be of type array, string given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 303`
* comment out the line in `functions.php` before proceeding

#### test the fix with NULL value

* use a clean env where Duplicate Post has never been active (otherwise, delete all the `duplicate_post_*` rows in `wp_options`)
* install this branch
* edit your theme's `functions.php` and add this snippet:  `add_filter( 'option_duplicate_post_taxonomies_blacklist', '__return_null' );`
* activate Duplicate Post
* see that you **don't** get `Fatal error: Uncaught Error: in_array(): Argument #2 ($haystack) must be of type array, null given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 149`
* visit the post list
* choose a post that is assigned to one or more categories and click on "Clone"
* see that you **don't** get `Fatal error: Uncaught Error: array_diff(): Argument #2 must be of type array, null given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 303`
* check that the copy has the same categories applied
* comment out the line in `functions.php` before proceeding

#### test the fix with with a string  value

* use a clean env where Duplicate Post has never been active (otherwise, delete all the `duplicate_post_*` rows in `wp_options`)
* install this branch
* edit your theme's `functions.php` and add this snippet:  `add_filter( 'option_duplicate_post_taxonomies_blacklist', function(){ return 'foo'; } );`
* activate Duplicate Post
* see that you **don't** get `Fatal error: Uncaught Error: in_array(): Argument #2 ($haystack) must be of type array, string given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 149`
* visit the post list
* choose a post that is assigned to one or more categories and click on "Clone"
* see that you **don´t** get  `Fatal error: Uncaught Error: array_diff(): Argument #2 must be of type array, string given
in /home/lopo/src/Yoast/plugin-development-docker/plugins/duplicate-post/admin-functions.php on line 303`
* check that the copy has the same categories applied

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant 
comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #263
