### PR TITLE
Fix republishing with metaboxes.

### DIFF
--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -270,8 +270,11 @@ final class Post_Republisher_Test extends TestCase {
 		// Verify the original is still published.
 		$this->assertEquals( 'publish', $updated_original->post_status );
 
-		// Verify the copy is deleted after republishing.
-		$this->assertNull( \get_post( $copy->ID ) );
+		// Verify the copy is NOT deleted by republish() - deletion is handled separately.
+		$this->assertNotNull( \get_post( $copy->ID ) );
+
+		// Verify the copy was marked as republished.
+		$this->assertEquals( '1', \get_post_meta( $copy->ID, '_dp_has_been_republished', true ) );
 	}
 
 	/**
@@ -1040,13 +1043,16 @@ final class Post_Republisher_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the full Rewrite & Republish workflow from start to finish.
+	 * Tests the Rewrite & Republish workflow updates original content.
+	 *
+	 * Note: This test verifies that republish() updates the original post content.
+	 * The copy deletion is handled separately by delete_copy() and tested in
+	 * test_full_rewrite_and_republish_workflow_with_delete().
 	 *
 	 * @covers ::republish
 	 * @covers ::republish_post_elements
 	 * @covers ::republish_post_taxonomies
 	 * @covers ::republish_post_meta
-	 * @covers ::delete_copy
 	 *
 	 * @return void
 	 */
