### PR TITLE
QA: use the most specific PHPUnit assertion possible [2]

### DIFF
--- a/tests/Unit/Admin/Options_Form_Generator_Test.php
+++ b/tests/Unit/Admin/Options_Form_Generator_Test.php
@@ -194,7 +194,7 @@ final class Options_Form_Generator_Test extends TestCase {
 			'option_1' => [],
 		];
 
-		$this->assertEmpty( $this->instance->generate_options_input( $options ) );
+		$this->assertSame( '', $this->instance->generate_options_input( $options ) );
 	}
 
 	/**

--- a/tests/Unit/Admin/Options_Test.php
+++ b/tests/Unit/Admin/Options_Test.php
@@ -141,7 +141,7 @@ final class Options_Test extends TestCase {
 	public function test_get_options_for_non_existing_tab() {
 		$options = $this->instance->get_options_for_tab( 'tab3' );
 
-		$this->assertEmpty( $options );
+		$this->assertSame( [], $options );
 	}
 
 	/**
@@ -154,7 +154,7 @@ final class Options_Test extends TestCase {
 	public function test_get_options_for_non_existing_fieldset() {
 		$options = $this->instance->get_options_for_tab( 'tab1', 'fieldset2' );
 
-		$this->assertEmpty( $options );
+		$this->assertSame( [], $options );
 	}
 
 	/**
@@ -191,6 +191,6 @@ final class Options_Test extends TestCase {
 	public function test_get_invalid_option() {
 		$options = $this->instance->get_option( 'option_4' );
 
-		$this->assertEmpty( $options );
+		$this->assertSame( [], $options );
 	}
 }

--- a/tests/WP/Admin_Functions_Test.php
+++ b/tests/WP/Admin_Functions_Test.php
@@ -1192,7 +1192,7 @@ final class Admin_Functions_Test extends TestCase {
 		$new_tags       = \wp_get_post_tags( $new_id );
 
 		$this->assertContains( $category_id, $new_categories );
-		$this->assertEmpty( $new_tags );
+		$this->assertSame( [], $new_tags );
 	}
 
 	/**
@@ -1226,7 +1226,7 @@ final class Admin_Functions_Test extends TestCase {
 		$new_id = \duplicate_post_create_duplicate( $original );
 
 		// Thumbnail should NOT be copied when disabled.
-		$this->assertEmpty( \get_post_meta( $new_id, '_thumbnail_id', true ) );
+		$this->assertSame( '', \get_post_meta( $new_id, '_thumbnail_id', true ) );
 	}
 
 	/**

--- a/tests/WP/Handlers/Rest_API_Handler_Test.php
+++ b/tests/WP/Handlers/Rest_API_Handler_Test.php
@@ -118,7 +118,7 @@ final class Rest_API_Handler_Test extends TestCase {
 		$this->assertTrue( $data['success'] );
 
 		// Verify the meta is removed.
-		$this->assertEmpty( \get_post_meta( $copy_post, '_dp_original', true ) );
+		$this->assertSame( '', \get_post_meta( $copy_post, '_dp_original', true ) );
 	}
 
 	/**

--- a/tests/WP/Handlers/Save_Post_Handler_Test.php
+++ b/tests/WP/Handlers/Save_Post_Handler_Test.php
@@ -153,7 +153,7 @@ final class Save_Post_Handler_Test extends TestCase {
 		$this->instance->delete_on_save_post( $copy_post );
 
 		// Verify the meta is removed.
-		$this->assertEmpty( \get_post_meta( $copy_post, '_dp_original', true ) );
+		$this->assertSame( '', \get_post_meta( $copy_post, '_dp_original', true ) );
 	}
 
 	/**

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -355,7 +355,7 @@ final class Post_Republisher_Test extends TestCase {
 		$this->assertNull( \get_post( $copy_id ) );
 
 		// Verify the meta is cleaned up from the original.
-		$this->assertEmpty( \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
+		$this->assertSame( '', \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
 	}
 
 	/**
@@ -429,7 +429,7 @@ final class Post_Republisher_Test extends TestCase {
 		$this->assertNull( \get_post( $copy->ID ) );
 
 		// Verify meta cleanup.
-		$this->assertEmpty( \get_post_meta( $original_id, '_dp_has_rewrite_republish_copy', true ) );
+		$this->assertSame( '', \get_post_meta( $original_id, '_dp_has_rewrite_republish_copy', true ) );
 	}
 
 	/**
@@ -963,7 +963,7 @@ final class Post_Republisher_Test extends TestCase {
 
 		// Note: WordPress may assign default category.
 		$this->assertNotContains( $category_id, $updated_categories );
-		$this->assertEmpty( $updated_tags );
+		$this->assertSame( [], $updated_tags );
 	}
 
 	/**
@@ -1280,7 +1280,7 @@ final class Post_Republisher_Test extends TestCase {
 		$this->instance->clean_up_when_copy_manually_deleted( $copy->ID );
 
 		// Verify the meta is removed from the original.
-		$this->assertEmpty( \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
+		$this->assertSame( '', \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
 	}
 
 	/**
@@ -1358,7 +1358,7 @@ final class Post_Republisher_Test extends TestCase {
 		$this->assertNotNull( $still_existing_copy );
 
 		// Verify the meta was still cleaned up from the original.
-		$this->assertEmpty( \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
+		$this->assertSame( '', \get_post_meta( $original->ID, '_dp_has_rewrite_republish_copy', true ) );
 
 		// Clean up manually.
 		\wp_delete_post( $copy_id, true );


### PR DESCRIPTION

## Context

* Improve tests

## Summary

This PR can be summarized in the following changelog entry:

* Improve tests

## Relevant technical choices:

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available have been extended hugely over the years.

To have the most reliable tests, the most specific assertion should be used.

Most notably, this changes calls to `assertEmpty()` to different assertions as `assertEmpty()` is a completely type-loose assertion.

Refs:
* https://phpunit.de/manual/9.6/en/appendixes.assertions.html#appendixes.assertions.assertEmpty


@enricobattocchi Tagging you as reviewer to verify that the updated assertions are documenting the intended behaviour of the application (and not accidental behaviour). Feel free to change/fix any assertions you deem incorrect.


## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_