### PR TITLE
GH Actions: enable linting and testing against PHP 8.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['7.2', '7.4', '8.0', '8.2', '8.3']
+        php_version: ['7.2', '7.4', '8.0', '8.4', 'nightly']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,14 +73,14 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
         include:
         - php_version: 7.2
           coverage: true
-        - php_version: 8.3
+        - php_version: 8.4
           coverage: true
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"
@@ -159,6 +159,12 @@ jobs:
 
           - php_version: '8.3'
             wp_version: '6.6'
+            multisite: false
+            coverage: false
+
+          # WP 6.7 is the earliest version which supports PHP 8.4.
+          - php_version: '8.4'
+            wp_version: '6.7'
             multisite: true
             coverage: true
 


### PR DESCRIPTION
## Context

* Test against PHP 8.4

## Summary

This PR can be summarized in the following changelog entry:

* Test against PHP 8.4

## Relevant technical choices:

* As the PHP 8.4 builds pass and the PHP 8.4 release has been out for a few months, the builds are not _allowed to fail_.
* Update PHP version on which code coverage is run (high should now be 8.4).


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.