### PR TITLE
Fix CVE-2026-53739 (CSRF) & CVE-2026-53740 (XSS)

### DIFF
--- a/admin-functions.php
+++ b/admin-functions.php
@@ -241,10 +241,13 @@ function duplicate_post_show_update_notice() {
 			. '</div>
 		</div>';
 
+	$dismiss_nonce = wp_create_nonce( 'duplicate_post_dismiss_notice' );
+
 	echo "<script>
 			function duplicate_post_dismiss_notice(){
 				var data = {
 				'action': 'duplicate_post_dismiss_notice',
+				'nonce': '" . esc_js( $dismiss_nonce ) . "',
 				};
 
 				jQuery.post(ajaxurl, data, function(response) {
@@ -266,6 +269,14 @@ function duplicate_post_show_update_notice() {
  * @return bool
  */
 function duplicate_post_dismiss_notice() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return false;
+	}
+
+	if ( ! check_ajax_referer( 'duplicate_post_dismiss_notice', 'nonce', false ) ) {
+		return false;
+	}
+
 	return update_site_option( 'duplicate_post_show_notice', 0 );
 }
 

--- a/src/ui/classic-editor.php
+++ b/src/ui/classic-editor.php
@@ -269,7 +269,8 @@ class Classic_Editor {
 			return $messages;
 		}
 
-		$permalink      = \get_permalink( $post->ID );
+		$permalink      = \esc_url( \get_permalink( $post->ID ) );
+		$title          = \esc_html( $post->post_title );
 		$scheduled_date = \get_the_time( \get_option( 'date_format' ), $post );
 		$scheduled_time = \get_the_time( \get_option( 'time_format' ), $post );
 
@@ -280,7 +281,7 @@ class Classic_Editor {
 					'This rewritten post %1$s is now scheduled to replace the original post. It will be published on %2$s.',
 					'duplicate-post',
 				),
-				'<a href="' . $permalink . '">' . $post->post_title . '</a>',
+				'<a href="' . $permalink . '">' . $title . '</a>',
 				'<strong>' . $scheduled_date . ' ' . $scheduled_time . '</strong>',
 			);
 			return $messages;
@@ -293,7 +294,7 @@ class Classic_Editor {
 					'This rewritten page %1$s is now scheduled to replace the original page. It will be published on %2$s.',
 					'duplicate-post',
 				),
-				'<a href="' . $permalink . '">' . $post->post_title . '</a>',
+				'<a href="' . $permalink . '">' . $title . '</a>',
 				'<strong>' . $scheduled_date . ' ' . $scheduled_time . '</strong>',
 			);
 		}

