### PR TITLE
WP 7.1: Fix Rewrite & Republish race conditions with Real-Time Collaboration

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -249,6 +249,56 @@ class DuplicatePost {
 			wasSavingMetaboxes = completed.isSavingMetaBoxes;
 			wasAutoSavingPost  = completed.isAutosavingPost;
 		} );
+
+		// When another collaborator republishes, the copy is deleted server-side.
+		// The RTC status change may not propagate (User A navigates away too quickly),
+		// so periodically check if the copy still exists via the REST API.
+		this.detectCopyDeletion();
+	}
+
+	/**
+	 * Periodically checks if the R&R copy still exists.
+	 *
+	 * When another collaborator republishes, the copy is deleted after cleanup.
+	 * A 404 response means the copy is gone and we should redirect to the original.
+	 *
+	 * @returns {void}
+	 */
+	detectCopyDeletion() {
+		const originalEditUrl = duplicatePost.originalItem?.editUrl;
+		if ( ! originalEditUrl || ! duplicatePost.restBase ) {
+			return;
+		}
+
+		const path = `/wp/v2/${ duplicatePost.restBase }/${ duplicatePost.postId }?_fields=id,status&context=edit`;
+
+		const redirectToOriginal = () => {
+			clearInterval( interval );
+			dispatch( 'core/notices' ).createNotice(
+				'info',
+				__( 'Another user has republished this post. Redirecting to the original…', 'duplicate-post' ),
+				{ isDismissible: false, type: 'snackbar' },
+			);
+			const separator = originalEditUrl.includes( '?' ) ? '&' : '?';
+			setTimeout( () => window.location.assign( originalEditUrl + separator + 'dpcollabredirected=1' ), 3000 );
+		};
+
+		const checkCopy = async () => {
+			try {
+				const response = await apiFetch( { path } );
+
+				// The copy was republished but not yet cleaned up.
+				if ( response.status === 'dp-rewrite-republish' || response.status === 'trash' ) {
+					redirectToOriginal();
+				}
+			} catch {
+				// 404 or 403 — the copy was deleted.
+				redirectToOriginal();
+			}
+		};
+
+		const interval = setInterval( checkCopy, 2000 );
+		checkCopy();
 	}
 
 	/**

--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -1,12 +1,12 @@
 /* global duplicatePost, duplicatePostNotices */
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { registerPlugin } from "@wordpress/plugins";
 import { PluginDocumentSettingPanel, PluginPostStatusInfo } from "@wordpress/editor";
 import { Fragment } from "@wordpress/element";
 import { Button, ExternalLink, Modal } from '@wordpress/components';
 import { __ } from "@wordpress/i18n";
-import { select, subscribe, dispatch } from "@wordpress/data";
+import { select, subscribe, dispatch, useSelect } from "@wordpress/data";
 import apiFetch from "@wordpress/api-fetch";
 import { redirectOnSaveCompletion } from "./duplicate-post-functions";
 
