### PR TITLE
fix post excerpt typo

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -488,8 +488,8 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 		$cloned_child    = [
 			'ID'           => $new_attachment_id,
 			'post_title'   => $child->post_title,
-			'post_excerpt' => $child->post_excerpt,
-			'post_content' => $child->post_content,
+			'post_excerpt' => $child->post_excerpt, // Caption.
+			'post_content' => $child->post_content, // Description.
 			'post_author'  => $new_post_author->ID,
 		];
 		wp_update_post( wp_slash( $cloned_child ) );

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -489,6 +489,7 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 			'ID'           => $new_attachment_id,
 			'post_title'   => $child->post_title,
 			'post_excerpt' => $child->post_excerpt,
+			'post_content' => $child->post_content,
 			'post_author'  => $new_post_author->ID,
 		];
 		wp_update_post( wp_slash( $cloned_child ) );

--- a/admin-functions.php
+++ b/admin-functions.php
@@ -488,7 +488,7 @@ function duplicate_post_copy_attachments( $new_id, $post ) {
 		$cloned_child    = [
 			'ID'           => $new_attachment_id,
 			'post_title'   => $child->post_title,
-			'post_exceprt' => $child->post_title,
+			'post_excerpt' => $child->post_excerpt,
 			'post_author'  => $new_post_author->ID,
 		];
 		wp_update_post( wp_slash( $cloned_child ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* fix a typo for child pages post excerpt.
See Reports https://wordpress.org/support/topic/excerpt-problem-9/ and #369

Fixes #369

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where cloning an attachment did not copy its description as expected.
* Fixes a bug where cloning an attachment did not copy its caption as expected. Props to @masteradhoc.

## Relevant technical choices:

* -

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* in the Duplicate Post settings, under "Post/page elements to copy", select "Attachments" and save
* Create/edit a post
* add an image to it *by uploading a new one* 
* make sure to edit the image in the media library modal and add alt. text, caption and decription.
* save the post
* clone the post
* check the media library page: you should get 2 copies of the image you uploaded
* edit both of them and check that both have the same values for alt. text, caption and description.
  * without this PR, caption and description were not copied at all.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
