### PR TITLE
use safeCreateInterpolateElement

### DIFF
--- a/js/src/duplicate-post-strings.js
+++ b/js/src/duplicate-post-strings.js
@@ -1,6 +1,6 @@
 /* global duplicatePostStrings */
 
-import { createInterpolateElement } from "@wordpress/element";
+import { safeCreateInterpolateElement } from "./helpers/safe-create-interpolate-element";
 import { Button } from "@wordpress/components";
 import { __, setLocaleData } from "@wordpress/i18n";
 import { dispatch, subscribe } from "@wordpress/data";
@@ -34,7 +34,7 @@ const republishStrings = {
 
 	'Are you ready to publish?'	: __( 'Are you ready to republish your post?', 'duplicate-post' ),
 	'Double-check your settings before publishing.':
-		createInterpolateElement(
+		safeCreateInterpolateElement(
 			__( 'After republishing your changes will be merged into the original post and you\'ll be redirected there.<br /><br />Do you want to compare your changes with the original version before merging?<br /><br /><button>Save changes and compare</button>',
 				'duplicate-post' ),
 			{
@@ -49,7 +49,7 @@ const republishStrings = {
 
 	'Are you ready to schedule?' : __( 'Are you ready to schedule the republishing of your post?', 'duplicate-post' ),
 	'Your work will be published at the specified date and time.':
-		createInterpolateElement(
+		safeCreateInterpolateElement(
 			__( 'You\'re about to replace the original with this rewritten post at the specified date and time.<br /><br />Do you want to compare your changes with the original version before merging?<br /><br /><button>Save changes and compare</button>',
 				'duplicate-post' ),
 			{

--- a/js/src/helpers/safe-create-interpolate-element.js
+++ b/js/src/helpers/safe-create-interpolate-element.js
@@ -1,0 +1,17 @@
+import { createInterpolateElement } from "@wordpress/element";
+
+/**
+ * Wrapper function for `createInterpolateElement` to catch errors.
+ *
+ * @param {string} interpolatedString The interpolated string.
+ * @param {object} conversionMap The conversion map object.
+ * @returns {string} The interpolated string.
+ */
+export const safeCreateInterpolateElement = ( interpolatedString, conversionMap ) => {
+	try {
+		return createInterpolateElement( interpolatedString, conversionMap );
+	} catch ( error ) {
+		console.error( "Error in translation for:", interpolatedString, error );
+		return interpolatedString;
+	}
+};

--- a/js/src/helpers/safe-create-interpolate-element.js
+++ b/js/src/helpers/safe-create-interpolate-element.js
@@ -4,8 +4,8 @@ import { createInterpolateElement } from "@wordpress/element";
  * Wrapper function for `createInterpolateElement` to catch errors.
  *
  * @param {string} interpolatedString The interpolated string.
- * @param {object} conversionMap The conversion map object.
- * @returns {string} The interpolated string.
+ * @param {Object<string, JSX.Element>} conversionMap The conversion map object.
+ * @returns {JSX.Element|string} The interpolated element or string if it failed.
  */
 export const safeCreateInterpolateElement = ( interpolatedString, conversionMap ) => {
 	try {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds safety check to avoid breaking errors due to wrong tags order in translation.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When building the plugin, make sure you are on node 16.
* Go to posts or pages
* Hover over a post and click on `Rewrite and Republish`.
* Edit that new post and change the publish date to something in the future and click on `Schedule Republish`
* Check you see the message:
> You're about to replace the original with this rewritten post at the specified date and time.

![Screenshot 2025-05-09 at 17 24 00](https://github.com/user-attachments/assets/a9e67aa6-3583-4fd0-bded-183e9e00c2a6)

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes [Add and implement safeCreateInterpolateElement in duplicate-post #535](https://github.com/Yoast/reserved-tasks/issues/535)
