### PR TITLE
Fix notices errors with some locales

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=69",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=65",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=0",
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -95,14 +95,13 @@ class DuplicatePost {
 			return;
 		}
 
-		for ( const [ key, notice ] of Object.entries( duplicatePostNotices ) ){
-			let noticeObj = JSON.parse( notice );
-			if ( noticeObj.status && noticeObj.text ) {
+		for ( const [ key, notice ] of Object.entries( duplicatePostNotices ) ) {
+			if ( notice.status && notice.text ) {
 				dispatch( 'core/notices' ).createNotice(
-					noticeObj.status,
-					noticeObj.text,
+					notice.status,
+					notice.text,
 					{
-						isDismissible: noticeObj.isDismissible || true,
+						isDismissible: notice.isDismissible || true,
 					}
 				);
 			}

--- a/src/watchers/copied-post-watcher.php
+++ b/src/watchers/copied-post-watcher.php
@@ -110,14 +110,14 @@ class Copied_Post_Watcher {
 		if ( $this->permissions_helper->has_rewrite_and_republish_copy( $post ) ) {
 
 			$notice = [
-				'text'          => \wp_slash( $this->get_notice_text( $post ) ),
+				'text'          => $this->get_notice_text( $post ),
 				'status'        => 'warning',
 				'isDismissible' => true,
 			];
 
 			\wp_add_inline_script(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.has_rewrite_and_republish_notice = '" . \wp_json_encode( $notice ) . "';",
+				'duplicatePostNotices.has_rewrite_and_republish_notice = ' . \wp_json_encode( $notice ) . ';',
 				'before'
 			);
 		}

--- a/src/watchers/link-actions-watcher.php
+++ b/src/watchers/link-actions-watcher.php
@@ -42,9 +42,9 @@ class Link_Actions_Watcher {
 	/**
 	 * Adds vars to the removable query args.
 	 *
-	 * @param array $removable_query_args Array of query args keys.
+	 * @param array<string> $removable_query_args Array of query args keys.
 	 *
-	 * @return array The updated array of query args keys.
+	 * @return array<string> The updated array of query args keys.
 	 */
 	public function add_removable_query_args( $removable_query_args ) {
 		if ( \is_array( $removable_query_args ) ) {
@@ -113,7 +113,6 @@ class Link_Actions_Watcher {
 					\__(
 						'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", this rewritten post will replace the original post.',
 						'duplicate-post'
-
 					),
 				'status'        => 'warning',
 				'isDismissible' => true,

--- a/src/watchers/link-actions-watcher.php
+++ b/src/watchers/link-actions-watcher.php
@@ -109,19 +109,19 @@ class Link_Actions_Watcher {
 	public function add_rewrite_and_republish_block_editor_notice() {
 		if ( ! empty( $_REQUEST['rewriting'] ) ) {
 			$notice = [
-				'text'          => \wp_slash(
+				'text'          =>
 					\__(
 						'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", this rewritten post will replace the original post.',
 						'duplicate-post'
-					)
-				),
+
+					),
 				'status'        => 'warning',
 				'isDismissible' => true,
 			];
 
 			\wp_add_inline_script(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.rewriting_notice = '" . \wp_json_encode( $notice ) . "';",
+				'duplicatePostNotices.rewriting_notice = ' . \wp_json_encode( $notice ) . ';',
 				'before'
 			);
 		}

--- a/src/watchers/original-post-watcher.php
+++ b/src/watchers/original-post-watcher.php
@@ -92,14 +92,14 @@ class Original_Post_Watcher {
 		if ( $this->permissions_helper->has_original_changed( $post ) ) {
 
 			$notice = [
-				'text'          => \wp_slash( $this->get_notice_text() ),
+				'text'          => $this->get_notice_text(),
 				'status'        => 'warning',
 				'isDismissible' => true,
 			];
 
 			\wp_add_inline_script(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.has_original_changed_notice = '" . \wp_json_encode( $notice ) . "';",
+				'duplicatePostNotices.has_original_changed_notice = ' . \wp_json_encode( $notice ) . ';',
 				'before'
 			);
 		}

--- a/src/watchers/republished-post-watcher.php
+++ b/src/watchers/republished-post-watcher.php
@@ -43,9 +43,9 @@ class Republished_Post_Watcher {
 	/**
 	 * Adds vars to the removable query args.
 	 *
-	 * @param array $removable_query_args Array of query args keys.
+	 * @param array<string> $removable_query_args Array of query args keys.
 	 *
-	 * @return array The updated array of query args keys.
+	 * @return array<string> The updated array of query args keys.
 	 */
 	public function add_removable_query_args( $removable_query_args ) {
 		if ( \is_array( $removable_query_args ) ) {

--- a/src/watchers/republished-post-watcher.php
+++ b/src/watchers/republished-post-watcher.php
@@ -93,14 +93,14 @@ class Republished_Post_Watcher {
 	public function add_block_editor_notice() {
 		if ( ! empty( $_REQUEST['dprepublished'] ) ) {
 			$notice = [
-				'text'          => \wp_slash( $this->get_notice_text() ),
+				'text'          => $this->get_notice_text(),
 				'status'        => 'success',
 				'isDismissible' => true,
 			];
 
 			\wp_add_inline_script(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.republished_notice = '" . \wp_json_encode( $notice ) . "';",
+				'duplicatePostNotices.republished_notice = ' . \wp_json_encode( $notice ) . ';',
 				'before'
 			);
 		}

--- a/tests/Unit/Watchers/Copied_Post_Watcher_Test.php
+++ b/tests/Unit/Watchers/Copied_Post_Watcher_Test.php
@@ -277,7 +277,7 @@ final class Copied_Post_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_add_inline_script' )
 			->with(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.has_rewrite_and_republish_notice = '{\"text\":\"notice\",\"status\":\"warning\",\"isDismissible\":true}';",
+				'duplicatePostNotices.has_rewrite_and_republish_notice = {"text":"notice","status":"warning","isDismissible":true};',
 				'before'
 			);
 

--- a/tests/Unit/Watchers/Link_Actions_Watcher_Test.php
+++ b/tests/Unit/Watchers/Link_Actions_Watcher_Test.php
@@ -263,7 +263,7 @@ final class Link_Actions_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_add_inline_script' )
 			->with(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.rewriting_notice = '{\"text\":\"You can now start rewriting your post in this duplicate of the original post. If you click \\\"Republish\\\", this rewritten post will replace the original post.\",\"status\":\"warning\",\"isDismissible\":true}';",
+				'duplicatePostNotices.rewriting_notice = {"text":"You can now start rewriting your post in this duplicate of the original post. If you click \"Republish\", this rewritten post will replace the original post.","status":"warning","isDismissible":true};',
 				'before'
 			);
 

--- a/tests/Unit/Watchers/Original_Post_Watcher_Test.php
+++ b/tests/Unit/Watchers/Original_Post_Watcher_Test.php
@@ -200,7 +200,7 @@ final class Original_Post_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_add_inline_script' )
 			->with(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.has_original_changed_notice = '{\"text\":\"notice\",\"status\":\"warning\",\"isDismissible\":true}';",
+				'duplicatePostNotices.has_original_changed_notice = {"text":"notice","status":"warning","isDismissible":true};',
 				'before'
 			);
 

--- a/tests/Unit/Watchers/Republished_Post_Watcher_Test.php
+++ b/tests/Unit/Watchers/Republished_Post_Watcher_Test.php
@@ -161,7 +161,7 @@ final class Republished_Post_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( '\wp_add_inline_script' )
 			->with(
 				'duplicate_post_edit_script',
-				"duplicatePostNotices.republished_notice = '{\"text\":\"notice\",\"status\":\"success\",\"isDismissible\":true}';",
+				'duplicatePostNotices.republished_notice = {"text":"notice","status":"success","isDismissible":true};',
 				'before'
 			);
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where notices would not be appearing in the block editor, throwing console errors, with some locales.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the problem
* use the latest released version (or `main`)
* switch WP to Italian, this ensures that the translated string has an `'` which breaks the parsing
* keep the console open
* create a Rewrite & Republish copy of a published post
* see that when you are redirected to the Editor you don't see any notice
* see that you get a JS error in the console: `Uncaught ReferenceError: duplicatePostNotices is not defined`

#### Test the fix
* switch to this branch 
* switch WP to Italian, this ensures that the translated string has an `'`
* keep the console open
* create a Rewrite & Republish copy of a published post
* see that when you are redirected to the Editor you see a notice
  * `Ora puoi iniziare a riscrivere il tuo articolo in questo duplicato dell'originale. Se fai clic su "Ripubblica", questo articolo riscritto sostituirà l'originale.`
* see that you don't get a JS error in the console
* edit the original post
* see that when you are redirected to the Editor you see a notice
  * `È stato creato un duplicato di questo articolo. Tieni in considerazione che ogni modifica che fai a questo articolo sarà sostituita quando la versione duplicata sarà ripubblicata.`
* see that you don't get a JS error in the console
* make a change in the original post and click "Aggiorna" ("Update") 
* edit the R&R copy
* see that you see a notice
  * `L'articolo originale è stato nel frattempo modificato. Se fai clic su "Ripubblica", questo articolo riscritto sostituirà l'originale.`
* see that you don't get a JS error in the console
* change the date of the post to a future date and hit "Programma la ripubblicazione..." ("Schedule republishing")
* edit the original post
* see that when you are redirected to the Editor you see a notice
  * `È stato creato un duplicato di questo articolo, che dovrebbe sostituire questo articolo in data Maggio 18, 2024 alle ore 3:59 pm.`
* see that you don't get a JS error in the console
* edit the R&R copy
* change the date of the post to "Ora" ("Now") or to a past date and hit "Ripubblica" ("Republish")
* See that you see a notice
  * `Il tuo articolo originale è stato sostituito con l'articolo riscritto. Stai ora visualizzando l'articolo originale (riscritto).` 
* see that you don't get a JS error in the console

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
