### PR TITLE
Drop support for Php 7.2 and 7.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           coverage: none
 
       # This action also handles the caching of the Yarn dependencies.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['7.2', '7.4', '8.0', '8.4', 'nightly']
+        php_version: [ '7.4', '8.0', '8.4', 'nightly']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,12 +73,12 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php_version: ['7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
         include:
-        - php_version: 7.2
+        - php_version: 7.4
           coverage: true
         - php_version: 8.4
           coverage: true
@@ -127,12 +127,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - php_version: "7.2"
+          - php_version: "7.4"
             wp_version: "6.5"
             multisite: true
             coverage: true
 
-          - php_version: "7.3"
+          - php_version: "7.4"
             wp_version: "trunk"
             multisite: true
             coverage: false
@@ -175,9 +175,9 @@ jobs:
 
     services:
       mysql:
-        # Use MySQL 5.6 for PHP 7.2, use MySQL 5.7 for PHP 7.3 < 7.4, otherwise MySQL 8.0.
+        # Use MySQL 5.6 for PHP 7.4, use MySQL 5.7 for PHP 8.0, otherwise MySQL 8.0.
         # Also see: https://core.trac.wordpress.org/ticket/52496
-        image: mysql:${{ ( matrix.php_version == '7.2' && '5.6' ) || ( matrix.php_version < '7.4' && '5.7' ) || '8.0' }}
+        image: mysql:${{ ( matrix.php_version == '7.4' && '5.6' ) || ( matrix.php_version == '8.0' && '5.7' ) || '8.0' }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
         ports:
@@ -187,7 +187,7 @@ jobs:
     steps:
       - name: Install subversion
         run: sudo apt-get install -y subversion
-        
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"security": "https://yoast.com/security-program/"
 	},
 	"require": {
-		"php": "^7.2.5 || ^8.0",
+		"php": "^7.4 || ^8.0",
 		"composer/installers": "^1.12.0 || ^2.0"
 	},
 	"require-dev": {

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -14,7 +14,7 @@
  * Author URI:  https://yoa.st/team-yoast-duplicate
  * Text Domain: duplicate-post
  * Requires at least: 6.6
- * Requires PHP: 7.2.5
+ * Requires PHP: 7.4
  *
  * Copyright 2020-2024 Yoast BV (email : info@yoast.com)
  *

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: 				duplicate post, copy, clone
 Requires at least: 	6.6
 Tested up to: 		6.8
 Stable tag: 		4.5
-Requires PHP:		7.2.5
+Requires PHP:		7.4
 License: 			GPLv2 or later
 License URI: 		http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to drop PHP 7.2 and 7.3 compatibility.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Drops compatibility with PHP 7.2 and 7.3.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the exact same test instructions in [this](https://github.com/Yoast/wordpress-seo/pull/22077) PR.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [#401](https://github.com/Yoast/duplicate-post/issues/401)