--- a/tests/Unit/UI/Classic_Editor_Test.php
+++ b/tests/Unit/UI/Classic_Editor_Test.php
@@ -820,6 +820,7 @@ final class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_change_scheduled_notice_post() {
 		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
 
 		$post             = Mockery::mock( WP_Post::class );
 		$post->post_type  = 'post';
@@ -936,6 +937,7 @@ final class Classic_Editor_Test extends TestCase {
 	 */
 	public function test_should_change_scheduled_notice_page() {
 		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
 
 		$post             = Mockery::mock( WP_Post::class );
 		$post->post_type  = 'page';
@@ -1041,6 +1043,80 @@ final class Classic_Editor_Test extends TestCase {
 			->andReturn( $scheduled_time );
 
 		$this->assertSame( $result, $this->instance->change_scheduled_notice_classic_editor( $messages ) );
+	}
+
+	/**
+	 * Tests that change_scheduled_notice_classic_editor escapes a malicious post title (CVE-2026-53740).
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Classic_Editor::change_scheduled_notice_classic_editor
+	 *
+	 * @return void
+	 */
+	public function test_change_scheduled_notice_escapes_malicious_title() {
+		$this->stubTranslationFunctions();
+
+		Monkey\Functions\when( '\esc_html' )->alias(
+			static function ( $text ) {
+				return \htmlspecialchars( (string) $text, \ENT_QUOTES, 'UTF-8' );
+			},
+		);
+		Monkey\Functions\when( '\esc_url' )->alias(
+			static function ( $url ) {
+				return \htmlspecialchars( (string) $url, \ENT_QUOTES, 'UTF-8' );
+			},
+		);
+
+		$post             = Mockery::mock( WP_Post::class );
+		$post->post_type  = 'post';
+		$post->post_title = '</a><script>alert(1)</script>';
+		$post->ID         = 1;
+
+		$permalink      = 'http://basic.wordpress.test/example_post';
+		$date_format    = 'F j, Y';
+		$scheduled_date = 'December 18, 2020';
+		$time_format    = 'g:i a';
+		$scheduled_time = '2:30 pm';
+
+		Monkey\Functions\expect( '\get_post' )
+			->once()
+			->andReturn( $post );
+
+		$this->instance->expects( 'should_change_rewrite_republish_copy' )
+			->with( $post )
+			->once()
+			->andReturnTrue();
+
+		Monkey\Functions\expect( '\get_permalink' )
+			->once()
+			->with( $post->ID )
+			->andReturn( $permalink );
+
+		Monkey\Functions\expect( '\get_option' )
+			->once()
+			->with( 'date_format' )
+			->andReturn( $date_format );
+
+		Monkey\Functions\expect( '\get_option' )
+			->once()
+			->with( 'time_format' )
+			->andReturn( $time_format );
+
+		Monkey\Functions\expect( '\get_the_time' )
+			->once()
+			->with( $date_format, $post )
+			->andReturn( $scheduled_date );
+
+		Monkey\Functions\expect( '\get_the_time' )
+			->once()
+			->with( $time_format, $post )
+			->andReturn( $scheduled_time );
+
+		$result = $this->instance->change_scheduled_notice_classic_editor( [] );
+
+		$expected_link = '<a href="' . $permalink . '">&lt;/a&gt;&lt;script&gt;alert(1)&lt;/script&gt;</a>';
+
+		$this->assertStringContainsString( $expected_link, $result['post'][9] );
+		$this->assertStringNotContainsString( '<script>', $result['post'][9] );
 	}
 
 	/**

--- a/tests/WP/Admin_Functions_Test.php
+++ b/tests/WP/Admin_Functions_Test.php
@@ -1262,4 +1262,77 @@ final class Admin_Functions_Test extends TestCase {
 		// Thumbnail SHOULD be copied when enabled.
 		$this->assertSame( $attachment_id, (int) \get_post_meta( $new_id, '_thumbnail_id', true ) );
 	}
+
+	/**
+	 * Tests that duplicate_post_dismiss_notice() dismisses the notice for an authorized user with a valid nonce.
+	 *
+	 * @covers ::duplicate_post_dismiss_notice
+	 *
+	 * @return void
+	 */
+	public function test_dismiss_notice_succeeds_with_valid_nonce_and_capability() {
+		\update_site_option( 'duplicate_post_show_notice', 1 );
+
+		// The set_up() already logs in an administrator (has manage_options).
+		$_REQUEST['nonce'] = \wp_create_nonce( 'duplicate_post_dismiss_notice' );
+
+		$result = \duplicate_post_dismiss_notice();
+
+		$this->assertTrue( $result );
+		$this->assertSame( 0, (int) \get_site_option( 'duplicate_post_show_notice' ) );
+
+		// Clean up.
+		unset( $_REQUEST['nonce'] );
+		\delete_site_option( 'duplicate_post_show_notice' );
+	}
+
+	/**
+	 * Tests that duplicate_post_dismiss_notice() does nothing for a user without the manage_options capability.
+	 *
+	 * @covers ::duplicate_post_dismiss_notice
+	 *
+	 * @return void
+	 */
+	public function test_dismiss_notice_fails_without_capability() {
+		\update_site_option( 'duplicate_post_show_notice', 1 );
+
+		// Switch to a subscriber, who does not have manage_options.
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		\wp_set_current_user( $subscriber_id );
+
+		// Even with a valid nonce the capability check must block the action.
+		$_REQUEST['nonce'] = \wp_create_nonce( 'duplicate_post_dismiss_notice' );
+
+		$result = \duplicate_post_dismiss_notice();
+
+		$this->assertFalse( $result );
+		$this->assertSame( 1, (int) \get_site_option( 'duplicate_post_show_notice' ) );
+
+		// Clean up.
+		unset( $_REQUEST['nonce'] );
+		\delete_site_option( 'duplicate_post_show_notice' );
+	}
+
+	/**
+	 * Tests that duplicate_post_dismiss_notice() does nothing when the nonce is missing or invalid.
+	 *
+	 * @covers ::duplicate_post_dismiss_notice
+	 *
+	 * @return void
+	 */
+	public function test_dismiss_notice_fails_with_invalid_nonce() {
+		\update_site_option( 'duplicate_post_show_notice', 1 );
+
+		// The set_up() already logs in an administrator (has manage_options).
+		$_REQUEST['nonce'] = 'invalid-nonce';
+
+		$result = \duplicate_post_dismiss_notice();
+
+		$this->assertFalse( $result );
+		$this->assertSame( 1, (int) \get_site_option( 'duplicate_post_show_notice' ) );
+
+		// Clean up.
+		unset( $_REQUEST['nonce'] );
+		\delete_site_option( 'duplicate_post_show_notice' );
+	}
 }


### PR DESCRIPTION
## Context

Two vulnerabilities were disclosed against Yoast Duplicate Post (all versions through 4.6):

* **CVE-2026-53739 (CSRF):** the "You've successfully installed Yoast Duplicate Post!" admin notice could be dismissed for everyone through a forged request, because the dismiss handler verified neither a nonce nor the user's capabilities.
* **CVE-2026-53740 (stored XSS):** the Classic editor's "scheduled to replace the original" notice printed a Rewrite & Republish copy's title and permalink without escaping. On supported WordPress (the plugin requires 6.8+) core neutralizes this at output, because `wp_admin_notice()` runs admin notices through `wp_kses_post()` (WP 6.4+), so the payload renders inert and script execution is only reachable on WordPress older than 6.4. The values are now escaped at the source so the plugin no longer relies on that core behavior.

## Summary

This PR can be summarized in the following changelog entry:

* Improves the security of the welcome notice dismissal by requiring a valid nonce and the `manage_options` capability.
* Improves the security of the scheduled republish notice in the Classic editor by escaping the post title and permalink before output.

## Relevant technical choices:

* The dismiss handler now requires the `manage_options` capability — the same capability already required to *see* the notice (`duplicate_post_show_update_notice()`) — plus a nonce that is generated with `wp_create_nonce()`, sent with the existing AJAX request, and verified with `check_ajax_referer()`.
* The scheduled-republish notice now wraps the permalink in `esc_url()` and the title in `esc_html()`. The surrounding sentence already goes through `esc_html__()`, so only the interpolated link needed escaping.
* This is defense-in-depth: WordPress core already strips executable markup from admin notices at output (`wp_kses_post()` via `wp_admin_notice()`, WP 6.4+), so the notice is not exploitable on the supported WP range (6.8+). The escaping also covers older cores that echo the message raw.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Stored XSS (CVE-2026-53740)**

Core (WP 6.4+) already strips `<script>` and event handlers from admin notices, so on a supported install this is verified by confirming the copy title is rendered as escaped text instead of being interpreted as HTML.

1. On a single-site install with the **Classic editor** active, create and publish a post, then choose **Rewrite & Republish** on it.
2. In the rewrite copy, set the title to `<img src=x onerror=alert(1)>` and schedule it for a future date.
3. On the scheduled-confirmation notice ("… is now scheduled to replace the original …"):
   * **Before the fix:** the title's markup is interpreted by the notice and a broken `<img>` element renders. (No alert fires even before the fix: WordPress core strips the `onerror` handler at output.)
   * **After the fix:** the title is shown as literal text (`<img src=x onerror=alert(1)>`) and no element renders.
4. Optional: view the page source to confirm the title appears HTML-encoded after the fix.

**CSRF (CVE-2026-53739)**

This verifies the notice can only be dismissed by a request that carries a valid nonce (what a normal click sends), and not by a forged request that lacks one.

1. Make sure the notice is visible: log in as an administrator and go to **Dashboard** or **Plugins**. You should see the "You've successfully installed Yoast Duplicate Post!" notice. (If you've already dismissed it, re-enable it under **Settings → Duplicate Post → Display** by ticking **Show welcome notice** and saving, or with WP-CLI: `wp eval "update_site_option('duplicate_post_show_notice', 1);"`, then reload.)
2. Open your browser's developer tools (F12) and switch to the **Console** tab. You are logged in as admin, so your session cookies are sent automatically — this simulates a forged request that has the right action but no valid nonce.
3. Paste this and press Enter to fire a dismiss request **without** a nonce:
   ```js
   jQuery.post(ajaxurl, { action: 'duplicate_post_dismiss_notice' }, function (r) { console.log('response:', r); });
   ```
   (Optionally repeat with an invalid nonce by adding `nonce: 'invalid'` to the object.) The logged response should be `0` — the request was rejected.
4. Reload the page. **Expected:** the notice is **still there** — the forged request did not dismiss it.
5. Positive control: click the notice's **×** button (this sends the real request, with the nonce the page generated). The notice disappears, and after a reload it stays gone — confirming legitimate dismissal still works.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The "You've successfully installed Yoast Duplicate Post!" admin notice and its dismissal (`duplicate_post_dismiss_notice()` AJAX handler in `admin-functions.php`).
* The Classic editor scheduled-republish notice for Rewrite & Republish copies (`src/ui/classic-editor.php`).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes CVE-2026-53739 and CVE-2026-53740.
