### PR TITLE
Composer: remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
 		"composer/installers": "^1.12.0 || ^2.0"
 	},
 	"require-dev": {
-		"roave/security-advisories": "dev-master",
 		"yoast/wp-test-utils": "^1.2.0",
 		"yoast/yoastcs": "^3.2.0"
 	},


### PR DESCRIPTION
## Context

* General maintenance

## Summary

This PR can be summarized in the following changelog entry:

* Removed dependency which is no longer needed

## Relevant technical choices:

The `roave/security-advisories` package was an inventive method to block installation of known insecure versions of other dependencies (via a `conflict` annotation).

As of Composer 2.9, using the `roave/security-advisories` package for this purpose is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

And while not all contributors to this repo may be using Composer 2.9+ (yet), Composer 2.9+ **_will_** be used in CI and CI failing on Composer blocking an insecure dependency offers the same level of protection as the package previously offered.

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Introduce a dependency with a known security vulnerability and run `composer install` with Composer >= 2.9 and see the install blocked by Composer.
Alternatively, run `composer audit`.