### PR TITLE
fix(republish): preserve capability-gated content in scheduled republish

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=57",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=52",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=0",
 			"Yoast\\WP\\Duplicate_Post\\Config\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -97,10 +97,10 @@ class Post_Republisher {
 	 * Runs on the `wp_insert_post_data` hook in `wp_insert_post()` when
 	 * submitting the post copy.
 	 *
-	 * @param array $data    An array of slashed, sanitized, and processed post data.
-	 * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
+	 * @param array<string, array|bool|int|string|null> $data    An array of slashed, sanitized, and processed post data.
+	 * @param array<string, array|bool|int|string|null> $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
 	 *
-	 * @return array An array of slashed, sanitized, and processed attachment post data.
+	 * @return array<string, array|bool|int|string|null> An array of slashed, sanitized, and processed attachment post data.
 	 */
 	public function change_post_copy_status( $data, $postarr ) {
 		if ( ! \array_key_exists( 'ID', $postarr ) || empty( $postarr['ID'] ) ) {
@@ -209,9 +209,21 @@ class Post_Republisher {
 			return;
 		}
 
-		\kses_remove_filters();
-		$this->republish( $copy, $original_post );
-		\kses_init_filters();
+		// WP-Cron runs without a logged-in user, which causes capability-gated save filters
+		// (kses, WPBakery's wpb_remove_custom_html, and similar) to strip otherwise valid
+		// content. Run the republish as the copy author so those filters evaluate against
+		// a real user; this also triggers kses_init via the set_current_user action, which
+		// adds or removes kses filters based on that user's actual capabilities.
+		$previous_user_id = \get_current_user_id();
+		\wp_set_current_user( (int) $copy->post_author );
+
+		try {
+			$this->republish( $copy, $original_post );
+		}
+		finally {
+			\wp_set_current_user( $previous_user_id );
+		}
+
 		$this->delete_copy( $copy->ID, $original_post->ID );
 	}
 

--- a/tests/Unit/Post_Republisher_Test.php
+++ b/tests/Unit/Post_Republisher_Test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Duplicate_Post\Tests\Unit;
 
 use Brain\Monkey;
 use Mockery;
+use RuntimeException;
 use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
 use Yoast\WP\Duplicate_Post\Post_Duplicator;
@@ -269,6 +270,7 @@ final class Post_Republisher_Test extends TestCase {
 
 		$copy              = Mockery::mock( WP_Post::class );
 		$copy->ID          = 123;
+		$copy->post_author = '7';
 		$copy->post_status = 'future';
 
 		$this->permissions_helper
@@ -284,11 +286,82 @@ final class Post_Republisher_Test extends TestCase {
 			->once()
 			->andReturn( $original );
 
-		Monkey\Functions\expect( 'kses_remove_filters' );
-		Monkey\Functions\expect( 'kses_init_filters' );
+		Monkey\Functions\expect( 'get_current_user_id' )
+			->once()
+			->andReturn( 0 );
+		Monkey\Functions\expect( 'wp_set_current_user' )
+			->once()
+			->ordered()
+			->with( 7 );
 
-		$this->instance->expects( 'republish' )->with( $copy, $original )->once();
+		$this->instance->expects( 'republish' )->with( $copy, $original )->once()->ordered();
+
+		Monkey\Functions\expect( 'wp_set_current_user' )
+			->once()
+			->ordered()
+			->with( 0 );
+
 		$this->instance->expects( 'delete_copy' )->with( $copy->ID, $original->ID )->once();
+
+		$this->instance->republish_scheduled_post( $copy );
+	}
+
+	/**
+	 * Tests the republish_scheduled_post function restores the current user when republishing fails.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_scheduled_post
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_republish_scheduled_post_restores_current_user_when_republish_fails() {
+		$original              = Mockery::mock( WP_Post::class );
+		$original->ID          = 1;
+		$original->post_status = 'publish';
+
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_author = '7';
+		$copy->post_status = 'future';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->once()
+			->andReturnTrue();
+
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils
+			->expects( 'get_original' )
+			->with( $copy->ID )
+			->once()
+			->andReturn( $original );
+
+		Monkey\Functions\expect( 'get_current_user_id' )
+			->once()
+			->andReturn( 0 );
+		Monkey\Functions\expect( 'wp_set_current_user' )
+			->once()
+			->ordered()
+			->with( 7 );
+
+		$this->instance
+			->expects( 'republish' )
+			->with( $copy, $original )
+			->once()
+			->ordered()
+			->andThrow( new RuntimeException( 'Republish failed.' ) );
+
+		Monkey\Functions\expect( 'wp_set_current_user' )
+			->once()
+			->ordered()
+			->with( 0 );
+
+		$this->instance->expects( 'delete_copy' )->never();
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Republish failed.' );
 
 		$this->instance->republish_scheduled_post( $copy );
 	}

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -491,6 +491,11 @@ final class Post_Republisher_Test extends TestCase {
 	public function test_republish_scheduled_post_preserves_raw_html_content() {
 		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 
+		// On multisite, regular Administrators do not have `unfiltered_html`; only Super Admins do.
+		if ( \is_multisite() ) {
+			\grant_super_admin( $admin_id );
+		}
+
 		$raw_html_content = '<!-- wp:html --><section data-raw-html="preserved">'
 			. '<script>window.duplicatePostRawHtml = true;</script></section><!-- /wp:html -->';
 

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -62,7 +62,7 @@ final class Post_Republisher_Test extends TestCase {
 	/**
 	 * Helper method to create a published post.
 	 *
-	 * @param array $args Optional. Arguments for wp_insert_post.
+	 * @param array<string, mixed> $args Optional. Arguments for wp_insert_post.
 	 *
 	 * @return WP_Post The created post object.
 	 */
@@ -99,7 +99,7 @@ final class Post_Republisher_Test extends TestCase {
 	 * This prevents the republish flow by removing the filter that changes the
 	 * copy status and by simulating a meta-box-loader request.
 	 *
-	 * @param array $postarr An array of post data to update.
+	 * @param array<string, mixed> $postarr An array of post data to update.
 	 *
 	 * @return int|WP_Error The post ID on success, WP_Error on failure.
 	 */
@@ -430,6 +430,140 @@ final class Post_Republisher_Test extends TestCase {
 
 		// Verify meta cleanup.
 		$this->assertSame( '', \get_post_meta( $original_id, '_dp_has_rewrite_republish_copy', true ) );
+	}
+
+	/**
+	 * Tests that republish_scheduled_post runs the republish as the copy author.
+	 *
+	 * This is a regression test for the scheduled-publish path stripping content
+	 * from capability-gated shortcodes (e.g. WPBakery's `[vc_raw_html]`) because
+	 * WP-Cron has no logged-in user and `current_user_can( 'unfiltered_html' )`
+	 * returns false. Setting the copy author as the current user before calling
+	 * `republish()` makes those filters evaluate against a real user.
+	 *
+	 * @covers ::republish_scheduled_post
+	 *
+	 * @return void
+	 */
+	public function test_republish_scheduled_post_runs_as_copy_author() {
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+
+		$original = $this->create_original_post();
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		$this->update_post_without_republish(
+			[
+				'ID'           => $copy->ID,
+				'post_author'  => $editor_id,
+				'post_title'   => 'Scheduled Title',
+				'post_content' => 'Scheduled content.',
+			],
+		);
+		$copy = \get_post( $copy->ID );
+
+		$captured_user_id = null;
+		$capture          = static function () use ( &$captured_user_id ) {
+			$captured_user_id = \get_current_user_id();
+		};
+		\add_action( 'duplicate_post_before_republish', $capture );
+
+		// Simulate WP-Cron: no logged-in user.
+		\wp_set_current_user( 0 );
+
+		try {
+			$this->instance->republish_scheduled_post( $copy );
+		}
+		finally {
+			\remove_action( 'duplicate_post_before_republish', $capture );
+		}
+
+		$this->assertSame( $editor_id, $captured_user_id );
+	}
+
+	/**
+	 * Tests that scheduled republishing preserves capability-gated raw HTML content.
+	 *
+	 * @covers ::republish_scheduled_post
+	 * @covers ::republish_post_elements
+	 *
+	 * @return void
+	 */
+	public function test_republish_scheduled_post_preserves_raw_html_content() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+
+		$raw_html_content = '<!-- wp:html --><section data-raw-html="preserved">'
+			. '<script>window.duplicatePostRawHtml = true;</script></section><!-- /wp:html -->';
+
+		$original = $this->create_original_post( [ 'post_author' => $admin_id ] );
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		\wp_set_current_user( $admin_id );
+
+		$this->update_post_without_republish(
+			[
+				'ID'           => $copy->ID,
+				'post_author'  => $admin_id,
+				'post_content' => $raw_html_content,
+			],
+		);
+		$copy = \get_post( $copy->ID );
+
+		$strip_raw_html_for_users_without_capability = static function ( $data ) {
+			if ( \current_user_can( 'unfiltered_html' ) ) {
+				return $data;
+			}
+
+			$data['post_content'] = \preg_replace(
+				'/<!-- wp:html -->.*?<!-- \/wp:html -->/s',
+				'<!-- wp:html --><!-- /wp:html -->',
+				$data['post_content'],
+			);
+
+			return $data;
+		};
+		\add_filter( 'wp_insert_post_data', $strip_raw_html_for_users_without_capability, 20 );
+
+		// Simulate WP-Cron: no logged-in user.
+		\wp_set_current_user( 0 );
+
+		try {
+			$this->instance->republish_scheduled_post( $copy );
+		}
+		finally {
+			\remove_filter( 'wp_insert_post_data', $strip_raw_html_for_users_without_capability, 20 );
+		}
+
+		$updated_original = \get_post( $original->ID );
+		$this->assertSame( $raw_html_content, $updated_original->post_content );
+	}
+
+	/**
+	 * Tests that republish_scheduled_post restores the previous user context after running.
+	 *
+	 * @covers ::republish_scheduled_post
+	 *
+	 * @return void
+	 */
+	public function test_republish_scheduled_post_restores_previous_user_context() {
+		$admin_id  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+
+		$original = $this->create_original_post( [ 'post_author' => $admin_id ] );
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		$this->update_post_without_republish(
+			[
+				'ID'          => $copy->ID,
+				'post_author' => $editor_id,
+			],
+		);
+		$copy = \get_post( $copy->ID );
+
+		\wp_set_current_user( $admin_id );
+
+		$this->instance->republish_scheduled_post( $copy );
+
+		$this->assertSame( $admin_id, \get_current_user_id() );
 	}
 
 	/**


### PR DESCRIPTION
## Context

The Rewrite & Republish feature publishes scheduled copies via WP-Cron. WP-Cron runs without a logged-in user, which caused capability-gated `post_content` filters to treat the operation as untrusted: WordPress's kses, WPBakery Page Builder's `wpb_remove_custom_html` (which strips `[vc_raw_html]`, `[vc_raw_js]` and `[vc_gmaps]` shortcodes when the current user lacks `unfiltered_html`), and other similar filters from third-party plugins. As a result, the inner content of WPBakery Raw HTML elements was being deleted from the original post when a Rewrite & Republish copy was scheduled to be published in the future, even though the user who scheduled the republish had `unfiltered_html`.

* Reported via wordpress.org support: https://wordpress.org/support/topic/scheduled-rewrite-and-republish-removes-content-from-raw-html-blocks/
* Reproduced against WPBakery 8.7.2 + WordPress 6.9.4.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where content inside WPBakery `[vc_raw_html]` (and similar capability-gated) shortcodes was deleted from the original post when a scheduled Rewrite & Republish was published via WP-Cron.

`changelog: bugfix`

## Relevant technical choices:

* Set the copy author as the current user before calling `republish()` and restore the previous user afterwards in a `try/finally`. This makes capability-gated filters evaluate against a real user the way they do for any normal save.
* Setting the user via `wp_set_current_user()` also triggers WordPress's own `kses_init` through the `set_current_user` action, which adds or removes kses filters based on that user's actual capabilities. This makes the previous manual `kses_remove_filters()` / `kses_init_filters()` workaround unnecessary, so it has been removed.
* The fix generalises beyond WPBakery: any plugin that gates `post_content` save filters on capability checks now behaves correctly during scheduled republish.
* Added a unit test that covers the failure path (the `try/finally` correctly restores the previous user when `republish()` throws).
* Added an integration test that simulates a capability-gated stripping filter and asserts the content survives the scheduled republish.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Set up a test site with WPBakery Page Builder installed (version 8.7.2 or similar recent).
2. Create a page that contains a Raw HTML element with some content (e.g. a block of HTML with a `<script>` tag inside).
3. Use Yoast Duplicate Post to create a Rewrite & Republish copy of that page.
4. Edit the copy, change something innocuous (e.g. the title), and Schedule it for a couple of minutes in the future.
5. Wait for the scheduled time to pass, then trigger WP-Cron (visit the front-end, or run `wp cron event run --due-now` with WP-CLI).
6. Open the original page.
   * Without this PR: the Raw HTML element exists but the inner content is missing.
   * With this PR: the Raw HTML element retains its full content.
7. Verify the immediate Republish flow is unchanged: create another Rewrite & Republish copy, click Republish without scheduling, and confirm the content is preserved.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The bug is in the cron handler, so it should reproduce regardless of which editor was used to schedule the copy. Worth verifying both Block Editor and Classic Editor flows still schedule and republish correctly.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The scheduled Rewrite & Republish path (`Post_Republisher::republish_scheduled_post`). Immediate Republish (Block Editor REST and Classic Editor) is unchanged because it already runs in an authenticated user context.
* Third-party plugins that hook `wp_insert_post_data` or `content_save_pre` with capability checks will now see the copy author as the current user during scheduled republish (previously: user 0). This is the intended behaviour and matches what those filters see during any normal save by the same user.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #210