### PR TITLE
Add action hooks before and after republishing.

### DIFF
--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -257,9 +257,21 @@ class Post_Republisher {
 	 * @return void
 	 */
 	public function republish( WP_Post $post, WP_Post $original_post ) {
-		
-		\do_action( 'dp_republish_start', $post, $original_post);
-		
+
+		/**
+		 * Fires before the Rewrite & Republish copy is republished to the original post.
+		 *
+		 * This action runs before any content, taxonomies, or meta are copied from the
+		 * Rewrite & Republish copy to the original post. Use this hook to perform actions
+		 * or modifications before the republishing process begins.
+		 *
+		 * @since 4.6
+		 *
+		 * @param WP_Post $post          The Rewrite & Republish copy.
+		 * @param WP_Post $original_post The original post that will be overwritten.
+		 */
+		\do_action( 'duplicate_post_before_republish', $post, $original_post );
+
 		// Remove WordPress default filter so a new revision is not created on republish.
 		\remove_action( 'post_updated', 'wp_save_post_revision', 10 );
 
@@ -275,8 +287,21 @@ class Post_Republisher {
 
 		// Re-enable the creation of a new revision.
 		\add_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
-		
-		\do_action( 'dp_republish_done', $post, $original_post);
+
+		/**
+		 * Fires after the Rewrite & Republish copy has been republished to the original post.
+		 *
+		 * This action runs after all content, taxonomies, and meta have been copied from
+		 * the Rewrite & Republish copy to the original post. The copy is marked as republished
+		 * but has not yet been deleted. Use this hook to perform cleanup or additional
+		 * processing after the republishing is complete.
+		 *
+		 * @since 4.6
+		 *
+		 * @param WP_Post $post          The Rewrite & Republish copy.
+		 * @param WP_Post $original_post The original post that has been updated.
+		 */
+		\do_action( 'duplicate_post_after_republish', $post, $original_post );
 	}
 
 	/**

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -1428,4 +1428,34 @@ final class Post_Republisher_Test extends TestCase {
 		// This is the expected behavior based on how the duplicator works.
 		$this->assertEquals( 'original_value', \get_post_meta( $original->ID, 'custom_meta_to_remove', true ) );
 	}
+
+	/**
+	 * Tests that duplicate_post_before_republish is fired before duplicate_post_after_republish.
+	 *
+	 * @covers ::republish
+	 *
+	 * @return void
+	 */
+	public function test_republish_fires_hooks_in_correct_order() {
+		$action_order    = [];
+		$before_callback = static function () use ( &$action_order ) {
+			$action_order[] = 'before';
+		};
+		$after_callback  = static function () use ( &$action_order ) {
+			$action_order[] = 'after';
+		};
+
+		\add_action( 'duplicate_post_before_republish', $before_callback );
+		\add_action( 'duplicate_post_after_republish', $after_callback );
+
+		$original = $this->create_original_post();
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		$this->instance->republish( $copy, $original );
+
+		\remove_action( 'duplicate_post_before_republish', $before_callback );
+		\remove_action( 'duplicate_post_after_republish', $after_callback );
+
+		$this->assertSame( [ 'before', 'after' ], $action_order );
+	}
 }


### PR DESCRIPTION
## Context

This PR introduces two new action hooks for the Rewrite & Republish feature: `duplicate_post_before_republish` and `duplicate_post_after_republish`. These hooks allow developers to execute custom code before and after a Rewrite & Republish copy is merged back into the original post.

## Summary

This PR can be summarized in the following changelog entry:

* Adds `duplicate_post_before_republish` and `duplicate_post_after_republish` action hooks fired before and after republishing. Props to @piscis.

## Relevant technical choices:

* The `duplicate_post_before_republish` hook fires before any content, taxonomies, or meta are copied from the copy to the original post.
* The `duplicate_post_after_republish` hook fires after all content has been republished but before the copy is deleted.
* Both hooks receive two parameters: the copy `WP_Post` object and the original `WP_Post` object.
* Follows the same naming convention as standard WP hooks.
* Hooks are documented with full PHPDoc blocks including `@since 4.6` tags.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Testing new hooks work correctly
- Add the following code to a test plugin or theme's functions.php:
```php
add_action( 'duplicate_post_before_republish', function( $copy, $original ) {
    error_log( 'Before republish - Copy ID: ' . $copy->ID . ', Original ID: ' . $original->ID );
}, 10, 2 );

add_action( 'duplicate_post_after_republish', function( $copy, $original ) {
    error_log( 'After republish - Copy ID: ' . $copy->ID . ', Original ID: ' . $original->ID );
}, 10, 2 );
```
- Enable `WP_DEBUG` and `WP_DEBUG_LOG` in wp-config.php
- Create a published post
- Use Rewrite & Republish to create an editable copy
- Make changes to the copy
- Republish the copy to the original
- Check the debug.log file:
  - "Before republish" should be logged first
  - "After republish" should be logged second
  - Both should contain the correct post IDs

#### Testing scheduled republish
- Create a published post
- Use Rewrite & Republish to create an editable copy
- Schedule the copy to be published in the future
- Wait for the scheduled time (or manually trigger cron)
- Verify both hooks are fired in the correct order

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/custom post types
* [x] Changes should be tested on different editors (Block/Classic)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [ ] QA should use the same steps as above.

NA, just adding hooks for external use.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

## UI changes

* [ ] This PR changes the UI in the plugin.

## Documentation

* [x] I have written documentation for this change. PHPDoc blocks have been added for both hooks.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added integration tests to verify the hooks fire correctly and in the correct order

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes #
