### PR TITLE
Add links to the existing duplicate notices

### DIFF
--- a/js/src/duplicate-post-edit-script.js
+++ b/js/src/duplicate-post-edit-script.js
@@ -257,6 +257,7 @@ class DuplicatePost {
 					notice.text,
 					{
 						isDismissible: notice.isDismissible || true,
+						__unstableHTML: notice.isHTML || false,
 					}
 				);
 			}

--- a/src/watchers/copied-post-watcher.php
+++ b/src/watchers/copied-post-watcher.php
@@ -47,18 +47,41 @@ class Copied_Post_Watcher {
 	 */
 	public function get_notice_text( $post ) {
 		if ( $this->permissions_helper->has_trashed_rewrite_and_republish_copy( $post ) ) {
+			$trash_url = \add_query_arg(
+				[
+					'post_status' => 'trash',
+					'post_type'   => $post->post_type,
+				],
+				\admin_url( 'edit.php' ),
+			);
+			$view_trash_html = \sprintf(
+				' <a href="%1$s">%2$s</a>',
+				\esc_url( $trash_url ),
+				\__( 'View trash.', 'duplicate-post' ),
+			);
+
 			return \__(
 				'You can only make one Rewrite & Republish duplicate at a time, and a duplicate of this post already exists in the trash. Permanently delete it if you want to make a new duplicate.',
 				'duplicate-post',
-			);
+			) . $view_trash_html;
 		}
+
+		$copy      = $this->permissions_helper->get_rewrite_and_republish_copy( $post );
+		$edit_url  = ( $copy instanceof WP_Post ) ? \get_edit_post_link( $copy->ID, 'raw' ) : '';
+		$link_html = ( $edit_url !== '' )
+			? \sprintf(
+				' <a href="%1$s">%2$s</a>',
+				\esc_url( $edit_url ),
+				\__( 'Edit the duplicate.', 'duplicate-post' ),
+			)
+			: '';
 
 		$scheduled_copy = $this->permissions_helper->has_scheduled_rewrite_and_republish_copy( $post );
 		if ( ! $scheduled_copy ) {
 			return \__(
 				'A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished.',
 				'duplicate-post',
-			);
+			) . $link_html;
 		}
 
 		return \sprintf(
@@ -69,7 +92,7 @@ class Copied_Post_Watcher {
 			),
 			\get_the_time( \get_option( 'date_format' ), $scheduled_copy ),
 			\get_the_time( \get_option( 'time_format' ), $scheduled_copy ),
-		);
+		) . $link_html;
 	}
 
 	/**
@@ -90,7 +113,7 @@ class Copied_Post_Watcher {
 
 		if ( $this->permissions_helper->has_rewrite_and_republish_copy( $post ) ) {
 			print '<div id="message" class="notice notice-warning is-dismissible fade"><p>'
-				. \esc_html( $this->get_notice_text( $post ) )
+				. \wp_kses( $this->get_notice_text( $post ), [ 'a' => [ 'href' => [] ] ] )
 				. '</p></div>';
 		}
 	}
@@ -113,6 +136,7 @@ class Copied_Post_Watcher {
 				'text'          => $this->get_notice_text( $post ),
 				'status'        => 'warning',
 				'isDismissible' => true,
+				'isHTML'        => true,
 			];
 
 			\wp_add_inline_script(

--- a/src/watchers/copied-post-watcher.php
+++ b/src/watchers/copied-post-watcher.php
@@ -69,7 +69,7 @@ class Copied_Post_Watcher {
 		$copy      = $this->permissions_helper->get_rewrite_and_republish_copy( $post );
 		$edit_url  = ( $copy instanceof WP_Post ) ? \get_edit_post_link( $copy->ID, 'raw' ) : '';
 		$link_html = '';
-		if ( $edit_url !== '' ) {
+		if ( ! empty( $edit_url ) ) {
 			$link_html = \sprintf(
 				' <a href="%1$s">%2$s</a>',
 				\esc_url( $edit_url ),

--- a/src/watchers/copied-post-watcher.php
+++ b/src/watchers/copied-post-watcher.php
@@ -47,7 +47,7 @@ class Copied_Post_Watcher {
 	 */
 	public function get_notice_text( $post ) {
 		if ( $this->permissions_helper->has_trashed_rewrite_and_republish_copy( $post ) ) {
-			$trash_url = \add_query_arg(
+			$trash_url       = \add_query_arg(
 				[
 					'post_status' => 'trash',
 					'post_type'   => $post->post_type,
@@ -68,13 +68,14 @@ class Copied_Post_Watcher {
 
 		$copy      = $this->permissions_helper->get_rewrite_and_republish_copy( $post );
 		$edit_url  = ( $copy instanceof WP_Post ) ? \get_edit_post_link( $copy->ID, 'raw' ) : '';
-		$link_html = ( $edit_url !== '' )
-			? \sprintf(
+		$link_html = '';
+		if ( $edit_url !== '' ) {
+			$link_html = \sprintf(
 				' <a href="%1$s">%2$s</a>',
 				\esc_url( $edit_url ),
 				\__( 'Edit the duplicate.', 'duplicate-post' ),
-			)
-			: '';
+			);
+		}
 
 		$scheduled_copy = $this->permissions_helper->has_scheduled_rewrite_and_republish_copy( $post );
 		if ( ! $scheduled_copy ) {

--- a/tests/Unit/Watchers/Copied_Post_Watcher_Test.php
+++ b/tests/Unit/Watchers/Copied_Post_Watcher_Test.php
@@ -81,8 +81,12 @@ final class Copied_Post_Watcher_Test extends TestCase {
 	 */
 	public function test_get_notice_text_not_scheduled() {
 		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
 
 		$post = Mockery::mock( WP_Post::class );
+		$copy = Mockery::mock( WP_Post::class );
+
+		$copy->ID = 456;
 
 		$this->permissions_helper
 			->expects( 'has_scheduled_rewrite_and_republish_copy' )
@@ -94,8 +98,16 @@ final class Copied_Post_Watcher_Test extends TestCase {
 			->with( $post )
 			->andReturnFalse();
 
+		$this->permissions_helper
+			->expects( 'get_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturn( $copy );
+
+		Monkey\Functions\when( '\get_edit_post_link' )
+			->justReturn( 'http://example.com/edit?post=456' );
+
 		$this->assertSame(
-			'A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished.',
+			'A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished. <a href="http://example.com/edit?post=456">Edit the duplicate.</a>',
 			$this->instance->get_notice_text( $post ),
 		);
 	}
@@ -109,9 +121,12 @@ final class Copied_Post_Watcher_Test extends TestCase {
 	 */
 	public function test_get_notice_text_scheduled() {
 		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
 
 		$post = Mockery::mock( WP_Post::class );
 		$copy = Mockery::mock( WP_Post::class );
+
+		$copy->ID = 789;
 
 		$this->permissions_helper
 			->expects( 'has_scheduled_rewrite_and_republish_copy' )
@@ -123,6 +138,14 @@ final class Copied_Post_Watcher_Test extends TestCase {
 			->with( $post )
 			->andReturnFalse();
 
+		$this->permissions_helper
+			->expects( 'get_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturn( $copy );
+
+		Monkey\Functions\when( '\get_edit_post_link' )
+			->justReturn( 'http://example.com/edit?post=789' );
+
 		Monkey\Functions\expect( '\get_option' )
 			->twice()
 			->andReturnValues( [ 'Y/m/d', 'g:i a' ] );
@@ -132,7 +155,7 @@ final class Copied_Post_Watcher_Test extends TestCase {
 			->andReturnValues( [ '2020/12/02', '10:30 am' ] );
 
 		$this->assertSame(
-			'A duplicate of this post was made, which is scheduled to replace this post on 2020/12/02 at 10:30 am.',
+			'A duplicate of this post was made, which is scheduled to replace this post on 2020/12/02 at 10:30 am. <a href="http://example.com/edit?post=789">Edit the duplicate.</a>',
 			$this->instance->get_notice_text( $post ),
 		);
 	}
@@ -146,8 +169,11 @@ final class Copied_Post_Watcher_Test extends TestCase {
 	 */
 	public function test_get_notice_text_copy_in_the_trash() {
 		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
 
 		$post = Mockery::mock( WP_Post::class );
+
+		$post->post_type = 'post';
 
 		$this->permissions_helper
 			->expects( 'has_scheduled_rewrite_and_republish_copy' )
@@ -158,8 +184,14 @@ final class Copied_Post_Watcher_Test extends TestCase {
 			->with( $post )
 			->andReturnTrue();
 
+		Monkey\Functions\when( '\admin_url' )
+			->justReturn( 'http://example.com/wp-admin/edit.php' );
+
+		Monkey\Functions\when( '\add_query_arg' )
+			->justReturn( 'http://example.com/wp-admin/edit.php?post_status=trash&post_type=post' );
+
 		$this->assertSame(
-			'You can only make one Rewrite & Republish duplicate at a time, and a duplicate of this post already exists in the trash. Permanently delete it if you want to make a new duplicate.',
+			'You can only make one Rewrite & Republish duplicate at a time, and a duplicate of this post already exists in the trash. Permanently delete it if you want to make a new duplicate. <a href="http://example.com/wp-admin/edit.php?post_status=trash&post_type=post">View trash.</a>',
 			$this->instance->get_notice_text( $post ),
 		);
 	}
@@ -190,6 +222,10 @@ final class Copied_Post_Watcher_Test extends TestCase {
 
 		$this->instance
 			->expects( 'get_notice_text' )
+			->andReturn( 'notice' );
+
+		Monkey\Functions\expect( '\wp_kses' )
+			->with( 'notice', [ 'a' => [ 'href' => [] ] ] )
 			->andReturn( 'notice' );
 
 		$this->instance->add_admin_notice();
@@ -268,16 +304,17 @@ final class Copied_Post_Watcher_Test extends TestCase {
 			'text'          => 'notice',
 			'status'        => 'warning',
 			'isDismissible' => true,
+			'isHTML'        => true,
 		];
 
 		Monkey\Functions\expect( '\wp_json_encode' )
 			->with( $notice )
-			->andReturn( '{"text":"notice","status":"warning","isDismissible":true}' );
+			->andReturn( '{"text":"notice","status":"warning","isDismissible":true,"isHTML":true}' );
 
 		Monkey\Functions\expect( '\wp_add_inline_script' )
 			->with(
 				'duplicate_post_edit_script',
-				'duplicatePostNotices.has_rewrite_and_republish_notice = {"text":"notice","status":"warning","isDismissible":true};',
+				'duplicatePostNotices.has_rewrite_and_republish_notice = {"text":"notice","status":"warning","isDismissible":true,"isHTML":true};',
 				'before',
 			);
 

--- a/tests/Unit/Watchers/Copied_Post_Watcher_Test.php
+++ b/tests/Unit/Watchers/Copied_Post_Watcher_Test.php
@@ -113,6 +113,50 @@ final class Copied_Post_Watcher_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that no link is appended when the current user cannot edit the copy.
+	 *
+	 * `get_edit_post_link()` returns `null` (not an empty string) when the user
+	 * lacks the `edit_post` capability for the copy, so the message should not
+	 * gain a broken link with an empty `href`.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text
+	 *
+	 * @return void
+	 */
+	public function test_get_notice_text_not_scheduled_without_edit_link() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$post = Mockery::mock( WP_Post::class );
+		$copy = Mockery::mock( WP_Post::class );
+
+		$copy->ID = 456;
+
+		$this->permissions_helper
+			->expects( 'has_scheduled_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->permissions_helper
+			->expects( 'has_trashed_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturnFalse();
+
+		$this->permissions_helper
+			->expects( 'get_rewrite_and_republish_copy' )
+			->with( $post )
+			->andReturn( $copy );
+
+		Monkey\Functions\when( '\get_edit_post_link' )
+			->justReturn( null );
+
+		$this->assertSame(
+			'A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished.',
+			$this->instance->get_notice_text( $post ),
+		);
+	}
+
+	/**
 	 * Tests the get_notice_text function when the copy is scheduled.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\Watchers\Copied_Post_Watcher::get_notice_text


### PR DESCRIPTION
## Context

Every time I edit a post or page which has an in-progress duplicate, I'm frustrated that the editing screen doesn't show a link to the editing screen for the duplicate.

<img alt="" src="https://github.com/user-attachments/assets/cb5cd625-f93c-45b0-adf8-3388ab519d28" />

This message is _informative_ but not _actionable_.

On a site with a large number of posts or pages, it can be laborious to find that post on the post listing screen in order to get the link to the in-progress duplicate. Each message about an existing duplicate should include a relevant link.

This PR adds a useful link to the editing screen, or the trash listing screen if the duplicate is in the trash:

<img alt="" src="https://github.com/user-attachments/assets/382bc364-0473-4e7f-bb35-e01dc11f5fba" />

<img alt="" src="https://github.com/user-attachments/assets/b30079dc-1a44-49b3-9cad-583aeb69716d" />

## Summary

This PR can be summarized in the following changelog entry:

* Adds a link to the existing duplicate in the Rewrite & Republish admin notices, so you can open it directly instead of hunting for it in the post list. Props to [@johnbillion](https://github.com/johnbillion).

## Relevant technical choices:

I have intentionally appended the links to the existing admin notice messages in order to avoid invalidating existing translations. They might perhaps read better with inline links, but that would require inserting the link HTML into localisable strings which I'm not a big fan of doing.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Click "Rewrite & Republish" on an existing post, and start work on making changes.
* Visit the original post at its permalink on the front end of the site.
* Click the "Edit" button the admin toolbar.
* Confirm that the admin notice now shows a useful link to edit the existing duplicate.

#### Verifying the notice when the duplicate isn't editable by the current user

This covers the case where the current user can edit the original post but *not* its duplicate (for example, the duplicate belongs to someone else). The notice should still appear, but without an "Edit the duplicate." link.

**Setup**

1. Make sure you have two users: an **Administrator** and an **Author** (the Author role can edit its own posts but not other users' posts).

**Steps**

1. Log in as the **Author**. Create a post titled "Original", publish it, and note that the Author is now its owner.
2. Log in as the **Administrator**. Go to **Posts**, hover "Original", and click **Rewrite & Republish** to create an in-progress duplicate.
3. Still as the Administrator, open that duplicate (the "Edit the duplicate." link in the notice on "Original" works for the admin). In the editor sidebar, set the duplicate's **Author** to the **Administrator** (so it is owned by a different user than "Original"), and save the draft.
4. Log out and log back in as the **Author**.
5. Edit the "Original" post.

**Expected result**

* The admin notice appears with the text "A duplicate of this post was made. Please note that any changes you make to this post will be replaced when the duplicated version is republished."
* There is **no** "Edit the duplicate." link after that sentence, and **no** empty or broken link in its place (before this fix, a link with an empty `href` was shown here).

Repeat steps 4–5 in the **Classic editor** to confirm the same behaviour there.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unit tests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.

