### PR TITLE
Set the WordPress tested up to version to 7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 Yoast Duplicate Post
 =========
 Requires at least: 	6.8
-Tested up to: 		6.9
+Tested up to: 		7.0
 Requires PHP: 7.4
 
 Changelog

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: 		yoast, lopo
 Donate link: 		https://yoast.com/wordpress/plugins/duplicate-post/
 Tags: 				duplicate post, copy, clone
 Requires at least: 	6.8
-Tested up to: 		6.9
+Tested up to: 		7.0
 Stable tag: 		4.6
 Requires PHP:		7.4
 License: 			GPLv2 or later


### PR DESCRIPTION
## Context

Bump the WordPress tested up to version to 7.0 for the upcoming WordPress 7.0 release.

## Summary

This PR can be summarized in the following changelog entry:

* Sets the _WordPress tested up to_ version to 7.0.

## Relevant technical choices:

*

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unittests to verify the code works as intended.

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes https://github.com/Yoast/wordpress-seo/issues/23093