### PR TITLE
GH Actions: enable linting and testing against PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,9 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: [ '7.4', '8.0', '8.4', 'nightly']
+        php_version: [ '7.4', '8.0', '8.5', 'nightly']
+
+    continue-on-error: ${{ matrix.php_version == 'nightly' }}
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,14 +73,14 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php_version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
         include:
         - php_version: 7.4
           coverage: true
-        - php_version: 8.4
+        - php_version: 8.5
           coverage: true
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"
@@ -147,7 +147,7 @@ jobs:
             coverage: false
 
           - php_version: "8.0"
-            wp_version: "6.7"
+            wp_version: "6.8"
             multisite: false
             coverage: false
 
@@ -169,6 +169,12 @@ jobs:
           # WP 6.7 is the earliest version which supports PHP 8.4.
           - php_version: '8.4'
             wp_version: '6.7'
+            multisite: false
+            coverage: false
+
+          # WP 6.9 is the earliest version which supports PHP 8.5.
+          - php_version: '8.5'
+            wp_version: '6.9'
             multisite: true
             coverage: true
 


### PR DESCRIPTION
## Context

* PHP cross-version compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Verified compatibility with PHP up to version 8.5.

## Relevant technical choices:

* As the PHP 8.5 builds pass and the PHP 8.5 has been released last month, the builds are not _allowed to fail_, though linting against PHP "nightly" _may_ fail.
* Update PHP version on which code coverage is run (high should now be 8.5).

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_