### PR TITLE
Fix expansion for older Bash versions

### DIFF
--- a/config/scripts/run-wp-env-tests.sh
+++ b/config/scripts/run-wp-env-tests.sh
@@ -153,4 +153,4 @@ npx wp-env run cli \
   -- env $ENV_PREFIX \
   php vendor/phpunit/phpunit/phpunit \
   -c phpunit-wp.xml.dist \
-  "${PHPUNIT_ARGS[@]}"
+  ${PHPUNIT_ARGS[@]+"${PHPUNIT_ARGS[@]}"}


### PR DESCRIPTION
## Context

The `coverage-wp-env` script uses `set -euo pipefail`. On older Bash versions (3.x, the default on macOS), expanding an empty array with `"${PHPUNIT_ARGS[@]}"` triggers an `unbound variable` error because Bash 3.x treats empty arrays as unset.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug in the `coverage-wp-env` script where older versions of Bash were causing an `unbound variable` error.

## Relevant technical choices:

* Uses the standard `${var[@]+...}` idiom for safe empty-array expansion across all Bash versions.
* Same fix as Yoast/wordpress-seo#23163.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have a Bash version 3.* or lower
* Run `composer install && yarn install`
* Run `composer coverage-wp-env`
  * With this PR, the script terminates correctly
  * Without this PR, the script errors out with the message `config/scripts/run-wp-env-tests.sh: line 156: PHPUNIT_ARGS[@]: unbound variable`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [X] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.

Fixes Yoast/wordpress-seo#23107