@@ -123,13 +123,62 @@ function DuplicatePostPanel() {
  *
  * @returns {JSX.Element|null} The rendered component or null.
  */
+/**
+ * Interval in milliseconds for polling the R&R copy meta.
+ *
+ * The R&R copy is created via a server-side admin action, so the meta change
+ * does not enter the RTC CRDT document. Periodic cache invalidation ensures
+ * the editor refetches the entity record and picks up the change.
+ *
+ * @type {number}
+ */
+const RR_COPY_POLL_INTERVAL = 15000;
+
 function DuplicatePostRender() {
 	// Don't try to render anything if there is no store.
 	if ( ! select( 'core/editor' ) || ! ( wp.editor && wp.editor.PluginPostStatusInfo ) ) {
 		return null;
 	}
 
-	const currentPostStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+	const { currentPostStatus, hasRewriteAndRepublishCopy, postType, postId } = useSelect( ( sel ) => {
+		const editor   = sel( 'core/editor' );
+		const type     = editor.getCurrentPostType();
+		const id       = editor.getCurrentPostId();
+		const record   = sel( 'core' ).getEntityRecord( 'postType', type, id );
+
+		return {
+			currentPostStatus: editor.getEditedPostAttribute( 'status' ),
+			hasRewriteAndRepublishCopy: !! record?.meta?._dp_has_rewrite_republish_copy,
+			postType: type,
+			postId: id,
+		};
+	}, [] );
+
+	const prevHasRRCopy = useRef( hasRewriteAndRepublishCopy );
+
+	// Periodically invalidate the entity record cache to detect server-side
+	// meta changes (e.g. when another user creates an R&R copy via admin action).
+	useEffect( () => {
+		if ( hasRewriteAndRepublishCopy || ! postType || ! postId ) {
+			return;
+		}
+		const interval = setInterval( () => {
+			dispatch( 'core' ).invalidateResolution( 'getEntityRecord', [ 'postType', postType, postId ] );
+		}, RR_COPY_POLL_INTERVAL );
+		return () => clearInterval( interval );
+	}, [ hasRewriteAndRepublishCopy, postType, postId ] );
+
+	// Notify the user when another collaborator creates an R&R copy.
+	useEffect( () => {
+		if ( hasRewriteAndRepublishCopy && ! prevHasRRCopy.current ) {
+			dispatch( 'core/notices' ).createNotice(
+				'info',
+				__( 'Another user has started a Rewrite & Republish for this post.', 'duplicate-post' ),
+				{ isDismissible: true, type: 'snackbar' },
+			);
+		}
+		prevHasRRCopy.current = hasRewriteAndRepublishCopy;
+	}, [ hasRewriteAndRepublishCopy ] );
 
 	return (
 		<Fragment>
@@ -146,7 +195,7 @@ function DuplicatePostRender() {
 							</Button>
 						</PluginPostStatusInfo>
 					}
-					{ ( currentPostStatus === 'publish' && duplicatePost.rewriteAndRepublishLink !== '' && duplicatePost.showLinks.rewrite_republish === '1' ) &&
+					{ ( currentPostStatus === 'publish' && ! hasRewriteAndRepublishCopy && duplicatePost.rewriteAndRepublishLink !== '' && duplicatePost.showLinks.rewrite_republish === '1' ) &&
 						<PluginPostStatusInfo>
 							<Button
 								variant="secondary"

--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -291,9 +291,12 @@ class DuplicatePost {
 				if ( response.status === 'dp-rewrite-republish' || response.status === 'trash' ) {
 					redirectToOriginal();
 				}
-			} catch {
-				// 404 or 403 — the copy was deleted.
-				redirectToOriginal();
+			} catch ( error ) {
+				// Only redirect on confirmed deletion/permission errors, not transient network failures.
+				const status = error?.data?.status ?? error?.status;
+				if ( status === 404 || status === 410 || status === 403 ) {
+					redirectToOriginal();
+				}
 			}
 		};
 

--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -154,7 +154,7 @@ class Post_Duplicator {
 		// permission check before either has set the meta.
 		$claimed = \add_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', 'pending', true );
 		if ( ! $claimed ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'duplicate_post_already_has_copy',
 				\__( 'A Rewrite & Republish copy already exists for this post.', 'duplicate-post' ),
 			);

--- a/src/post-duplicator.php
+++ b/src/post-duplicator.php
@@ -149,6 +149,17 @@ class Post_Duplicator {
 	 * @return int|WP_Error The copy ID, or a WP_Error object on failure.
 	 */
 	public function create_duplicate_for_rewrite_and_republish( WP_Post $post ) {
+		// Claim the slot on the original before creating the copy to prevent
+		// a race condition where two concurrent requests both pass the
+		// permission check before either has set the meta.
+		$claimed = \add_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', 'pending', true );
+		if ( ! $claimed ) {
+			return new \WP_Error(
+				'duplicate_post_already_has_copy',
+				\__( 'A Rewrite & Republish copy already exists for this post.', 'duplicate-post' ),
+			);
+		}
+
 		$options  = [
 			'copy_title'      => true,
 			'copy_date'       => true,
@@ -164,14 +175,18 @@ class Post_Duplicator {
 
 		$new_post_id = $this->create_duplicate( $post, $options );
 
-		if ( ! \is_wp_error( $new_post_id ) ) {
-			$this->copy_post_taxonomies( $new_post_id, $post, $options );
-			$this->copy_post_meta_info( $new_post_id, $post, $options );
-
-			\update_post_meta( $new_post_id, '_dp_is_rewrite_republish_copy', 1 );
-			\update_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', $new_post_id );
-			\update_post_meta( $new_post_id, '_dp_creation_date_gmt', \current_time( 'mysql', 1 ) );
+		if ( \is_wp_error( $new_post_id ) ) {
+			// Roll back the claim if copy creation failed.
+			\delete_post_meta( $post->ID, '_dp_has_rewrite_republish_copy' );
+			return $new_post_id;
 		}
+
+		$this->copy_post_taxonomies( $new_post_id, $post, $options );
+		$this->copy_post_meta_info( $new_post_id, $post, $options );
+
+		\update_post_meta( $new_post_id, '_dp_is_rewrite_republish_copy', 1 );
+		\update_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', $new_post_id );
+		\update_post_meta( $new_post_id, '_dp_creation_date_gmt', \current_time( 'mysql', 1 ) );
 
 		return $new_post_id;
 	}

--- a/src/ui/block-editor.php
+++ b/src/ui/block-editor.php
@@ -271,8 +271,11 @@ class Block_Editor {
 			];
 		}
 
+		$post_type_object = \get_post_type_object( $post->post_type );
+
 		return [
 			'postId'                  => $post->ID,
+			'restBase'                => $post_type_object ? $post_type_object->rest_base : '',
 			'newDraftLink'            => $this->get_new_draft_permalink(),
 			'rewriteAndRepublishLink' => $this->get_rewrite_republish_permalink(),
 			'showLinks'               => Utils::get_option( 'duplicate_post_show_link' ),

--- a/src/ui/block-editor.php
+++ b/src/ui/block-editor.php
@@ -275,7 +275,7 @@ class Block_Editor {
 
 		return [
 			'postId'                  => $post->ID,
-			'restBase'                => $post_type_object ? $post_type_object->rest_base : '',
+			'restBase'                => ( $post_type_object ) ? $post_type_object->rest_base : '',
 			'newDraftLink'            => $this->get_new_draft_permalink(),
 			'rewriteAndRepublishLink' => $this->get_rewrite_republish_permalink(),
 			'showLinks'               => Utils::get_option( 'duplicate_post_show_link' ),

--- a/src/ui/block-editor.php
+++ b/src/ui/block-editor.php
@@ -80,8 +80,8 @@ class Block_Editor {
 					'single'            => true,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
-					'auth_callback'     => static function () {
-						return \current_user_can( 'edit_posts' );
+					'auth_callback'     => static function ( $allowed, $meta_key, $post_id ) {
+						return \current_user_can( 'edit_post', $post_id );
 					},
 				],
 			);
@@ -272,10 +272,14 @@ class Block_Editor {
 		}
 
 		$post_type_object = \get_post_type_object( $post->post_type );
+		$rest_base        = '';
+		if ( $post_type_object ) {
+			$rest_base = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
+		}
 
 		return [
 			'postId'                  => $post->ID,
-			'restBase'                => ( $post_type_object ) ? $post_type_object->rest_base : '',
+			'restBase'                => $rest_base,
 			'newDraftLink'            => $this->get_new_draft_permalink(),
 			'rewriteAndRepublishLink' => $this->get_rewrite_republish_permalink(),
 			'showLinks'               => Utils::get_option( 'duplicate_post_show_link' ),

--- a/src/ui/block-editor.php
+++ b/src/ui/block-editor.php
@@ -51,11 +51,41 @@ class Block_Editor {
 	 * @return void
 	 */
 	public function register_hooks() {
+		\add_action( 'init', [ $this, 'register_post_meta' ] );
 		\add_action( 'elementor/editor/after_enqueue_styles', [ $this, 'hide_elementor_post_status' ] );
 		\add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_elementor_script' ], 9 );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'should_previously_used_keyword_assessment_run' ], 9 );
 		\add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_scripts' ] );
 		\add_filter( 'wpseo_link_suggestions_indexables', [ $this, 'remove_original_from_wpseo_link_suggestions' ], 10, 3 );
+	}
+
+	/**
+	 * Registers the _dp_has_rewrite_republish_copy post meta for the REST API.
+	 *
+	 * This allows the block editor to reactively check whether a post already
+	 * has an R&R copy, enabling dynamic button state updates when collaborators
+	 * create a copy via Real-Time Collaboration.
+	 *
+	 * @return void
+	 */
+	public function register_post_meta() {
+		$enabled_post_types = $this->permissions_helper->get_enabled_post_types();
+
+		foreach ( $enabled_post_types as $post_type ) {
+			\register_post_meta(
+				$post_type,
+				'_dp_has_rewrite_republish_copy',
+				[
+					'show_in_rest'      => true,
+					'single'            => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+					'auth_callback'     => static function () {
+						return \current_user_can( 'edit_posts' );
+					},
+				],
+			);
+		}
 	}
 
 	/**

--- a/src/watchers/republished-post-watcher.php
+++ b/src/watchers/republished-post-watcher.php
@@ -52,6 +52,7 @@ class Republished_Post_Watcher {
 			$removable_query_args[] = 'dprepublished';
 			$removable_query_args[] = 'dpcopy';
 			$removable_query_args[] = 'dpnonce';
+			$removable_query_args[] = 'dpcollabredirected';
 		}
 		return $removable_query_args;
 	}
@@ -69,6 +70,18 @@ class Republished_Post_Watcher {
 	}
 
 	/**
+	 * Generates the translated text for the collaborator redirect notice.
+	 *
+	 * @return string The translated text for the collaborator redirect notice.
+	 */
+	public function get_collab_redirect_notice_text() {
+		return \__(
+			'Another user has republished the Rewrite & Republish copy you were editing. You are now viewing the original post.',
+			'duplicate-post',
+		);
+	}
+
+	/**
 	 * Shows a notice on the Classic editor.
 	 *
 	 * @return void
@@ -81,6 +94,12 @@ class Republished_Post_Watcher {
 		if ( ! empty( $_REQUEST['dprepublished'] ) ) {
 			echo '<div id="message" class="notice notice-success is-dismissible"><p>'
 				. \esc_html( $this->get_notice_text() )
+				. '</p></div>';
+		}
+
+		if ( ! empty( $_REQUEST['dpcollabredirected'] ) ) {
+			echo '<div id="message" class="notice notice-info is-dismissible"><p>'
+				. \esc_html( $this->get_collab_redirect_notice_text() )
 				. '</p></div>';
 		}
 	}
@@ -101,6 +120,20 @@ class Republished_Post_Watcher {
 			\wp_add_inline_script(
 				'duplicate_post_edit_script',
 				'duplicatePostNotices.republished_notice = ' . \wp_json_encode( $notice ) . ';',
+				'before',
+			);
+		}
+
+		if ( ! empty( $_REQUEST['dpcollabredirected'] ) ) {
+			$notice = [
+				'text'          => $this->get_collab_redirect_notice_text(),
+				'status'        => 'info',
+				'isDismissible' => true,
+			];
+
+			\wp_add_inline_script(
+				'duplicate_post_edit_script',
+				'duplicatePostNotices.collab_redirect_notice = ' . \wp_json_encode( $notice ) . ';',
 				'before',
 			);
 		}

--- a/tests/Unit/UI/Block_Editor_Test.php
+++ b/tests/Unit/UI/Block_Editor_Test.php
@@ -97,6 +97,17 @@ final class Block_Editor_Test extends TestCase {
 
 		$this->assertNotFalse(
 			\has_action(
+				'init',
+				[
+					$this->instance,
+					'register_post_meta',
+				],
+			),
+			'Does not have expected init action',
+		);
+
+		$this->assertNotFalse(
+			\has_action(
 				'elementor/editor/after_enqueue_styles',
 				[
 					$this->instance,
@@ -149,6 +160,37 @@ final class Block_Editor_Test extends TestCase {
 			),
 			'Does not have expected wpseo_link_suggestions_indexables filter',
 		);
+	}
+
+	/**
+	 * Tests that register_post_meta registers the meta for each enabled post type.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::register_post_meta
+	 *
+	 * @return void
+	 */
+	public function test_register_post_meta() {
+		$this->permissions_helper
+			->expects( 'get_enabled_post_types' )
+			->andReturn( [ 'post', 'page' ] );
+
+		Monkey\Functions\expect( '\register_post_meta' )
+			->once()
+			->with(
+				'post',
+				'_dp_has_rewrite_republish_copy',
+				Mockery::type( 'array' ),
+			);
+
+		Monkey\Functions\expect( '\register_post_meta' )
+			->once()
+			->with(
+				'page',
+				'_dp_has_rewrite_republish_copy',
+				Mockery::type( 'array' ),
+			);
+
+		$this->instance->register_post_meta();
 	}
 
 	/**

--- a/tests/Unit/UI/Block_Editor_Test.php
+++ b/tests/Unit/UI/Block_Editor_Test.php
@@ -174,21 +174,23 @@ final class Block_Editor_Test extends TestCase {
 			->expects( 'get_enabled_post_types' )
 			->andReturn( [ 'post', 'page' ] );
 
-		Monkey\Functions\expect( '\register_post_meta' )
-			->once()
-			->with(
-				'post',
-				'_dp_has_rewrite_republish_copy',
-				Mockery::type( 'array' ),
-			);
+		$expected_args = Mockery::on(
+			static function ( $args ) {
+				return $args['show_in_rest'] === true
+					&& $args['single'] === true
+					&& $args['type'] === 'string'
+					&& $args['sanitize_callback'] === 'sanitize_text_field'
+					&& \is_callable( $args['auth_callback'] );
+			},
+		);
 
 		Monkey\Functions\expect( '\register_post_meta' )
 			->once()
-			->with(
-				'page',
-				'_dp_has_rewrite_republish_copy',
-				Mockery::type( 'array' ),
-			);
+			->with( 'post', '_dp_has_rewrite_republish_copy', $expected_args );
+
+		Monkey\Functions\expect( '\register_post_meta' )
+			->once()
+			->with( 'page', '_dp_has_rewrite_republish_copy', $expected_args );
 
 		$this->instance->register_post_meta();
 	}

--- a/tests/Unit/UI/Block_Editor_Test.php
+++ b/tests/Unit/UI/Block_Editor_Test.php
@@ -310,6 +310,7 @@ final class Block_Editor_Test extends TestCase {
 		$utils                      = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$post                       = Mockery::mock( WP_Post::class );
 		$post->ID                   = 123;
+		$post->post_type            = 'post';
 		$new_draft_link             = 'http://fakeu.rl/new_draft';
 		$rewrite_and_republish_link = 'http://fakeu.rl/rewrite_and_republish';
 		$rewriting                  = 0;
@@ -374,8 +375,16 @@ final class Block_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturnNull();
 
+		$post_type_object            = Mockery::mock( 'WP_Post_Type' );
+		$post_type_object->rest_base = 'posts';
+
+		Monkey\Functions\expect( '\get_post_type_object' )
+			->with( 'post' )
+			->andReturn( $post_type_object );
+
 		$edit_js_object = [
 			'postId'                  => 123,
+			'restBase'                => 'posts',
 			'newDraftLink'            => $new_draft_link,
 			'rewriteAndRepublishLink' => $rewrite_and_republish_link,
 			'showLinks'               => $show_links,
@@ -414,6 +423,7 @@ final class Block_Editor_Test extends TestCase {
 		$utils                      = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
 		$post                       = Mockery::mock( WP_Post::class );
 		$post->ID                   = 123;
+		$post->post_type            = 'post';
 		$new_draft_link             = 'http://fakeu.rl/new_draft';
 		$rewrite_and_republish_link = 'http://fakeu.rl/rewrite_and_republish';
 		$rewriting                  = 1;
@@ -475,8 +485,16 @@ final class Block_Editor_Test extends TestCase {
 			->with( $post )
 			->andReturnNull();
 
+		$post_type_object            = Mockery::mock( 'WP_Post_Type' );
+		$post_type_object->rest_base = 'posts';
+
+		Monkey\Functions\expect( '\get_post_type_object' )
+			->with( 'post' )
+			->andReturn( $post_type_object );
+
 		$edit_js_object = [
 			'postId'                  => 123,
+			'restBase'                => 'posts',
 			'newDraftLink'            => $new_draft_link,
 			'rewriteAndRepublishLink' => $rewrite_and_republish_link,
 			'showLinks'               => $show_links,

--- a/tests/Unit/Watchers/Republished_Post_Watcher_Test.php
+++ b/tests/Unit/Watchers/Republished_Post_Watcher_Test.php
@@ -241,6 +241,7 @@ final class Republished_Post_Watcher_Test extends TestCase {
 				'dprepublished',
 				'dpcopy',
 				'dpnonce',
+				'dpcollabredirected',
 			],
 			$this->instance->add_removable_query_args( $array ),
 		);

--- a/tests/WP/Post_Duplicator_Test.php
+++ b/tests/WP/Post_Duplicator_Test.php
@@ -50,4 +50,72 @@ final class Post_Duplicator_Test extends TestCase {
 
 		$this->assertIsInt( $id );
 	}
+
+	/**
+	 * Tests that creating an R&R copy claims the slot on the original post.
+	 *
+	 * @covers ::create_duplicate_for_rewrite_and_republish
+	 *
+	 * @return void
+	 */
+	public function test_create_duplicate_for_rewrite_and_republish_claims_slot() {
+		$post = $this->factory->post->create_and_get( [ 'post_status' => 'publish' ] );
+
+		$copy_id = $this->instance->create_duplicate_for_rewrite_and_republish( $post );
+
+		$this->assertIsInt( $copy_id );
+		$this->assertSame( (string) $copy_id, \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true ) );
+		$this->assertSame( 1, (int) \get_post_meta( $copy_id, '_dp_is_rewrite_republish_copy', true ) );
+	}
+
+	/**
+	 * Tests that creating an R&R copy fails when the original already has one.
+	 *
+	 * @covers ::create_duplicate_for_rewrite_and_republish
+	 *
+	 * @return void
+	 */
+	public function test_create_duplicate_for_rewrite_and_republish_blocks_duplicate() {
+		$post = $this->factory->post->create_and_get( [ 'post_status' => 'publish' ] );
+
+		$first_copy_id = $this->instance->create_duplicate_for_rewrite_and_republish( $post );
+
+		$this->assertIsInt( $first_copy_id );
+
+		$second_result = $this->instance->create_duplicate_for_rewrite_and_republish( $post );
+
+		$this->assertInstanceOf( \WP_Error::class, $second_result );
+		$this->assertSame( 'duplicate_post_already_has_copy', $second_result->get_error_code() );
+
+		// Original should still reference the first copy only.
+		$meta_values = \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy' );
+		$this->assertCount( 1, $meta_values );
+		$this->assertSame( (string) $first_copy_id, $meta_values[0] );
+	}
+
+	/**
+	 * Tests that the claim is rolled back when copy creation fails.
+	 *
+	 * @covers ::create_duplicate_for_rewrite_and_republish
+	 *
+	 * @return void
+	 */
+	public function test_create_duplicate_for_rewrite_and_republish_rolls_back_on_failure() {
+		$post = $this->factory->post->create_and_get( [ 'post_status' => 'publish' ] );
+
+		// Force wp_insert_post to fail by filtering the post data.
+		\add_filter(
+			'wp_insert_post_empty_content',
+			'__return_true',
+		);
+
+		$result = $this->instance->create_duplicate_for_rewrite_and_republish( $post );
+
+		\remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+
+		// The claim should have been rolled back.
+		$this->assertSame( '', \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true ) );
+	}
 }

--- a/tests/WP/Post_Duplicator_Test.php
+++ b/tests/WP/Post_Duplicator_Test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Duplicate_Post\Tests\WP;
 
+use WP_Error;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
@@ -84,11 +85,11 @@ final class Post_Duplicator_Test extends TestCase {
 
 		$second_result = $this->instance->create_duplicate_for_rewrite_and_republish( $post );
 
-		$this->assertInstanceOf( \WP_Error::class, $second_result );
+		$this->assertInstanceOf( WP_Error::class, $second_result );
 		$this->assertSame( 'duplicate_post_already_has_copy', $second_result->get_error_code() );
 
 		// Original should still reference the first copy only.
-		$meta_values = \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy' );
+		$meta_values = \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', false );
 		$this->assertCount( 1, $meta_values );
 		$this->assertSame( (string) $first_copy_id, $meta_values[0] );
 	}
@@ -113,7 +114,7 @@ final class Post_Duplicator_Test extends TestCase {
 
 		\remove_filter( 'wp_insert_post_empty_content', '__return_true' );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 
 		// The claim should have been rolled back.
 		$this->assertSame( '', \get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WordPress 7.0 ships Real-Time Collaboration (RTC) enabled by default. RTC is active on sites using Duplicate Post with the block editor because the plugin uses `PluginDocumentSettingPanel` instead of metaboxes. This creates several issues with the Rewrite & Republish flow when multiple users are involved.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves compatibility of the Rewrite & Republish feature with Real-Time Collaboration in WordPress 7.0.

## Relevant technical choices:

* **Race condition (item 1)**: Uses `add_post_meta()` with `$unique = true` to claim the slot on the original post before creating the copy. This prevents duplicate copies at the database level. If `wp_insert_post()` fails, the claim is rolled back.
* **Collaborator redirect (item 2)**: The RTC status change does not propagate because the republishing user navigates away before the CRDT update is sent. Instead, we poll the REST API every 2 seconds to detect when the copy is republished (`dp-rewrite-republish` status), trashed, or deleted (404). The `restBase` is provided via localized PHP data because `select('core').getPostType()` is a resolver-backed selector that returns `undefined` at script initialization time.
* **Dynamic button (item 3)**: Registers `_dp_has_rewrite_republish_copy` with `show_in_rest` and reads it via `getEntityRecord` from the `core` store. Server-side meta changes bypass the RTC CRDT, so periodic cache invalidation via `invalidateResolution` every 15 seconds ensures the editor picks up the change. `invalidateResolution` is safe with unsaved local edits — the store's `edits` reducer preserves local changes that differ from the server response.
* All changes are backward-compatible with WP 6.x — the new code paths are harmless no-ops without concurrent editors.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Setup:** WordPress 7.0+ with RTC enabled, two browser sessions (different users or normal + incognito).

**Item 1 — Race condition:**
1. Open a published post in the block editor.
2. Click "Rewrite & Republish" to create a copy.
3. Go back to the same published post and verify the "Rewrite & Republish" button/link is no longer available (a copy already exists).
4. To test the concurrent scenario more rigorously: open two browser tabs on the same published post's row actions, and click "Rewrite & Republish" in both tabs as quickly as possible. Only one should succeed; the other should show an error message.

**Item 2 — Collaborator redirect:**
1. Both users open the same R&R copy in the block editor.
2. User A clicks "Republish".
3. Verify User A is redirected to the original post as before.
4. Verify User B sees a snackbar "Another user has republished this post. Redirecting to the original…" and is redirected after ~3 seconds.
5. Verify User B sees an info notice on the original post: "Another user has republished the Rewrite & Republish copy you were editing. You are now viewing the original post."

**Item 3 — Dynamic button:**
1. Both users open the same published post in the block editor.
2. Verify both see the "Rewrite & Republish" button.
3. User A clicks "Rewrite & Republish".
4. Verify User B's button disappears within ~15 seconds and a snackbar notification appears.

**Backward compatibility:**
1. On WP 6.9 (no RTC), verify the normal single-user R&R flow works: create copy → edit → republish → redirect to original.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
Check the console for unexpected errors during the RTC polling. Test on at least two browsers to verify RTC collaboration works correctly.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Rewrite & Republish copy creation flow (`src/post-duplicator.php`)
* The block editor UI and redirect logic (`js/src/duplicate-post-edit-script.js`)
* The republished post watcher notices (`src/watchers/republished-post-watcher.php`)
* The localized JS data object (`src/ui/block-editor.php`)

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes Yoast/reserved-tasks#1127
