### PR TITLE
Sets the minimum supported WordPress version to 6.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       matrix:
         include:
           - php_version: "7.4"
-            wp_version: "6.8"
+            wp_version: "6.9"
             multisite: true
             coverage: true
 
@@ -147,7 +147,7 @@ jobs:
             coverage: false
 
           - php_version: "8.0"
-            wp_version: "6.8"
+            wp_version: "6.9"
             multisite: false
             coverage: false
 
@@ -157,21 +157,20 @@ jobs:
             coverage: false
 
           - php_version: "8.2"
-            wp_version: "6.8"
+            wp_version: "6.9"
             multisite: true
             coverage: false
 
           - php_version: '8.3'
-            wp_version: '6.8'
+            wp_version: '6.9'
             multisite: false
             coverage: false
 
           - php_version: '8.4'
-            wp_version: '6.8'
+            wp_version: '6.9'
             multisite: false
             coverage: false
 
-          # WP 6.9 is the earliest version which supports PHP 8.5.
           - php_version: '8.5'
             wp_version: '6.9'
             multisite: true

--- a/duplicate-post.php
+++ b/duplicate-post.php
@@ -13,7 +13,7 @@
  * Author:      Enrico Battocchi & Team Yoast
  * Author URI:  https://yoa.st/team-yoast-duplicate
  * Text Domain: duplicate-post
- * Requires at least: 6.8
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  *
  * Copyright 2020-2024 Yoast BV (email : info@yoast.com)

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: 		yoast, lopo
 Donate link: 		https://yoast.com/wordpress/plugins/duplicate-post/
 Tags: 				duplicate post, duplicate page, clone, copy, rewrite republish
-Requires at least: 	6.8
+Requires at least: 	6.9
 Tested up to: 		7.0
 Stable tag: 		4.7
 Requires PHP:		7.4


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Refs Yoast/wordpress-seo#23529.

Previous iteration: Yoast/duplicate-post#438.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum supported WordPress version to 6.9.

## Relevant technical choices:

* Bumps the WordPress versions used in the CI test matrix accordingly.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that `duplicate-post.php` and `readme.txt` state `Requires at least: 6.9`.
* On a site running WordPress 6.9 or newer, verify that the plugin activates and works as before.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The plugin can no longer be installed on WordPress versions below 6.9.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
