### PR TITLE
CS: fix up after recent merge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=71",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=57",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=0",
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -146,7 +146,7 @@ class Post_Republisher {
 			\wp_die(
 				\esc_html__( 'You are not allowed to republish this post.', 'duplicate-post' ),
 				\esc_html__( 'Permission denied', 'duplicate-post' ),
-				[ 'response' => 403 ]
+				[ 'response' => 403 ],
 			);
 		}
 

--- a/src/watchers/bulk-actions-watcher.php
+++ b/src/watchers/bulk-actions-watcher.php
@@ -74,10 +74,10 @@ class Bulk_Actions_Watcher {
 						'%s item skipped due to insufficient permissions.',
 						'%s items skipped due to insufficient permissions.',
 						$skipped_posts,
-						'duplicate-post'
-					)
+						'duplicate-post',
+					),
 				) . '</p></div>',
-				\esc_html( $skipped_posts )
+				\esc_html( $skipped_posts ),
 			);
 		}
 	}
@@ -114,10 +114,10 @@ class Bulk_Actions_Watcher {
 						'%s item skipped due to insufficient permissions.',
 						'%s items skipped due to insufficient permissions.',
 						$skipped_posts,
-						'duplicate-post'
-					)
+						'duplicate-post',
+					),
 				) . '</p></div>',
-				\esc_html( $skipped_posts )
+				\esc_html( $skipped_posts ),
 			);
 		}
 	}

--- a/tests/Unit/Handlers/Bulk_Handler_Test.php
+++ b/tests/Unit/Handlers/Bulk_Handler_Test.php
@@ -60,12 +60,12 @@ final class Bulk_Handler_Test extends TestCase {
 	public function test_constructor() {
 		$this->assertInstanceOf(
 			Post_Duplicator::class,
-			$this->getPropertyValue( $this->instance, 'post_duplicator' )
+			$this->getPropertyValue( $this->instance, 'post_duplicator' ),
 		);
 
 		$this->assertInstanceOf(
 			Permissions_Helper::class,
-			$this->getPropertyValue( $this->instance, 'permissions_helper' )
+			$this->getPropertyValue( $this->instance, 'permissions_helper' ),
 		);
 	}
 
@@ -138,7 +138,7 @@ final class Bulk_Handler_Test extends TestCase {
 			->andReturnUsing(
 				static function ( $key, $value, $url ) {
 					return $url . ( ( \strpos( $url, '?' ) === false ) ? '?' : '&' ) . $key . '=' . $value;
-				}
+				},
 			);
 
 		$result = $this->instance->clone_bulk_action_handler( $redirect_to, 'duplicate_post_bulk_clone', [ 1, 2 ] );
@@ -245,7 +245,7 @@ final class Bulk_Handler_Test extends TestCase {
 			->andReturnUsing(
 				static function ( $key, $value, $url ) {
 					return $url . ( ( \strpos( $url, '?' ) === false ) ? '?' : '&' ) . $key . '=' . $value;
-				}
+				},
 			);
 
 		$result = $this->instance->clone_bulk_action_handler( $redirect_to, 'duplicate_post_bulk_clone', [ 1 ] );
@@ -314,7 +314,7 @@ final class Bulk_Handler_Test extends TestCase {
 			->andReturnUsing(
 				static function ( $key, $value, $url ) {
 					return $url . ( ( \strpos( $url, '?' ) === false ) ? '?' : '&' ) . $key . '=' . $value;
-				}
+				},
 			);
 
 		$result = $this->instance->rewrite_bulk_action_handler( $redirect_to, 'duplicate_post_bulk_rewrite_republish', [ 1, 2 ] );

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -980,7 +980,7 @@ final class Post_Republisher_Test extends TestCase {
 				'post_title'   => 'Admin Post',
 				'post_content' => 'Admin content.',
 				'post_author'  => $admin_user_id,
-			]
+			],
 		);
 
 		$copy = $this->create_rewrite_and_republish_copy( $original );
@@ -990,7 +990,7 @@ final class Post_Republisher_Test extends TestCase {
 			[
 				'ID'          => $copy->ID,
 				'post_status' => 'dp-rewrite-republish',
-			]
+			],
 		);
 		$copy = \get_post( $copy->ID );
 


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

PR #452 introduced a number of new, auto-fixable CS issues after the upgrade to YoastCS 3.3.0.

These should have been (auto-)fixed. Instead the CS threshold was raised without justification. /cc @leonidasmi 

Fixed now.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_