### PR TITLE
Prevents and cleans up orphan Rewrite & Republish copies

### DIFF
--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -146,7 +146,7 @@ class Post_Republisher {
 
 		// Trigger the redirect in the Classic Editor.
 		if ( $this->is_classic_editor_post_request() ) {
-			$this->redirect( $original_post->ID, $post->ID );
+			$this->redirect( $original_post->ID );
 		}
 	}
 
@@ -445,7 +445,7 @@ class Post_Republisher {
 					'dprepublished' => 1,
 					'dpnonce'       => \wp_create_nonce( 'dp-republish' ),
 				],
-				\admin_url( 'post.php?action=edit&post=' . (int) $original_post_id )
+				\admin_url( 'post.php?action=edit&post=' . $original_post_id )
 			)
 		);
 		exit();

--- a/tests/Unit/Post_Republisher_Test.php
+++ b/tests/Unit/Post_Republisher_Test.php
@@ -119,7 +119,7 @@ final class Post_Republisher_Test extends TestCase {
 			->with( [ $this->instance, 'clean_up_after_redirect' ] );
 
 		Monkey\Actions\expectAdded( 'load-post.php' )
-			->with( [ $this->instance, 'clean_up_orphaned_copy' ], 11, 1 );
+			->with( [ $this->instance, 'clean_up_orphaned_copy' ], 11 );
 
 		Monkey\Actions\expectAdded( 'before_delete_post' )
 			->with( [ $this->instance, 'clean_up_when_copy_manually_deleted' ] );

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -937,7 +937,7 @@ final class Post_Republisher_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_republish_removes_taxonomies_when_removed_from_copy() {
+	public function test_republish_replaces_taxonomies_from_copy() {
 		$category_id = $this->factory->category->create( [ 'name' => 'Original Category' ] );
 		$tag_id      = $this->factory->tag->create( [ 'name' => 'Original Tag' ] );
 


### PR DESCRIPTION
## Context
* Rewrite & Republish copies could remain stuck in the `dp-rewrite-republish` status whenever the redirect cleanup didn’t run (for example when the editor tab was closed early), which kept the original post locked and prevented authors from starting a new Rewrite & Republish session.

## Summary
This PR can be summarized in the following changelog entry:
* Fixes a bug where Rewrite & Republish copies could remain orphaned, blocking editors from creating a new Rewrite & Republish copy for the original post.

## Relevant technical choices:
* Hooked `clean_up_orphaned_copy()` into `load-post.php` (priority 5) so any stale Rewrite & Republish copies are deleted as soon as the editor for the original post opens.
* Delete the copy immediately inside `republish()` once the original post has been updated, and keep `clean_up_after_redirect()` strictly for nonce validation (the `dpcopy` query arg is no longer needed).
* Updated the unit test to assert that the new cleanup hook is registered.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
1. In a WP test site with the plugin active, ensure “Rewrite & Republish” is enabled in Duplicate Post → Permissions.
2. Pick a published post, click “Rewrite & Republish”, edit the copy (title) in the Block Editor, and press “Republish”. After the redirect completes, confirm there is no lingering copy with the same title/status and that the “Rewrite & Republish” action is available again on the original post.
3. simulate a failure when the copy is deleted: edit your functions.php and add this snippet:
```php
add_filter( 'pre_delete_post', function( $delete, $post, $force_delete ) {
    if ( $post->post_status === 'dp-rewrite-republish' || get_post_meta( $post->ID, '_dp_original', true ) ) {
        wp_die( 'Yoast Duplicate Post: blocking deletion of post with ID ' . $post->ID );
    }
    return $delete;
}, 10, 3 );
```
4. Repeat step 2 and see that the snippet causes the operation to fail. Navigate to the post list and see the post has been republished (the title has been updated), you cannot see the R&R copy but you cannot select "Rewrite & Republish" for that post anymore.
5. **delete the snippet** or comment it out, otherwise it will prevent you to contunue.
6. Reopen the original post in the Block Editor; the stuck copy should be removed automatically and you should be able to start Rewrite & Republish again immediately.
7. Perform steps 2–6 in the Classic Editor (e.g., via the Classic Editor plugin or `?classic-editor=1`) to ensure the cleanup works across editors.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Block Editor and Classic Editor both load through `post.php`, so verifying both ensures the new `load-post.php` cleanup hook behaves in each workflow.

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

QA can test this PR by following these steps:
* 

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:
*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance
* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation
* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
