### PR TITLE
Composer: update dev dependencies

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -109,15 +109,23 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       # Check the codestyle of the files against a threshold of expected errors and warnings.
+      # Keep track of the exit code as it determines whether to run the branch check or not.
+      # Exit code 128 means the thresholds needs to be lowered. Other exit codes imply CS errors.
       - name: Check PHP code style against the thresholds
-        run: composer check-cs-thresholds
+        id: thresholds
+        run: |
+          set +e
+          composer check-cs-thresholds
+          exitcode="$?"
+          echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
+          exit "$exitcode"
 
       # Check the codestyle only of the files which were changed in the current branch.
       # This step will only be executed if the threshold check exited with a failure status.
       # The results of this CS check will be shown inline in the PR via the CS2PR tool.
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Check PHP code style for the changes made in the branch only
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.thresholds.outputs.EXITCODE != 128 }}
         id: phpcs
         run: composer check-branch-cs -- ${{ steps.base_branch.outputs.REF }}
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"roave/security-advisories": "dev-master",
 		"yoast/wp-test-utils": "^1.2.0",
-		"yoast/yoastcs": "^3.0"
+		"yoast/yoastcs": "^3.1.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -153,6 +153,11 @@ class Actions {
 			$above_threshold = false;
 		}
 
+		$threshold_exact = true;
+		if ( \strpos( $phpcs_output, ' than the threshold, great job!' ) !== false ) {
+			$threshold_exact = false;
+		}
+
 		/*
 		 * Don't run the branch check in CI/GH Actions as it prevents the errors from being shown inline.
 		 * The GH Actions script will run this via a separate script step.
@@ -167,7 +172,15 @@ class Actions {
 			@\passthru( 'composer check-branch-cs' );
 		}
 
-		exit( ( $above_threshold === true || $return > 2 ) ? $return : 0 );
+		$exit_code = 0;
+		if ( $above_threshold === true || $return > 2 ) {
+			$exit_code = $return;
+		}
+		elseif ( $threshold_exact === false ) {
+			$exit_code = 128;
+		}
+
+		exit( $exit_code );
 	}
 
 	/**

--- a/src/watchers/link-actions-watcher.php
+++ b/src/watchers/link-actions-watcher.php
@@ -109,11 +109,10 @@ class Link_Actions_Watcher {
 	public function add_rewrite_and_republish_block_editor_notice() {
 		if ( ! empty( $_REQUEST['rewriting'] ) ) {
 			$notice = [
-				'text'          =>
-					\__(
-						'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", this rewritten post will replace the original post.',
-						'duplicate-post'
-					),
+				'text'          => \__(
+					'You can now start rewriting your post in this duplicate of the original post. If you click "Republish", this rewritten post will replace the original post.',
+					'duplicate-post'
+				),
 				'status'        => 'warning',
 				'isDismissible' => true,
 			];


### PR DESCRIPTION
## Context

* Update dev dependencies

## Summary

This PR can be summarized in the following changelog entry:

* Update dev dependencies

## Relevant technical choices:

### Composer: update dev dependencies

Nearly all dev dependencies have had new releases. This commit updates the plugin to use the new versions.

For linting, the upgrade will get us preliminary PHP 8.4 support.
For CS, the upgrades will get us improved syntax support for PHP 8.3, more documentation and a range of bug fixes.

### CS/check thresholds: require exact match for thresholds

This changes the implementation of the coding standards threshold check to require that both the `YOASTCS_THRESHOLD_ERRORS` environment variable, as well as the `YOASTCS_THRESHOLD_WARNINGS` environment variable match the current status exactly.

This prevents PR A fixing some issues and forgetting to update the threshold, which then would allow PR B to introduce new issues.

### CS: minor clean up 

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_