### PR TITLE
GH Actions/tests: fix up the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
       matrix:
         include:
           - php_version: "7.2"
-            wp_version: "6.2"
+            wp_version: "6.5"
             multisite: true
             coverage: true
 
@@ -143,7 +143,7 @@ jobs:
             coverage: false
 
           - php_version: "8.0"
-            wp_version: "6.2"
+            wp_version: "6.6"
             multisite: false
             coverage: false
 
@@ -153,13 +153,12 @@ jobs:
             coverage: false
 
           - php_version: "8.2"
-            wp_version: "6.3"
+            wp_version: "6.5"
             multisite: true
             coverage: false
 
-          # WP 6.4 is the earliest version which supports PHP 8.3.
           - php_version: '8.3'
-            wp_version: '6.4'
+            wp_version: '6.6'
             multisite: true
             coverage: true
 


### PR DESCRIPTION
## Context

* CI improvement

## Summary

This PR can be summarized in the following changelog entry:

* CI improvement

## Relevant technical choices:

PR #380 dropped support for WP < 6.4, but the integration test matrix had not been updated to reflect this change.

Fixed now.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build runs & passes, we're good.