### PR TITLE
fix: prevent unauthorized Rewrite & Republish post takeover

### DIFF
--- a/src/post-republisher.php
+++ b/src/post-republisher.php
@@ -128,11 +128,15 @@ class Post_Republisher {
 	 * @return void
 	 */
 	public function republish_request( $post ) {
-		if (
-			! $post instanceof WP_Post
-			|| ! $this->permissions_helper->is_rewrite_and_republish_copy( $post )
-			|| ! $this->permissions_helper->is_copy_allowed_to_be_republished( $post )
-		) {
+		if ( ! $post instanceof WP_Post || ! $this->permissions_helper->is_rewrite_and_republish_copy( $post ) ) {
+			return;
+		}
+
+		$is_republishing = $this->permissions_helper->is_copy_allowed_to_be_republished( $post );
+		$is_scheduling   = ( $post->post_status === 'future' );
+
+		// Only act on a republish submission or the scheduling of a republish.
+		if ( ! $is_republishing && ! $is_scheduling ) {
 			return;
 		}
 
@@ -143,6 +147,9 @@ class Post_Republisher {
 		}
 
 		if ( ! \current_user_can( 'edit_post', $original_post->ID ) ) {
+			// Undo the republish or scheduling but keep the copy's content, so the original is never overwritten.
+			$this->revert_unauthorized_copy( $post );
+
 			\wp_die(
 				\esc_html__( 'You are not allowed to republish this post.', 'duplicate-post' ),
 				\esc_html__( 'Permission denied', 'duplicate-post' ),
@@ -150,11 +157,14 @@ class Post_Republisher {
 			);
 		}
 
-		$this->republish( $post, $original_post );
+		// A scheduled copy is republished by cron at the scheduled time, not now.
+		if ( $is_republishing ) {
+			$this->republish( $post, $original_post );
 
-		// Trigger the redirect in the Classic Editor.
-		if ( $this->is_classic_editor_post_request() ) {
-			$this->redirect( $original_post->ID, $post->ID );
+			// Trigger the redirect in the Classic Editor.
+			if ( $this->is_classic_editor_post_request() ) {
+				$this->redirect( $original_post->ID, $post->ID );
+			}
 		}
 	}
 
@@ -463,6 +473,25 @@ class Post_Republisher {
 			),
 		);
 		exit();
+	}
+
+	/**
+	 * Reverts a copy that the current user is not allowed to republish back to draft.
+	 *
+	 * Preserves the copy's content while undoing the republish or scheduling, so the original
+	 * is never overwritten and the copy is not left published or in a republish-pending state.
+	 *
+	 * @param WP_Post $post The copy's post object.
+	 *
+	 * @return void
+	 */
+	protected function revert_unauthorized_copy( WP_Post $post ) {
+		\wp_update_post(
+			[
+				'ID'          => $post->ID,
+				'post_status' => 'draft',
+			],
+		);
 	}
 
 	/**

--- a/src/ui/block-editor.php
+++ b/src/ui/block-editor.php
@@ -233,8 +233,11 @@ class Block_Editor {
 		$original_data                 = null;
 
 		if ( $original_item instanceof WP_Post ) {
+			// get_edit_post_link() returns null when the current user cannot edit the original post.
+			$edit_link = (string) \get_edit_post_link( $original_item->ID, 'raw' );
+
 			$original_data = [
-				'editUrl'  => \esc_url_raw( \get_edit_post_link( $original_item->ID, 'raw' ) ),
+				'editUrl'  => \esc_url_raw( $edit_link ),
 				'viewUrl'  => \esc_url_raw( \get_permalink( $original_item->ID ) ),
 				'title'    => \html_entity_decode( \_draft_or_post_title( $original_item ), \ENT_QUOTES, 'UTF-8' ),
 				'canEdit'  => \current_user_can( 'edit_post', $original_item->ID ),

--- a/tests/Unit/Post_Republisher_Test.php
+++ b/tests/Unit/Post_Republisher_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Duplicate_Post\Tests\Unit;
 
 use Brain\Monkey;
+use Exception;
 use Mockery;
 use WP_Post;
 use Yoast\WP\Duplicate_Post\Permissions_Helper;
@@ -251,6 +252,267 @@ final class Post_Republisher_Test extends TestCase {
 				],
 			],
 		];
+	}
+
+	/**
+	 * Tests that republish_request returns early when the post is not a Rewrite & Republish copy.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_request
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_returns_early_when_not_a_copy() {
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_status = 'dp-rewrite-republish';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->andReturnFalse();
+
+		$this->permissions_helper->expects( 'is_copy_allowed_to_be_republished' )->never();
+		$this->instance->expects( 'republish' )->never();
+
+		$this->instance->republish_request( $copy );
+	}
+
+	/**
+	 * Tests that republish_request returns early when the copy is neither being republished nor scheduled.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_request
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_returns_early_when_status_is_not_actionable() {
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_status = 'draft';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'is_copy_allowed_to_be_republished' )
+			->with( $copy )
+			->andReturnFalse();
+
+		$this->instance->expects( 'republish' )->never();
+
+		$this->instance->republish_request( $copy );
+	}
+
+	/**
+	 * Tests that republish_request republishes the copy when the user is allowed to edit the original.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_request
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_republishes_when_user_is_allowed() {
+		$original     = Mockery::mock( WP_Post::class );
+		$original->ID = 1;
+
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_status = 'dp-rewrite-republish';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'is_copy_allowed_to_be_republished' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils
+			->expects( 'get_original' )
+			->with( $copy->ID )
+			->andReturn( $original );
+
+		Monkey\Functions\expect( '\current_user_can' )
+			->with( 'edit_post', $original->ID )
+			->andReturnTrue();
+
+		$this->instance->expects( 'republish' )->with( $copy, $original )->once();
+		$this->instance->expects( 'is_classic_editor_post_request' )->andReturnFalse();
+
+		$this->instance->republish_request( $copy );
+	}
+
+	/**
+	 * Tests that republish_request does not republish a scheduled copy when the user is allowed.
+	 *
+	 * The scheduled copy is republished later by cron, not at scheduling time.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_request
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_does_not_republish_scheduled_copy_when_user_is_allowed() {
+		$original     = Mockery::mock( WP_Post::class );
+		$original->ID = 1;
+
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_status = 'future';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'is_copy_allowed_to_be_republished' )
+			->with( $copy )
+			->andReturnFalse();
+
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils
+			->expects( 'get_original' )
+			->with( $copy->ID )
+			->andReturn( $original );
+
+		Monkey\Functions\expect( '\current_user_can' )
+			->with( 'edit_post', $original->ID )
+			->andReturnTrue();
+
+		$this->instance->expects( 'republish' )->never();
+
+		$this->instance->republish_request( $copy );
+	}
+
+	/**
+	 * Tests that republish_request reverts the copy to draft and stops when the user may not republish.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_request
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::revert_unauthorized_copy
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_reverts_to_draft_and_dies_when_user_is_not_allowed() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$original     = Mockery::mock( WP_Post::class );
+		$original->ID = 1;
+
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_status = 'dp-rewrite-republish';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'is_copy_allowed_to_be_republished' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils
+			->expects( 'get_original' )
+			->with( $copy->ID )
+			->andReturn( $original );
+
+		Monkey\Functions\expect( '\current_user_can' )
+			->with( 'edit_post', $original->ID )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( '\wp_update_post' )
+			->once()
+			->with(
+				[
+					'ID'          => $copy->ID,
+					'post_status' => 'draft',
+				],
+			);
+
+		Monkey\Functions\expect( '\wp_die' )
+			->once()
+			->andThrow( Exception::class, 'wp_die called.' );
+
+		$this->instance->expects( 'republish' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'wp_die called.' );
+
+		$this->instance->republish_request( $copy );
+	}
+
+	/**
+	 * Tests that republish_request reverts a scheduled copy to draft and stops when the user may not republish.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::republish_request
+	 * @covers \Yoast\WP\Duplicate_Post\Post_Republisher::revert_unauthorized_copy
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_reverts_scheduled_copy_to_draft_and_dies_when_user_is_not_allowed() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$original     = Mockery::mock( WP_Post::class );
+		$original->ID = 1;
+
+		$copy              = Mockery::mock( WP_Post::class );
+		$copy->ID          = 123;
+		$copy->post_status = 'future';
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $copy )
+			->andReturnTrue();
+
+		$this->permissions_helper
+			->expects( 'is_copy_allowed_to_be_republished' )
+			->with( $copy )
+			->andReturnFalse();
+
+		$utils = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$utils
+			->expects( 'get_original' )
+			->with( $copy->ID )
+			->andReturn( $original );
+
+		Monkey\Functions\expect( '\current_user_can' )
+			->with( 'edit_post', $original->ID )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( '\wp_update_post' )
+			->once()
+			->with(
+				[
+					'ID'          => $copy->ID,
+					'post_status' => 'draft',
+				],
+			);
+
+		Monkey\Functions\expect( '\wp_die' )
+			->once()
+			->andThrow( Exception::class, 'wp_die called.' );
+
+		$this->instance->expects( 'republish' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'wp_die called.' );
+
+		$this->instance->republish_request( $copy );
 	}
 
 	/**

--- a/tests/Unit/UI/Block_Editor_Test.php
+++ b/tests/Unit/UI/Block_Editor_Test.php
@@ -468,6 +468,136 @@ final class Block_Editor_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the original item data falls back to an empty edit URL when the
+	 * current user cannot edit the original post.
+	 *
+	 * `get_edit_post_link()` returns null when the user lacks `edit_post` on the
+	 * original; passing that null to `esc_url_raw()` triggers a deprecation on PHP 8.1+.
+	 *
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::enqueue_block_editor_scripts
+	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::generate_js_object
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_block_editor_scripts_when_original_cannot_be_edited() {
+		$utils                      = Mockery::mock( 'alias:\Yoast\WP\Duplicate_Post\Utils' );
+		$post                       = Mockery::mock( WP_Post::class );
+		$post->ID                   = 123;
+		$original                   = Mockery::mock( WP_Post::class );
+		$original->ID               = 456;
+		$new_draft_link             = 'http://fakeu.rl/new_draft';
+		$rewrite_and_republish_link = 'http://fakeu.rl/rewrite_and_republish';
+		$original_edit_url          = 'http://fakeu.rl/original';
+		$check_link                 = 'http://fakeu.rl/check';
+
+		$show_links = [
+			'new_draft'         => '1',
+			'clone'             => '1',
+			'rewrite_republish' => '1',
+		];
+
+		$show_links_in = [
+			'row'         => '1',
+			'adminbar'    => '1',
+			'submitbox'   => '1',
+			'bulkactions' => '1',
+		];
+
+		$this->permissions_helper
+			->expects( 'is_edit_post_screen' )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( '\get_post' )
+			->andReturn( $post );
+
+		$this->permissions_helper
+			->expects( 'is_rewrite_and_republish_copy' )
+			->with( $post )
+			->twice()
+			->andReturnTrue();
+
+		$this->instance
+			->expects( 'get_new_draft_permalink' )
+			->andReturn( $new_draft_link );
+
+		$this->instance
+			->expects( 'get_rewrite_republish_permalink' )
+			->andReturn( $rewrite_and_republish_link );
+
+		$utils
+			->expects( 'get_option' )
+			->andReturn( $show_links );
+
+		$utils
+			->expects( 'get_option' )
+			->andReturn( $show_links_in );
+
+		$this->instance
+			->expects( 'get_original_post_edit_url' )
+			->andReturn( $original_edit_url );
+
+		Monkey\Functions\expect( '\get_option' )
+			->with( 'duplicate_post_show_original_meta_box' )
+			->andReturn( '0' );
+
+		$utils
+			->expects( 'get_original' )
+			->with( $post )
+			->andReturn( $original );
+
+		// The user cannot edit the original, so get_edit_post_link returns null.
+		Monkey\Functions\expect( '\get_edit_post_link' )
+			->with( $original->ID, 'raw' )
+			->andReturnNull();
+		Monkey\Functions\expect( '\get_permalink' )
+			->with( $original->ID )
+			->andReturn( 'http://fakeu.rl/original-view' );
+		Monkey\Functions\expect( '\_draft_or_post_title' )
+			->with( $original )
+			->andReturn( 'Original Title' );
+		Monkey\Functions\expect( '\current_user_can' )
+			->with( 'edit_post', $original->ID )
+			->andReturnFalse();
+		Monkey\Functions\when( '\esc_url_raw' )->returnArg();
+
+		$edit_js_object = [
+			'postId'                  => 123,
+			'newDraftLink'            => $new_draft_link,
+			'rewriteAndRepublishLink' => $rewrite_and_republish_link,
+			'showLinks'               => $show_links,
+			'showLinksIn'             => $show_links_in,
+			'rewriting'               => 1,
+			'originalEditURL'         => $original_edit_url,
+			'showOriginalMetaBox'     => false,
+			'originalItem'            => [
+				'editUrl' => '',
+				'viewUrl' => 'http://fakeu.rl/original-view',
+				'title'   => 'Original Title',
+				'canEdit' => false,
+			],
+		];
+
+		$this->asset_manager
+			->expects( 'enqueue_styles' );
+
+		$this->asset_manager
+			->expects( 'enqueue_edit_script' )
+			->with( $edit_js_object );
+
+		$this->instance
+			->expects( 'get_check_permalink' )
+			->andReturn( $check_link );
+
+		$this->asset_manager
+			->expects( 'enqueue_strings_script' )
+			->with( [ 'checkLink' => $check_link ] );
+
+		$this->instance->enqueue_block_editor_scripts();
+	}
+
+	/**
 	 * Tests the enqueueing of the scripts when no post is displayed.
 	 *
 	 * @covers \Yoast\WP\Duplicate_Post\UI\Block_Editor::enqueue_block_editor_scripts

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -94,6 +94,32 @@ final class Post_Republisher_Test extends TestCase {
 	}
 
 	/**
+	 * Helper method to genuinely schedule a Rewrite & Republish copy for a future date.
+	 *
+	 * Both post_date and post_date_gmt are set, otherwise wp_update_post keeps the copy's
+	 * existing GMT date and WordPress coerces the 'future' status back to 'publish'.
+	 *
+	 * @param WP_Post $copy The Rewrite & Republish copy to schedule.
+	 *
+	 * @return WP_Post The refreshed copy, now persisted in the 'future' status.
+	 */
+	private function schedule_copy_for_future( WP_Post $copy ) {
+		$future = \gmdate( 'Y-m-d H:i:s', ( \time() + \DAY_IN_SECONDS ) );
+
+		$this->update_post_without_republish(
+			[
+				'ID'            => $copy->ID,
+				'post_status'   => 'future',
+				'post_date'     => $future,
+				'post_date_gmt' => $future,
+				'edit_date'     => true,
+			],
+		);
+
+		return \get_post( $copy->ID );
+	}
+
+	/**
 	 * Helper method to update a post without triggering the republish redirect.
 	 *
 	 * This prevents the republish flow by removing the filter that changes the
@@ -1560,10 +1586,9 @@ final class Post_Republisher_Test extends TestCase {
 		);
 		$copy     = $this->create_rewrite_and_republish_copy( $original );
 
-		// Simulate the scheduling submission: republish_request receives the copy with the 'future'
-		// status, exactly as the save hooks pass it when a future date is set in the editor.
-		$copy              = \get_post( $copy->ID );
-		$copy->post_status = 'future';
+		// Genuinely schedule the copy, as saving it with a future date in the editor would.
+		$copy = $this->schedule_copy_for_future( $copy );
+		$this->assertSame( 'future', $copy->post_status );
 
 		// A user who cannot edit the original attempts to schedule the republish.
 		$unauthorized_id = $this->factory->user->create( [ 'role' => 'author' ] );
@@ -1580,7 +1605,7 @@ final class Post_Republisher_Test extends TestCase {
 		$unchanged_original = \get_post( $original->ID );
 		$this->assertSame( 'Original Title', $unchanged_original->post_title );
 
-		// The copy is left as a draft (not scheduled or published), so it cannot republish the original.
+		// The scheduled copy is reverted from 'future' to 'draft', so cron can no longer publish it over the original.
 		$reverted_copy = \get_post( $copy->ID );
 		$this->assertSame( 'draft', $reverted_copy->post_status );
 	}
@@ -1601,9 +1626,9 @@ final class Post_Republisher_Test extends TestCase {
 		);
 		$copy     = $this->create_rewrite_and_republish_copy( $original );
 
-		// Simulate the scheduling submission: republish_request receives the copy with the 'future' status.
-		$copy              = \get_post( $copy->ID );
-		$copy->post_status = 'future';
+		// Genuinely schedule the copy for a future date.
+		$copy = $this->schedule_copy_for_future( $copy );
+		$this->assertSame( 'future', $copy->post_status );
 
 		// A user who can edit the original schedules the republish.
 		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
@@ -1611,6 +1636,10 @@ final class Post_Republisher_Test extends TestCase {
 
 		// An authorized scheduling is not blocked and is not republished now (cron does that at the scheduled time).
 		$this->instance->republish_request( $copy );
+
+		// The copy stays scheduled: not reverted to draft and not republished onto the original now.
+		$scheduled_copy = \get_post( $copy->ID );
+		$this->assertSame( 'future', $scheduled_copy->post_status );
 
 		// The original is not republished yet.
 		$unchanged_original = \get_post( $original->ID );

--- a/tests/WP/Post_Republisher_Test.php
+++ b/tests/WP/Post_Republisher_Test.php
@@ -1488,4 +1488,133 @@ final class Post_Republisher_Test extends TestCase {
 		// Clean up (may not be reached due to exception).
 		unset( $_GET['dprepublished'], $_GET['dpcopy'], $_GET['post'], $_GET['dpnonce'], $_REQUEST['dpnonce'] );
 	}
+
+	/**
+	 * Tests that republish_request blocks an immediate republish by a user who cannot edit the original.
+	 *
+	 * @covers ::republish_request
+	 * @covers ::revert_unauthorized_copy
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_blocks_unauthorized_immediate_republish() {
+		$owner_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$original = $this->create_original_post(
+			[
+				'post_title'   => 'Original Title',
+				'post_content' => 'Original content.',
+				'post_author'  => $owner_id,
+			],
+		);
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		// Put the copy in the republish-pending state, as a republish submission would.
+		$this->update_post_without_republish(
+			[
+				'ID'           => $copy->ID,
+				'post_title'   => 'Rewritten Title',
+				'post_content' => 'Rewritten content.',
+				'post_status'  => 'dp-rewrite-republish',
+			],
+		);
+		$copy = \get_post( $copy->ID );
+
+		// A user who cannot edit the original attempts the republish.
+		$unauthorized_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		\wp_set_current_user( $unauthorized_id );
+
+		try {
+			$this->instance->republish_request( $copy );
+			$this->fail( 'Expected wp_die was not triggered for an unauthorized republish.' );
+		} catch ( WPDieException $e ) {
+			$this->assertInstanceOf( WPDieException::class, $e );
+		}
+
+		// The original is never overwritten.
+		$unchanged_original = \get_post( $original->ID );
+		$this->assertSame( 'Original Title', $unchanged_original->post_title );
+		$this->assertSame( 'Original content.', $unchanged_original->post_content );
+
+		// The copy is reverted to draft, preserving its content.
+		$reverted_copy = \get_post( $copy->ID );
+		$this->assertSame( 'draft', $reverted_copy->post_status );
+		$this->assertSame( 'Rewritten Title', $reverted_copy->post_title );
+	}
+
+	/**
+	 * Tests that republish_request blocks scheduling a republish by a user who cannot edit the original.
+	 *
+	 * @covers ::republish_request
+	 * @covers ::revert_unauthorized_copy
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_blocks_unauthorized_scheduling() {
+		$owner_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$original = $this->create_original_post(
+			[
+				'post_title'   => 'Original Title',
+				'post_content' => 'Original content.',
+				'post_author'  => $owner_id,
+			],
+		);
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		// Simulate the scheduling submission: republish_request receives the copy with the 'future'
+		// status, exactly as the save hooks pass it when a future date is set in the editor.
+		$copy              = \get_post( $copy->ID );
+		$copy->post_status = 'future';
+
+		// A user who cannot edit the original attempts to schedule the republish.
+		$unauthorized_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		\wp_set_current_user( $unauthorized_id );
+
+		try {
+			$this->instance->republish_request( $copy );
+			$this->fail( 'Expected wp_die was not triggered for an unauthorized scheduling.' );
+		} catch ( WPDieException $e ) {
+			$this->assertInstanceOf( WPDieException::class, $e );
+		}
+
+		// The original is never overwritten.
+		$unchanged_original = \get_post( $original->ID );
+		$this->assertSame( 'Original Title', $unchanged_original->post_title );
+
+		// The copy is left as a draft (not scheduled or published), so it cannot republish the original.
+		$reverted_copy = \get_post( $copy->ID );
+		$this->assertSame( 'draft', $reverted_copy->post_status );
+	}
+
+	/**
+	 * Tests that republish_request leaves a scheduled copy untouched when the user can edit the original.
+	 *
+	 * @covers ::republish_request
+	 *
+	 * @return void
+	 */
+	public function test_republish_request_allows_authorized_scheduling() {
+		$original = $this->create_original_post(
+			[
+				'post_title'   => 'Original Title',
+				'post_content' => 'Original content.',
+			],
+		);
+		$copy     = $this->create_rewrite_and_republish_copy( $original );
+
+		// Simulate the scheduling submission: republish_request receives the copy with the 'future' status.
+		$copy              = \get_post( $copy->ID );
+		$copy->post_status = 'future';
+
+		// A user who can edit the original schedules the republish.
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		\wp_set_current_user( $admin_id );
+
+		// An authorized scheduling is not blocked and is not republished now (cron does that at the scheduled time).
+		$this->instance->republish_request( $copy );
+
+		// The original is not republished yet.
+		$unchanged_original = \get_post( $original->ID );
+		$this->assertSame( 'Original Title', $unchanged_original->post_title );
+		$this->assertSame( 'Original content.', $unchanged_original->post_content );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Rewrite & Republish is the plugin feature that makes a private, editable copy of an already-published post so it can be reworked and then swapped in over the original.

A security report showed that a user who is allowed to make copies, but is not allowed to edit a particular published post, could still overwrite that post. The "replace it now" path already refused them, but the "schedule it for later" path did not: it published the copy over the original at the scheduled time without checking permission. This PR closes that gap by checking permission at the moment the user republishes or schedules, in both the block editor and the classic editor.

While reproducing that issue we found a second, smaller problem in the same area. When such a user opened one of these copies in the block editor, the page printed a PHP "Deprecated" notice (followed by "headers already sent" warnings), because the code built an "edit the original" link that does not exist for a user who cannot edit the original. This PR fixes that as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a published post could be overwritten by a user without permission to edit it, when that user scheduled a Rewrite & Republish copy of the post for future publication. Props to [@nacento](https://github.com/nacento).
* Fixes a bug where a PHP deprecation notice appeared in the block editor, when a user opened a Rewrite & Republish copy of a post they were not allowed to edit.

## Relevant technical choices:

* The permission check is now done when the user acts, in `Post_Republisher::republish_request()`, for both the immediate-republish submission (status `dp-rewrite-republish`/`private`) and the scheduling submission (status `future`), rather than only the immediate one. That method already runs on both save hooks (`rest_after_insert_{type}` for the block editor and `wp_insert_post` for the classic editor), so one check covers both editors.
* When the check fails, the copy is reverted to a draft (its rewritten content is preserved) and the request is refused with the existing `You are not allowed to republish this post.` message. The original post is never modified. Reverting to a draft also replaces the old behaviour where a blocked immediate republish left the copy stuck in the `dp-rewrite-republish` status (later hard-deleted by the orphan cleanup), which discarded the user's work.
* Enforcement is at the user action only, not in the WP-cron publish step (`republish_scheduled_post()` is unchanged). Once an unauthorized user can no longer reach the `future` status, cron never receives such a copy. The narrow case of a user authorized at scheduling time who loses access before the scheduled run is a deliberately accepted edge case.
* For the deprecation: `get_edit_post_link()` returns `null` for a user who cannot edit the original, and passing `null` to `esc_url_raw()` triggers the PHP 8.1+ `ltrim()` notice. The link is cast to a string so it falls back to an empty string. The editor already picks the public view link over the edit link based on `canEdit`, so an empty edit link has no visible effect.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Setup (once, as the site owner):
* In the plugin settings, under the list of who may make copies, turn the feature on for the **Author** role. (An "Author" is a basic user who can write and publish their own posts but cannot edit other people's posts.)
* Have an **Administrator** account and an **Author** account.
* Have a post that is **published and owned by the Administrator**. Logged in as the Author, confirm there is no way to edit that post.

A. An Author cannot take over the post by scheduling it:
1. Log in as the Author.
2. Open the Administrator's published post on the public side of the site, and in the top toolbar click **Rewrite & Republish**. The Author's private copy opens in the editor.
3. Change the title and text, set it to go live at a **future** date and time, and click **Schedule**.
4. Expected: it is refused with "You are not allowed to republish this post.", the copy becomes a **draft** with the text kept, and the Administrator's post is unchanged.

B. An Author cannot take over by replacing it immediately:
1. As the Author, with that copy open, click **Republish** (without a future date).
2. Expected: same refusal, the copy stays a **draft**, and the original is unchanged.

C. The edit screen no longer shows a PHP error:
1. As the Author, open one of these copies (whose original belongs to someone else) in the block editor.
2. Expected: the editor opens cleanly, with no red "Deprecated" / "headers already sent" text at the top of the page.

D. People who are allowed are unaffected:
1. Log in as the Administrator. Make a Rewrite & Republish copy of a post you own, edit it, and click **Republish**: the original updates as before.
2. Do the same but **Schedule** it for a future time: it stays scheduled and goes live automatically at that time, replacing the original, as before.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
Test on both posts and pages, because Rewrite & Republish is available for both. Test in the block editor and the classic editor, because the republish and schedule actions run in both, and the PHP-notice fix is specific to the block editor.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

Same as the acceptance test steps above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Rewrite & Republish flow: republishing now, scheduling for later, and the normal (authorized) versions of both.
* The block editor sidebar data for a Rewrite & Republish copy (the "original item" panel and its links).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
