### PR TITLE
Composer: prevent a lock file from being created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"composer/installers": true
 		},
-		"classmap-authoritative": true
+		"classmap-authoritative": true,
+		"lock": false
 	},
 	"scripts": {
 		"lint": [


### PR DESCRIPTION
## Context

* Improve dev experience

## Summary

This PR can be summarized in the following changelog entry:

* Improve dev experience

## Relevant technical choices:

Composer 1.10.0 introduced a `lock` config option, which, when set to `false` will prevent a `composer.lock` file from being created and will ignore it when one exists.

As for this package, none of the dependencies need to be locked, we can use this option.

It also makes life easier for contributors as they don't have to remember that for this repo they should use `composer update` instead of `composer install`. Both will now work the same.

Refs:
https://getcomposer.org/doc/06-config.md#lock


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Delete a potentially existing `composer.lock` from your local clone
* Run `composer install`
* Verify that the  `composer.lock` file was not re-created.
