### PR TITLE
Fix publish-box button layout on classic editor (WP 7.0+)

### DIFF
--- a/css/duplicate-post.css
+++ b/css/duplicate-post.css
@@ -17,6 +17,17 @@
 }
 
 /* Copy links in the classic editor. */
+/* WP 7.0 turned #major-publishing-actions into a flex row; only opt that container into wrapping when our buttons are present. */
+#major-publishing-actions:has(> #duplicate-action),
+#major-publishing-actions:has(> #rewrite-republish-action) {
+	flex-wrap: wrap;
+}
+
+#major-publishing-actions:has(> #duplicate-action) > #duplicate-action,
+#major-publishing-actions:has(> #rewrite-republish-action) > #rewrite-republish-action {
+	flex-basis: 100%;
+}
+
 #duplicate-action {
 	margin-bottom: 12px;
 }


### PR DESCRIPTION
## Context

* WordPress 7.0 turned `#major-publishing-actions` into a flex row (`flex-wrap: nowrap`), which squeezed our "Copy to a new draft" and "Rewrite & Republish" links onto the same row as "Move to Trash" and "Update", shrinking all four controls.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the _Copy to a new draft_ and _Rewrite & Republish_ links broke the layout of the Classic Editor Publish meta box on WordPress 7.0.

## Relevant technical choices:

* Scope both `flex-wrap: wrap` (on the container) and `flex-basis: 100%` (on each button) behind a `:has(> #duplicate-action)` / `:has(> #rewrite-republish-action)` guard, so the whole fix only applies when our buttons are direct children of `#major-publishing-actions` and each one claims its own row.
* The rules are no-ops on WordPress 6.9 and earlier, where the container is not a flex parent, so no version check is needed and the previous layout is preserved there. Scoping both halves behind the same guard keeps them enabled and disabled in lockstep, so neither rule is left dangling if a future WordPress version changes the markup or drops the flex layout.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a published post in the Classic Editor on WordPress 7.0 or later.
* Confirm "Copy to a new draft" and "Rewrite & Republish" each appear on their own row, above the "Move to Trash" and "Update" controls.
* If available, repeat on WordPress 6.9: the layout should be unchanged.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

This change only affects the Classic Editor Publish meta box; the Block Editor sidebar is untouched.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Classic Editor Publish meta box only.
* If WordPress 7.0.1 or 7.1 ships its own fix for the `#major-publishing-actions` flex layout, re-check this meta box: the rules are scoped behind `:has()` and go inert if the container stops being a flex parent, but a quick visual check confirms our CSS is not redundantly overriding a core fix.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