@@ -1088,9 +1094,11 @@ final class Post_Republisher_Test extends TestCase {
 		$this->assertEquals( 'Rewritten content.', $updated_original->post_content );
 		$this->assertEquals( 'publish', $updated_original->post_status );
 
-		// Step 6: Verify the copy is deleted and meta is cleaned up.
-		$this->assertNull( \get_post( $copy->ID ) );
-		$this->assertEmpty( \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
+		// Step 6: Verify the copy is NOT deleted by republish() - deletion is separate.
+		$this->assertNotNull( \get_post( $copy->ID ) );
+
+		// Verify the copy was marked as republished.
+		$this->assertEquals( '1', \get_post_meta( $copy->ID, '_dp_has_been_republished', true ) );
 	}
 
 	/**
@@ -1313,36 +1321,22 @@ final class Post_Republisher_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that republish still updates original even if delete_copy fails.
+	 * Tests that delete_copy cleans up meta even if wp_delete_post fails.
 	 *
-	 * This verifies the behavior when wp_delete_post() fails during republish.
-	 * The original post should still be updated, and the meta cleanup should still happen.
+	 * This verifies the behavior when wp_delete_post() fails during delete_copy().
+	 * The meta cleanup should still happen even if the post is not actually deleted.
 	 *
-	 * @covers ::republish
 	 * @covers ::delete_copy
-	 * @covers ::republish_post_elements
 	 *
 	 * @return void
 	 */
-	public function test_republish_updates_original_even_if_delete_fails() {
-		$original = $this->create_original_post(
-			[
-				'post_title'   => 'Original Title',
-				'post_content' => 'Original content.',
-			],
-		);
+	public function test_delete_copy_cleans_meta_even_if_wp_delete_post_fails() {
+		$original = $this->create_original_post();
 		$copy     = $this->create_rewrite_and_republish_copy( $original );
 		$copy_id  = $copy->ID;
 
-		// Update copy content.
-		\wp_update_post(
-			[
-				'ID'           => $copy->ID,
-				'post_title'   => 'Updated Title',
-				'post_content' => 'Updated content.',
-			],
-		);
-		$copy = \get_post( $copy->ID );
+		// Verify the meta exists before deletion.
+		$this->assertEquals( $copy_id, (int) \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
 
 		// Prevent deletion by filtering pre_delete_post.
 		$prevent_deletion = static function ( $delete, $post ) use ( $copy_id ) {
@@ -1353,16 +1347,11 @@ final class Post_Republisher_Test extends TestCase {
 		};
 		\add_filter( 'pre_delete_post', $prevent_deletion, 10, 2 );
 
-		// Republish - delete will fail but republish should still work.
-		$this->instance->republish( $copy, $original );
+		// Call delete_copy - wp_delete_post will fail but meta cleanup should still happen.
+		$this->instance->delete_copy( $copy_id, $original->ID );
 
 		// Remove the filter.
 		\remove_filter( 'pre_delete_post', $prevent_deletion, 10 );
-
-		// Verify the original was still updated despite delete failure.
-		$updated_original = \get_post( $original->ID );
-		$this->assertEquals( 'Updated Title', $updated_original->post_title );
-		$this->assertEquals( 'Updated content.', $updated_original->post_content );
 
 		// Verify the copy still exists (because deletion failed).
 		$still_existing_copy = \get_post( $copy_id );
@@ -1370,9 +1359,6 @@ final class Post_Republisher_Test extends TestCase {
 
 		// Verify the meta was still cleaned up from the original.
 		$this->assertEmpty( \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
-
-		// Verify the copy was marked as republished.
-		$this->assertEquals( '1', \get_post_meta( $copy_id, '_dp_has_been_republished', true ) );
 
 		// Clean up manually.
 		\wp_delete_post( $copy_id, true );
@@ -1484,9 +1470,11 @@ final class Post_Republisher_Test extends TestCase {
 	 */
 	public function test_clean_up_after_redirect_dies_with_invalid_nonce() {
 		$original = $this->create_original_post();
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
 
 		// Set the redirect parameters with an invalid nonce.
 		$_GET['dprepublished'] = '1';
+		$_GET['dpcopy']        = $copy->ID;
 		$_GET['post']          = $original->ID;
 		$_GET['dpnonce']       = 'invalid_nonce';
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput,WordPress.Security.NonceVerification -- Setting up test data.
@@ -1498,6 +1486,6 @@ final class Post_Republisher_Test extends TestCase {
 		$this->instance->clean_up_after_redirect();
 
 		// Clean up (may not be reached due to exception).
-		unset( $_GET['dprepublished'], $_GET['post'], $_GET['dpnonce'], $_REQUEST['dpnonce'] );
+		unset( $_GET['dprepublished'], $_GET['dpcopy'], $_GET['post'], $_GET['dpnonce'], $_REQUEST['dpnonce'] );
 	}
 }


### PR DESCRIPTION
## Context

Partial revert of #447 to make it work with metaboxes.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes Rewrite & Republish workflow deleting the copy before metaboxes can save their data.

## Relevant technical choices:

* **Deferred copy deletion**: Instead of deleting the copy immediately in `republish()`, the copy is now deleted again in `clean_up_after_redirect()`. This ensures that when WP processes the POST request, custom metaboxes can still read data from the copy and save it to the original post.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Basic Rewrite & Republish workflow
1. Create and publish a post
2. Click "Rewrite & Republish" to create a copy
3. Edit the copy and make changes to the content
4. Click "Republish"
5. Verify that:
   - You are redirected to the original post edit screen
   - The original post contains the updated content
   - The copy has been deleted

#### With custom metaboxes (main use case)
1. Install a plugin that adds custom metaboxes: Yoast SEO will do the job
2. Create and publish a post with custom metabox data, e.g. the focus keyphrase "original keyphrase"
3. Click "Rewrite & Republish" to create a copy
4. Edit the copy and modify the custom metabox fields, e.g. "new keyphrase", but **don't save**
5. Click "Republish" before an autosave is triggered
6. Verify that:
   - The custom metabox data is properly saved to the original post, e.g. you can see "new keyphrase"
   - The copy has been deleted after the redirect

#### Classic Editor specific test
1. Disable Gutenberg or edit a post in Classic Editor mode
2. Create a Rewrite & Republish copy
3. Make changes in the copy
4. Click "Republish"
5. Verify the redirect contains both `dprepublished` and `dpcopy` parameters
6. Verify the copy is deleted after redirect

#### Cleanup of orphan copies
Test #447 again:

1. In a WP test site with the plugin active, ensure “Rewrite & Republish” is enabled in Duplicate Post → Permissions.
2. Pick a published post, click “Rewrite & Republish”, edit the copy (title) in the Block Editor, and press “Republish”. After the redirect completes, confirm there is no lingering copy with the same title/status and that the “Rewrite & Republish” action is available again on the original post.
3. simulate a failure when the copy is deleted: edit your functions.php and add this snippet:
```php
add_filter( 'pre_delete_post', function( $delete, $post, $force_delete ) {
    if ( $post->post_status === 'dp-rewrite-republish' || get_post_meta( $post->ID, '_dp_original', true ) ) {
        wp_die( 'Yoast Duplicate Post: blocking deletion of post with ID ' . $post->ID );
    }
    return $delete;
}, 10, 3 );
```
4. Repeat step 2 and see that the snippet causes the operation to fail. Navigate to the post list and see the post has been republished (the title has been updated), you cannot see the R&R copy but you cannot select "Rewrite & Republish" for that post anymore.
5. **delete the snippet** or comment it out, otherwise it will prevent you to contunue.
6. Reopen the original post in the Block Editor; the stuck copy should be removed automatically and you should be able to start Rewrite & Republish again immediately.
7. Perform steps 2–6 in the Classic Editor (e.g., via the Classic Editor plugin or `?classic-editor=1`) to ensure the cleanup works across editors.



#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/custom post types
* [x] Changes should be tested on Classic Editor
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above, with particular focus on plugins that use custom metaboxes.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

## UI changes

* [ ] This PR changes the UI in the plugin.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have updated integration tests to verify the new behavior

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes #
