### PR TITLE
docs: add AI agent documentation and contributor guide

### DIFF
--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,16 @@
+---
+description: Duplicate Post contributor and agent instructions — always apply
+alwaysApply: true
+---
+
+The canonical contributor guide for this repository is [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md). It covers architecture, tooling, workflows, testing, code style, commits, and PR conventions. [`AGENTS.md`](../../AGENTS.md) adds a short set of behaviours specific to AI coding agents on top. Cursor should treat `CONTRIBUTING.md` as the primary source of truth and `AGENTS.md` as the agent-behaviour delta.
+
+@../../.github/CONTRIBUTING.md
+
+@../../AGENTS.md
+
+Additional authoritative doc:
+
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) — PR template and changelog conventions.
+
+If anything in this file contradicts `CONTRIBUTING.md`, the PR template, or `AGENTS.md`, prefer those.

--- a/.cursor/rules/create-pr.mdc
+++ b/.cursor/rules/create-pr.mdc
@@ -1,0 +1,14 @@
+---
+description: Duplicate Post — create a pull request workflow. Apply whenever the user asks to open, file, or update a pull request.
+alwaysApply: false
+---
+
+When the user asks to create, open, or update a pull request, follow the procedure in [`docs/workflows/create-pr.md`](../../docs/workflows/create-pr.md) exactly. That file is the canonical workflow shared across tools — do not reinvent it from context.
+
+@../../docs/workflows/create-pr.md
+
+The recipe's own references are:
+
+- [`AGENTS.md`](../../AGENTS.md) — conventions and architecture.
+- [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md) — pre-push checks and coverage policy.
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) — changelog grammar, labels, and section structure.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,208 @@
+# Contribution Guidelines
+
+Thanks for taking the time to contribute to Yoast Duplicate Post! Before filing a bug report, feature request, or pull request, please read the guidelines below.
+
+This file is the canonical contributor guide for this repository. It is written for both humans and AI coding tools. The repo-root [`AGENTS.md`](../AGENTS.md) adds a small set of behaviours specific to AI agents on top of the rules here; the [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) carries the detailed changelog and label rules.
+
+## Contents
+
+- [How to use GitHub](#how-to-use-github)
+- [Security issues](#security-issues)
+- [I have found a bug](#i-have-found-a-bug)
+- [I have a feature request](#i-have-a-feature-request)
+- [I want to create a patch](#i-want-to-create-a-patch)
+  - [License and copyright](#license-and-copyright)
+  - [Supported environment](#supported-environment)
+  - [Repository layout](#repository-layout)
+  - [Where to put new code](#where-to-put-new-code)
+    - [Legacy procedural files](#legacy-procedural-files)
+  - [No dependency-injection container](#no-dependency-injection-container)
+  - [PHP workflow](#php-workflow)
+  - [JavaScript workflow](#javascript-workflow)
+  - [Testing](#testing)
+  - [Code style](#code-style)
+  - [Opening a pull request](#opening-a-pull-request)
+    - [Before you push or open/update a PR](#before-you-push-or-openupdate-a-pr)
+  - [Changelog entry and label](#changelog-entry-and-label)
+  - [Submitting an issue you have found](#submitting-an-issue-you-have-found)
+- [Additional resources](#additional-resources)
+
+## How to use GitHub
+
+We use GitHub exclusively for well-documented bugs, feature requests, and code contributions. Communication is always done in English.
+
+For support with Duplicate Post, use the [support forum](https://wordpress.org/support/plugin/duplicate-post) on WordPress.org.
+
+## Security issues
+
+Please do **not** report security issues on GitHub. Follow our [security program](https://yoast.com/security-program/) instead — see [`yoast.com/security.txt`](https://yoast.com/security.txt) for the canonical contact details — so we can handle them quickly and responsibly.
+
+## I have found a bug
+
+Before opening a new issue, please:
+
+* update to the latest versions of WordPress and Duplicate Post.
+* search for duplicate issues to avoid filing the same report twice. If an open issue already exists, please comment on it.
+* check for plugin and theme conflicts, and include your findings.
+* check for JavaScript errors in your browser's console and include any output.
+* pick the matching GitHub issue form (Bug report, Feature request, Task) and fill in every section.
+* include everything needed to understand and reproduce the problem — screenshots, clear reproduction steps, plugin and theme versions, and any relevant logs — but stay focused. A tight, reproducible report is easier to triage than a long narrative with unrelated context.
+
+## I have a feature request
+
+Before opening a new issue:
+
+* search for duplicate issues to avoid filing the same request twice. If an open request already exists, please add your thoughts there.
+* pick the Feature request issue form and explain *why* you think this feature is worth considering.
+
+## I want to create a patch
+
+Community patches, localizations, bug reports, and contributions are very welcome.
+
+### License and copyright
+
+Duplicate Post is licensed under [GPL-2.0-or-later](../LICENSE). By opening a pull request you confirm that your contribution is offered under the same license. Before contributing code, make sure that:
+
+- You wrote the code yourself, or you have the right to relicense it under GPL-2.0-or-later.
+- You have not copied code from sources whose license is incompatible with GPL-2.0-or-later (for example proprietary code, CC-licensed snippets that restrict commercial use, or GPL-3.0-only code).
+- If you have reused code from a GPL-2.0-compatible source (MIT, BSD, public domain, etc.), you have preserved the original copyright notice and license header, and noted the provenance in the commit message.
+- You have not included code whose licensing status is unclear — including AI-generated code whose training or output terms you have not verified as compatible.
+
+If you are unsure whether a piece of code is safe to include, ask in the issue or PR before opening it for review.
+
+### Supported environment
+
+* PHP: the minimum version is the `Requires PHP` header in [`readme.txt`](../readme.txt) (also pinned in [`composer.json`](../composer.json)).
+* WordPress: the supported range is the `Requires at least` and `Tested up to` headers in [`readme.txt`](../readme.txt).
+* The plugin is a single PHP plugin with a small JavaScript bundle (block-editor integration) built through webpack and Grunt.
+
+### Repository layout
+
+The top-level paths you will touch (or explicitly avoid):
+
+| Path | Purpose | Editable? |
+| --- | --- | --- |
+| `src/` | Namespaced PHP (`Yoast\WP\Duplicate_Post\`). All new backend work lives here. | Yes |
+| `js/src/` | Source for the block-editor JavaScript. | Yes |
+| `tests/` | PHPUnit tests (`tests/Unit`, `tests/WP`). | Yes |
+| `config/` | Grunt, webpack, wp-env, composer actions, build scripts. | Yes, with care |
+| `compat/` | Compatibility shims for third-party plugins. | Yes, with care |
+| `admin-functions.php`, `common-functions.php`, `options.php` | Legacy procedural PHP. | **Maintenance only** — see below |
+| `duplicate-post.php` | Plugin bootstrap and manual service wiring. | With care |
+| `vendor/`, `node_modules/` | Composer / Yarn dependencies. | Never hand-edit |
+| `js/dist/`, `artifact/`, `languages/` | Generated or distribution artifacts. | Never hand-edit — regenerate via Grunt |
+| `readme.txt`, `changelog.md` | wordpress.org readme and the generated changelog. | See [Changelog entry and label](#changelog-entry-and-label) |
+
+### Where to put new code
+
+`src/` is classmap-autoloaded under the `Yoast\WP\Duplicate_Post\` namespace. Code is grouped by its role in the plugin rather than by onion layers:
+
+```
+src/
+├── admin/        Admin screens, settings, and their views.
+├── handlers/     Request handlers (bulk, REST, save-post, links, …).
+├── ui/           User-facing surfaces (metabox, block editor, columns, row actions, …).
+├── watchers/     Hook listeners that react to post lifecycle events.
+└── *.php         Shared services (post-duplicator, post-republisher, permissions-helper, utils, …).
+```
+
+When you extend an existing feature, keep the new code in the matching folder and follow the surrounding patterns. New files are a last resort — prefer extending an existing class. PHP files are kebab-case (`link-handler.php`); class names follow Yoast's convention of snake_case with underscores (e.g. `Link_Handler`).
+
+#### Legacy procedural files
+
+`admin-functions.php`, `common-functions.php`, and `options.php` contain pre-namespace procedural code. Treat them as **maintenance-only**: fix bugs and keep them compatible, but do not add new features there. When a legacy function needs significant changes, consider extracting the affected responsibility into a class under `src/`.
+
+### No dependency-injection container
+
+Unlike Yoast SEO, Duplicate Post does **not** use a compiled DI container. Services are instantiated and wired by hand in the `duplicate-post.php` bootstrap. There is no `compile-di` step — when you add a service, wire it explicitly in the bootstrap and pass its dependencies through the constructor.
+
+### PHP workflow
+
+All commands are run from the repo root.
+
+| Command | What it does |
+| --- | --- |
+| `composer update` | Install PHP dependencies. `composer.lock` is not committed in this repo, so use `update` rather than `install`. |
+| `composer lint` | PHP parse-error check across the repo. |
+| `composer check-cs` | Run phpcs with the Yoast ruleset (errors only, no warnings). |
+| `composer check-branch-cs` | Run phpcs against the files changed on the current branch. |
+| `composer check-staged-cs` | Run phpcs against staged files. |
+| `composer fix-cs` | Auto-fix fixable phpcs violations. |
+| `composer test` | Run PHPUnit unit tests (no WP, no coverage). |
+| `composer test-wp` | Run the WP integration tests against a local WP test install. |
+| `composer test-wp-env` | Run the WP integration tests inside the `wp-env` Docker environment (preferred locally). |
+| `composer coverage` / `coverage-wp-env` | The test commands above, with coverage. |
+
+Coding standards are enforced by the Yoast Coding Standard (`yoast/yoastcs`) — a superset of the WordPress Coding Standards — plus parallel-lint for syntax. Run `composer check-branch-cs` before opening a PR.
+
+### JavaScript workflow
+
+The block-editor JavaScript is built through Grunt (which drives webpack). `package.json` has no npm scripts; use Grunt directly.
+
+| Command | What it does |
+| --- | --- |
+| `yarn install` | Install JS build dependencies. |
+| `grunt` / `grunt build` | Build the block-editor JS bundle (webpack development build). |
+| `grunt release` | Production JS build (used by the release/artifact pipeline). |
+| `grunt build:images` | Optimise the wp.org store assets in `svn-assets/` (banner, icons, screenshots) via imagemin. Run manually only when you change those assets — it is **not** part of `grunt build` or the release pipeline. |
+
+### Testing
+
+- **Every PR that changes PHP behaviour should ship unit tests.** Place them under `tests/Unit/…`, mirroring the path of the class under test.
+- **Integration tests** (those that boot WordPress) live under `tests/WP/…` and run via `composer test-wp-env`, which starts an isolated WP in Docker through `@wordpress/env`.
+- Test one method per test class where practical; share setup via abstract base classes or traits (examples already exist under `tests/Unit`).
+- If you cannot run the integration tests in your environment, say so explicitly in the PR description rather than skipping them silently.
+
+### Code style
+
+- Follow the existing code. When two styles look plausible, match the file you are editing.
+- PHP: Yoast CS (`yoast/yoastcs`), configured in [`.phpcs.xml.dist`](../.phpcs.xml.dist). Namespaces live under `Yoast\WP\Duplicate_Post\…`.
+- The CS check enforces an error/warning **threshold** (see the `check-cs-thresholds` composer script). Do not raise the threshold to make a violation pass — fix the violation.
+- Comments: document **why**, not **what**. End every inline comment with a full stop.
+- Don't add features, scaffolding, or abstractions the task doesn't need.
+
+### Opening a pull request
+
+1. Create your branch from `trunk`. `trunk` is the active development branch and the default branch on GitHub — every PR should target it unless a maintainer asks otherwise. When the work tracks a GitHub issue, name your branch `<issue-number>-<short-description>` (e.g. `210-scheduled-republish`).
+2. Make your changes.
+3. Follow the [Yoast Coding Standards](https://github.com/Yoast/yoastcs).
+4. Document any new functions, actions, and filters following the [PHP inline-documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
+5. Write tests. We expect every PR that changes PHP behaviour to ship unit tests.
+6. Use the [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages (e.g. `fix: …`, `feat(ui): …`). **Prefer atomic commits** — each commit should represent a single logical change. If your PR mixes unrelated changes, split them into separate commits or ideally separate PRs.
+7. Push your branch and open a pull request against `trunk`. **Use the pull request template** at [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) and fill in every section — even for small changes.
+8. **Keep the PR description focused.** Fill every required section of the template with what the reviewer actually needs. *Test instructions* should be concrete steps, not essays. Link to the issue rather than restating it.
+
+#### Before you push or open/update a PR
+
+Run these checks locally and make sure each one is clean. CI runs the same checks.
+
+* `composer test` — the unit test suite must pass.
+* `composer test-wp-env` — the WordPress integration tests (Docker via `@wordpress/env`) must pass if your change touches code that has or needs WP integration coverage.
+* `composer check-branch-cs` — must report **no new errors or warnings** introduced by your branch. Use `composer fix-cs` to auto-fix what it can, and address the rest by hand.
+* `composer lint` — PHP parse-error check.
+* For changes under `js/`: run `grunt build` and confirm the bundle builds.
+* Only if you changed a wp.org store asset under `svn-assets/`: run `grunt build:images` and commit the optimised output. (It is not run by `grunt build` or the release pipeline, so it will not happen automatically.)
+
+If a check fails or you need to skip one (e.g. you can't run Docker locally for `test-wp-env`), say so explicitly in the PR description so reviewers know what still needs validating.
+
+### Changelog entry and label
+
+Every PR needs a **changelog entry** in the Summary section of the PR body and a **changelog label** on the PR itself:
+
+* Write one bullet describing the change in present tense, 3rd person singular, ending with a full stop. For bugfixes, describe the incorrect behaviour followed by the condition that triggered it, in clear past tense (e.g. `Fixes a bug where X happened when Y`). See [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) for the full grammar.
+* Keep each bullet to one short sentence. Extra context belongs in *Context* or *Relevant technical choices*, not in the bullet.
+* Attach one of: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
+* If the change also affects another Yoast repo, add an extra bullet prefixed with `[<repo-name>]`.
+* The release `changelog.md` is generated from merged PRs by [`.github/scripts/generate-changelog.sh`](./scripts/generate-changelog.sh) — do not hand-write release sections into it; the PR body's bullet and label are the source.
+
+Milestones are set by the maintainer who merges your PR.
+
+### Submitting an issue you have found
+
+Make sure your problem doesn't already have a ticket by searching [the existing issues](https://github.com/Yoast/duplicate-post/issues). If you can't find anything matching, please [open a new issue](https://github.com/Yoast/duplicate-post/issues/new/choose).
+
+## Additional resources
+
+* [Yoast developer portal](https://developer.yoast.com/)
+* [General GitHub documentation](https://docs.github.com/)
+* [GitHub Pull Request documentation](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ phpunit-wp.xml
 # Temp files
 ############
 /.tmp
+
+############
+# AI
+############
+/.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md — Duplicate Post agent delta
+
+This file follows the [AGENTS.md](https://agents.md/) convention (supported natively by OpenAI Codex, Cursor, Aider, Zed, Copilot, Gemini CLI, Windsurf, JetBrains Junie, and others; Claude Code reads it via a thin `CLAUDE.md` pointer).
+
+**Read [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md) first.** It is the canonical source of truth for this repository: architecture, repository layout, code placement, build and test commands, coding standards, commits, branches, the PR opening procedure, changelog rules, license, and security. This file does not repeat any of that — it only lists the behaviours specific to working in this repo as an **AI coding agent**.
+
+If a rule appears to conflict between this file and `CONTRIBUTING.md` or [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md), prefer those. Edit the source, not this delta.
+
+## Behaviour rules for agents
+
+- **Delegate long-running commands.** Do not run `composer` or `grunt` in the main session — the output clutters context. If a build-runner-style agent is available, delegate to it and have it return PASS/FAIL plus failing-case details only. When no such agent is available, summarise the output rather than inlining it.
+
+- **Verify before you recommend.** Before citing a file path, function name, class, flag, or any other code identifier from memory, confirm it still exists — `ls`, `grep`, or a file read. Memory is a snapshot; the tree may have moved.
+
+- **Use the real commands for this repo.** Tests and CS run through `composer` (`test`, `test-wp`, `test-wp-env`, `check-branch-cs`, `fix-cs`, `lint`); the JS bundle builds through `grunt` / `grunt build` (dev) or `grunt release` (production). There is **no** `composer compile-di`, **no** `grunt build:dev`, and **no** npm/yarn run-scripts in this repo — don't invent them. See [CONTRIBUTING.md → "JavaScript workflow"](./.github/CONTRIBUTING.md#javascript-workflow).
+
+- **Prefer editing over creating.** Before adding a new file, abstraction, or directory, search for where similar functionality already lives and extend that instead. New files are the last resort.
+
+- **Don't paper over failures.** If a pre-push check, test, or coding-standard rule fails, fix it or flag it. Do not skip tests, raise the CS error/warning threshold (the `check-cs-thresholds` script), add ignore pragmas, or untick quality-assurance boxes on the PR template without explicit permission.
+
+- **Don't hand-edit generated or vendored files.** `vendor/`, `node_modules/`, `js/dist/`, `artifact/`, `languages/` — regenerate via the appropriate tooling. The full list is in [CONTRIBUTING.md → "Repository layout"](./.github/CONTRIBUTING.md#repository-layout).
+
+- **Run `grunt build:images` only when you change the wp.org store assets.** `grunt build:images` (imagemin) is configured to optimise only the wp.org store assets under `svn-assets/` (banner, icons, screenshots); there is no `images/` source dir, and other image files elsewhere in the repo are not processed by it. If you edit an `svn-assets/` asset, run it and commit the optimised output. It is **not** part of `grunt build` or the release pipeline, so nothing runs it automatically — for any normal code change it is irrelevant.
+
+- **Respect the legacy/`src/` split.** New backend work goes in `src/` under `Yoast\WP\Duplicate_Post\`. The root `*-functions.php` files and `options.php` are maintenance-only legacy code — don't add features there. There is no DI container; wire new services by hand in the `duplicate-post.php` bootstrap. See [CONTRIBUTING.md → "Where to put new code"](./.github/CONTRIBUTING.md#where-to-put-new-code).
+
+- **Keep changelog bullets to one short sentence.** Extra context goes in *Context* or *Relevant technical choices*, not in the bullet. Attach exactly one `changelog:` label and never set the milestone. See [CONTRIBUTING.md → "Changelog entry and label"](./.github/CONTRIBUTING.md#changelog-entry-and-label).
+
+- **Ask, don't guess.** If a change might affect another Yoast repo but the diff does not prove it, ask before adding a cross-repo changelog entry. If the licensing status of reused or AI-generated code is unclear, ask before including it.
+
+- **Default to CONTRIBUTING.md.** Anything not listed in this delta is in `CONTRIBUTING.md` or the PR template. Read those before making assumptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+The canonical contributor guide for this repository is [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md) — it covers architecture, tooling, workflows, testing, code style, commits, and PR conventions. [`AGENTS.md`](./AGENTS.md) layers a short set of behaviours specific to AI coding agents on top. Both are pulled into context below so Claude Code sees them on every session.
+
+@.github/CONTRIBUTING.md
+
+@AGENTS.md

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -1,0 +1,98 @@
+# Creating a pull request
+
+This is the canonical workflow for opening a pull request on this repository. It is written to be followed by both humans and AI coding agents. Tool-specific entry points — the Claude Code skill, the Cursor rule, any future Copilot chat mode — should be thin pointers to this file so every tool follows the same procedure.
+
+Rules and templates live elsewhere — this file is the **procedure**:
+
+- **Changelog grammar, label rules, section structure** → [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+- **Architecture, repository layout, placement rules, build/test commands, Yoast CS ruleset, testing policy, commit style, branching, pre-push checks** → [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md)
+- **Agent-specific behaviours (delegate long-running commands, verify before recommending, ask don't guess)** → [`AGENTS.md`](../../AGENTS.md)
+
+If anything here contradicts those files, prefer them. Edits to rules belong there, not in this file.
+
+## 0. Creator vs. merger responsibilities
+
+Every merged PR needs a changelog entry and a changelog label. The milestone is the merger's job.
+
+- **Creator provides:** a changelog entry (in the PR body) and a `changelog:` label on the PR.
+- **Creator MUST NOT set:** the milestone. Do not add a milestone via `gh pr edit --milestone`.
+
+## 1. Gather context
+
+Run in parallel:
+
+- `git status`
+- `git diff`
+- `git log <base>..HEAD` and `git diff <base>...HEAD` — inspect **every** commit since the branch diverged, not just the tip.
+- Check whether the branch has an upstream and is up to date.
+
+Identify the base branch: usually `trunk`. PRs targeting `release/*` follow stricter label rules — check the PR template.
+
+Read [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) so the PR body matches it section-for-section.
+
+## 2. Verify checks
+
+Follow the pre-push checklist in [`.github/CONTRIBUTING.md` — "Before you push or open/update a PR"](../../.github/CONTRIBUTING.md#before-you-push-or-openupdate-a-pr). All required checks must pass **before** calling `gh pr create`:
+
+- `composer test`
+- `composer test-wp-env` — when the change touches code that has or needs WP integration coverage (disclose in the PR body if Docker is unavailable)
+- `composer check-branch-cs`
+- `composer lint`
+- `grunt build` if `js/` changed; `grunt build:images` only if you changed a wp.org asset under `svn-assets/`.
+
+Do not paper over failures by excluding tests, raising CS thresholds, or adding ignore pragmas without explicit permission. If a `build-runner`-style agent is available in your tool, delegate the actual command execution there so the main session stays focused on the workflow.
+
+## 3. Decide how many changelog bullets the PR needs
+
+Default is **one bullet**, describing one logical change. Write more than one bullet only when:
+
+- **Multiple distinct changes in the same repo and same label** — one bullet per change, no brackets.
+- **Bullets with different changelog types** — note the differing type where relevant.
+- **Impact on another repo** — add a bullet prefixed with `[<repo-name>]`.
+
+Grammar, bracket syntax, and the bugfix template live in the PR template — follow it, do not restate the rules in the PR body.
+
+If you are not certain a change affects another repo, ask the user rather than guessing.
+
+## 4. Fill every PR-template section
+
+Cover every section of `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- **Context** — *why* the change is being made.
+- **Summary** — the changelog bullet(s) from step 3.
+- **Relevant technical choices** — non-obvious decisions, trade-offs, architectural notes.
+- **Test instructions (acceptance)** — step-by-step, aimed at non-technical users.
+- **Relevant test scenarios** — tick the boxes that apply (console open, post/page/CPT/taxonomy, editor type, browser, multisite) and explain why for each ticked box.
+- **Test instructions for QA in the RC** — tick "same steps as above" when acceptance and QA match, or write separate steps.
+- **Impact check** — parts of the plugin that may need regression testing.
+- **UI changes** — tick the box and add the `UI change` label only when the PR changes the UI.
+- **Documentation / Quality assurance / Innovation** checkboxes — tick only those that are actually true.
+- **Fixes #** — link the issue being closed, if any.
+
+Preserve the HTML comments from the template so future editors keep the same structure.
+
+## 5. Create and label the PR
+
+1. Push the branch if it has no upstream: `git push -u origin <branch>`.
+2. `gh pr create --base <base> --title "<title>" --body-file <file>`.
+   - Pass `--base` with the base branch identified in step 1 (usually `trunk`, or a `release/*` branch). Do not rely on the repository default — be explicit so release PRs target the right branch.
+   - Title under 70 characters. Use a Conventional Commits prefix when natural (`fix: …`, `feat(ui): …`).
+   - Pass the body via `--body-file`, never an inline heredoc — Markdown fences and `$` sigils mangle through shell escaping.
+3. Apply the changelog label immediately: `gh pr edit <number> --add-label "changelog: <type>"`. Add the `UI change` label in the same call only when the PR changes the UI.
+4. **Never set the milestone.**
+5. Return the PR URL.
+
+## 6. Self-check
+
+Before reporting the PR as created, verify:
+
+- [ ] Pre-push checks (step 2) ran and passed — any skipped check is disclosed in the PR body.
+- [ ] The body contains at least one changelog bullet, correctly prefixed for every affected changelog.
+- [ ] Exactly one `changelog:` label is attached; the `UI change` label matches the content.
+- [ ] Bugfix bullets describe the incorrect behaviour followed by the triggering condition, in past tense, per the PR template's grammar rules.
+- [ ] Every PR-template section has content — no empty bullets, no leftover placeholder text.
+- [ ] No milestone was set.
+- [ ] If the branch changed a wp.org asset under `svn-assets/`, `grunt build:images` was run and the optimised output committed.
+- [ ] Each changelog bullet is one short sentence; extra context lives in *Context* or *Relevant technical choices*.
+
+If any item fails, fix it (edit the body or labels with `gh pr edit`) before returning the URL.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This repository had no contributor guide and no documentation aimed at AI coding tools. Yoast SEO (`wordpress-seo`) recently grew a layered set of agent docs, and this PR ports that layer to Duplicate Post so that Claude Code, Cursor, Codex, and human contributors all work from one consistent, repo-accurate set of rules.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds contributor and AI-agent documentation (`CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`, Cursor rules, and a shared pull-request workflow).

## Relevant technical choices:

* The design follows `wordpress-seo`: `.github/CONTRIBUTING.md` is the single source of truth, `AGENTS.md` is a small cross-tool "delta" layered on top of it, and every tool entry point (`CLAUDE.md`, the Cursor rules, the create-pr skill) is a thin pointer that `@`-imports the canonical docs rather than duplicating them.
* All content was rewritten for this repo rather than copied. `CONTRIBUTING.md` documents the real `composer`/`grunt` commands, the role-based `src/` layout, manual service wiring (there is **no** DI container here, unlike Yoast SEO), and the actual PR template. The pre-existing `build-runner` agent was a verbatim Yoast SEO copy with the wrong plugin name, non-existent commands (`compile-di`, `yarn` scripts), and a broken absolute memory path; it has been corrected.
* `/.claude/` is gitignored exactly as in `wordpress-seo`, so the `build-runner` agent and the create-pr skill stay local-only. The shared, tracked layer is `AGENTS.md`, `CLAUDE.md`, the Cursor rules, and `docs/workflows/create-pr.md`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check out this branch.
* Open `.github/CONTRIBUTING.md` and read it through: confirm the commands, paths, and `src/` folders it mentions actually exist in the repo.
* Open `CLAUDE.md` and `AGENTS.md` and confirm every link points to a file that exists (`.github/CONTRIBUTING.md`, `AGENTS.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `docs/workflows/create-pr.md`).
* In `docs/workflows/create-pr.md`, confirm step 5 uses `gh pr create --base <base> ...`.
* Optionally, in Claude Code run `/create-pr` and confirm it loads the workflow from `docs/workflows/create-pr.md`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
Not applicable. This PR only adds repository documentation and AI-tooling configuration; there is nothing for QA to test in the RC.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None. No runtime PHP or JavaScript is changed; the PR touches only documentation and a `.gitignore` rule.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
