### PR TITLE
ci: deploy to dist from the release workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,16 +34,34 @@ on:
       - '**'
   # Allow manually triggering the workflow.
   workflow_dispatch:
+  # Allow the release workflows to deploy the tag they just pushed. A push made with the
+  # built-in Actions token raises no events, so a release workflow cannot rely on its own
+  # tag push to trigger this workflow.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to build and deploy. Pass the tag name for a release.'
+        required: true
+        type: string
+      is-release:
+        description: 'Deploy `ref` as a release: take the version from the ref name, sync to the dist default branch and tag it there.'
+        required: false
+        default: false
+        type: boolean
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The concurrency group contains the workflow name and the deployed ref.
+  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 env:
   DIST_ORG: 'Yoast-dist'
   DIST_DEFAULT_BRANCH: 'main'
+  # A `workflow_call` gets the ref to deploy and the release flag from the calling
+  # workflow; `push` and `workflow_dispatch` derive both from the triggering ref.
+  DEPLOY_REF_NAME: ${{ inputs.ref || github.ref_name }}
+  IS_RELEASE: ${{ inputs.is-release || github.ref_type == 'tag' }}
 
 jobs:
   prepare:
@@ -53,11 +71,31 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    outputs:
+      SHA: ${{ steps.set_metadata.outputs.SHA }}
+      COMMIT_MSG: ${{ steps.set_metadata.outputs.COMMIT_MSG }}
+      COMMIT_TIME: ${{ steps.set_metadata.outputs.COMMIT_TIME }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
+
+      - name: "Set variables: commit metadata"
+        id: set_metadata
+        # The `push` payload carries the commit that triggered the run, but the
+        # `workflow_dispatch` and `workflow_call` payloads do not, so read the metadata
+        # from the checked-out ref instead.
+        run: |
+          {
+            echo "SHA=$(git rev-parse HEAD)"
+            echo "COMMIT_TIME=$(git log -1 --format=%cI)"
+            echo "COMMIT_MSG<<COMMIT_MSG_EOF"
+            git log -1 --format=%B
+            echo "COMMIT_MSG_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -92,14 +130,12 @@ jobs:
       - name: Yarn install
         run: yarn install
 
-      - name: "Grunt: set package version (tags only)"
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: grunt set-version -new-version="$REF_NAME"
+      - name: "Grunt: set package version (releases only)"
+        if: ${{ env.IS_RELEASE == 'true' }}
+        run: grunt set-version -new-version="$DEPLOY_REF_NAME"
 
-      - name: "Grunt: update package version (tags only)"
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      - name: "Grunt: update package version (releases only)"
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: grunt update-version
 
       - name: "Grunt: create artifact"
@@ -138,25 +174,26 @@ jobs:
       - name: "Set variable: short sha"
         id: set_sha
         env:
-          SHA: ${{ github.sha }}
+          SHA: ${{ needs.prepare.outputs.SHA }}
         run: |
           shortsha=$(echo "$SHA" | cut -b 1-6)
           echo "SHORTSHA=$shortsha" >> "$GITHUB_OUTPUT"
 
       - name: "Set variables: target branch, commit title"
         id: set_vars
-        env:
-          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'branch' && "$REF_NAME" != "${{ env.DIST_DEFAULT_BRANCH }}" ]]; then
-            echo "BRANCH=$REF_NAME" >> "$GITHUB_OUTPUT"
-            echo "TITLE=Syncing branch $REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "$REF_NAME" != "${{ env.DIST_DEFAULT_BRANCH }}" ]]; then
-            echo "BRANCH=$REF_NAME" >> "$GITHUB_OUTPUT"
-            echo "TITLE=Manual deploy for $REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> "$GITHUB_OUTPUT"
-          else # = Pushed tag.
+          # A release goes to the dist default branch and gets tagged there; any other ref
+          # syncs to a same-named branch. A run on the dist default branch itself takes the
+          # release path, as it did before.
+          if [[ "$IS_RELEASE" == 'true' || "$DEPLOY_REF_NAME" == "${{ env.DIST_DEFAULT_BRANCH }}" ]]; then
             echo "BRANCH=${{ env.DIST_DEFAULT_BRANCH }}" >> "$GITHUB_OUTPUT"
-            echo "TITLE=Release $REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "TITLE=Release $DEPLOY_REF_NAME" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'branch' ]]; then
+            echo "BRANCH=$DEPLOY_REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "TITLE=Syncing branch $DEPLOY_REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> "$GITHUB_OUTPUT"
+          else
+            echo "BRANCH=$DEPLOY_REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "TITLE=Manual deploy for $DEPLOY_REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout Yoast Dist repo
@@ -215,12 +252,12 @@ jobs:
         run: git add -A
 
       - name: "Commit the files (branch)"
-        if: ${{ github.event_name != 'push' || github.ref_type != 'tag' }}
+        if: ${{ env.IS_RELEASE != 'true' }}
         env:
-          COMMITTER: ${{ github.event.head_commit.committer.username }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
-          COMMIT_URL: ${{ github.event.head_commit.url }}
-          COMMIT_TIME: ${{ github.event.head_commit.timestamp }}
+          COMMITTER: ${{ github.event.head_commit.committer.username || github.actor }}
+          COMMIT_MSG: ${{ github.event.head_commit.message || needs.prepare.outputs.COMMIT_MSG }}
+          COMMIT_URL: ${{ github.event.head_commit.url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, needs.prepare.outputs.SHA) }}
+          COMMIT_TIME: ${{ github.event.head_commit.timestamp || needs.prepare.outputs.COMMIT_TIME }}
         run: |
           git commit --allow-empty -m "${{ steps.set_vars.outputs.TITLE }}" \
             -m "Synced up to commit hash: $COMMIT_URL" \
@@ -232,12 +269,12 @@ jobs:
             -m "$COMMIT_MSG"
 
       - name: "Commit the files (release)"
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         env:
-          COMMITTER: ${{ github.event.head_commit.committer.username }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
-          COMMIT_URL: ${{ github.event.head_commit.url }}
-          COMMIT_TIME: ${{ github.event.head_commit.timestamp }}
+          COMMITTER: ${{ github.event.head_commit.committer.username || github.actor }}
+          COMMIT_MSG: ${{ github.event.head_commit.message || needs.prepare.outputs.COMMIT_MSG }}
+          COMMIT_URL: ${{ github.event.head_commit.url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, needs.prepare.outputs.SHA) }}
+          COMMIT_TIME: ${{ github.event.head_commit.timestamp || needs.prepare.outputs.COMMIT_TIME }}
         run: |
           git commit -m "${{ steps.set_vars.outputs.TITLE }}" \
             -m "Commit hash for tag: $COMMIT_URL" \
@@ -249,10 +286,8 @@ jobs:
             -m "$COMMIT_MSG"
 
       - name: "Tag the commit (releases only)"
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: git tag "$REF_NAME" "$(git rev-parse HEAD)"
+        if: ${{ env.IS_RELEASE == 'true' }}
+        run: git tag "$DEPLOY_REF_NAME" "$(git rev-parse HEAD)"
 
       - name: Push to target branch
         run: git push -u origin ${{ steps.set_vars.outputs.BRANCH }} --tags -v

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -21,10 +21,15 @@ name: Release RC
 # Finally merges the release branch back into trunk so the version bump and
 # changelog regen land there too.
 #
+# A follow-up job calls .github/workflows/deploy.yml, which builds the RC tag and
+# pushes the artifact to Yoast-dist/duplicate-post. A push made with the built-in
+# Actions token raises no events, so the tag push cannot trigger that workflow by
+# itself.
+#
 # Pass `dry-run=true` to rehearse the pipeline without any remote side effect:
-# every `git push`, the SVN deploy, the GitHub pre-release, and the merge-back
-# push are skipped. The built zip is uploaded as a workflow artifact so you
-# can inspect it. Overrides `deploy-to-svn-trunk`.
+# every `git push`, the SVN deploy, the GitHub pre-release, the dist deploy, and
+# the merge-back push are skipped. The built zip is uploaded as a workflow
+# artifact so you can inspect it. Overrides `deploy-to-svn-trunk`.
 ##############################################################################
 
 on:
@@ -45,7 +50,7 @@ on:
         default: false
         type: boolean
       dry-run:
-        description: 'Dry-run: do all in-tree work (changelog regen, version bump, local commit/merge/tag, artifact build) but skip every remote side-effect (no git push, no SVN, no GH pre-release). The built zip is uploaded as a workflow artifact for inspection. Overrides `deploy-to-svn-trunk`.'
+        description: 'Dry-run: do all in-tree work (changelog regen, version bump, local commit/merge/tag, artifact build) but skip every remote side-effect (no git push, no SVN, no GH pre-release, no dist deploy). The built zip is uploaded as a workflow artifact for inspection. Overrides `deploy-to-svn-trunk`.'
         required: false
         default: false
         type: boolean
@@ -64,6 +69,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+
+    outputs:
+      RC_VERSION: ${{ steps.rc.outputs.RC_VERSION }}
 
     env:
       RELEASE_BRANCH: "release/${{ inputs.version }}"
@@ -96,6 +104,7 @@ jobs:
           git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Determine next RC number
+        id: rc
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -106,6 +115,7 @@ jobs:
           RC_VERSION="${VERSION}-RC${NEXT}"
           echo "RC_VERSION=${RC_VERSION}" >> "$GITHUB_ENV"
           echo "RC_NUM=${NEXT}" >> "$GITHUB_ENV"
+          echo "RC_VERSION=${RC_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Previous RC: ${LAST:-none}. Next RC: ${RC_VERSION}"
 
       - name: Create or check out release branch
@@ -482,6 +492,7 @@ jobs:
             fi
             echo "* \`gh release create ${RC_VERSION} --prerelease\` with \`${ZIP}\` attached and the QA changelog below"
             echo "* \`git push origin trunk\` (after merging \`${RELEASE_BRANCH}\` back)"
+            echo "* Build tag \`${RC_VERSION}\` and push the artifact to Yoast-dist/duplicate-post"
             echo ""
             echo "The built plugin is available as the \`duplicate-post-${RC_VERSION}\` workflow artifact above (download yields \`${ZIP}\` containing the \`duplicate-post/\` folder)."
             echo ""
@@ -489,3 +500,14 @@ jobs:
             echo ""
             cat qa-changelog.md
           } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-to-dist:
+    name: "Deploy to dist"
+    needs: release-rc
+    # A dry run pushes no tag, so there is nothing to deploy.
+    if: ${{ inputs.dry-run != true }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ref: ${{ needs.release-rc.outputs.RC_VERSION }}
+      is-release: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ name: Release
 #   2. Bumps the version (package.json, plugin header, DUPLICATE_POST_CURRENT_VERSION, Stable tag)
 #      on the source branch: release/x.y when an RC was cut, otherwise trunk.
 #   3. Merges the source branch into main (--no-ff), tags and pushes from main.
-#      (The tag push also triggers .github/workflows/deploy.yml, which builds
-#       and pushes the artifact to Yoast-dist/duplicate-post.)
 #   4. Builds the artifact locally and deploys it to wordpress.org SVN via the
 #      10up action (uses WPORG_SVN_USERNAME / WPORG_SVN_PASSWORD secrets).
 #   5. Creates a GitHub release with the changelog.md section as notes and
@@ -19,10 +17,14 @@ name: Release
 #      next version.
 #   7. Merges main back into trunk.
 #   8. Emits a Slack message body in the job summary for manual posting.
+#   9. Calls .github/workflows/deploy.yml from a follow-up job, which builds the
+#      tag and pushes the artifact to Yoast-dist/duplicate-post. A push made with
+#      the built-in Actions token raises no events, so the tag push in step 3
+#      cannot trigger that workflow by itself.
 #
 # Pass `dry-run=true` to rehearse the pipeline without any remote side effect:
-# every `git push`, the SVN deploy, the GitHub release, and the milestone API
-# calls are skipped. The built zip is still uploaded as a workflow artifact
+# every `git push`, the SVN deploy, the GitHub release, the dist deploy, and the
+# milestone API calls are skipped. The built zip is still uploaded as a workflow artifact
 # (named duplicate-post-${VERSION}, containing the duplicate-post/ folder)
 # so you can inspect it.
 ##############################################################################
@@ -39,7 +41,7 @@ on:
         required: false
         type: string
       dry-run:
-        description: 'Dry-run: do all in-tree work (version bump, local commit/merge/tag, artifact build) but skip every remote side-effect (no git push, no SVN, no GH release, no milestone changes). The built zip is uploaded as a workflow artifact for inspection.'
+        description: 'Dry-run: do all in-tree work (version bump, local commit/merge/tag, artifact build) but skip every remote side-effect (no git push, no SVN, no GH release, no dist deploy, no milestone changes). The built zip is uploaded as a workflow artifact for inspection.'
         required: false
         default: false
         type: boolean
@@ -376,6 +378,7 @@ jobs:
             echo "* \`gh release create ${VERSION}\` with \`${ZIP_NAME}\` attached and the release notes below"
             echo "* Close milestone \`${VERSION}\` and open milestone \`${NEXT_VERSION}\`"
             echo "* \`git push origin trunk\` (after merging \`main\` back)"
+            echo "* Build tag \`${VERSION}\` and push the artifact to Yoast-dist/duplicate-post"
             echo ""
             echo "The built plugin is available as the \`duplicate-post-${VERSION}\` workflow artifact above (download yields \`duplicate-post-${VERSION}.zip\` containing the \`duplicate-post/\` folder)."
             echo ""
@@ -383,3 +386,14 @@ jobs:
             echo ""
             cat release-notes.md
           } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-to-dist:
+    name: "Deploy to dist"
+    needs: release
+    # A dry run pushes no tag, so there is nothing to deploy.
+    if: ${{ inputs.dry-run != true }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ref: ${{ inputs.version }}
+      is-release: true
+    secrets: inherit


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* `Release` and `Release RC` push their tag with the built-in Actions token. GitHub raises no events for pushes made with that token, so the tag push never started `Deploy` and `Yoast-dist/duplicate-post` stopped receiving released code. The dist repository has no `4.7` tag, while `4.6`, `4.6-RC1` and `4.6-RC2` are all still there from when tags were pushed by hand.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `Deploy to dist` job to the `Release` and `Release RC` workflows, so a released tag reaches `Yoast-dist/duplicate-post` again.

## Relevant technical choices:

* `deploy.yml` gains a `workflow_call` trigger with a `ref` input and an `is-release` input, and both release workflows call it after the tag push with `secrets: inherit`. A reusable workflow can only be called as a job, so the dist deploy runs as a follow-up job after the release job finishes.
* Alternatives considered: push the tag over SSH with the existing `YOASTBOT_CI_KEY` deploy key, or add a token with write access for this repository. `workflow_call` needs no extra secret and keeps the dist deploy visible inside the release run.
* A called run has no push event payload, so `deploy.yml` no longer reads that payload for everything: the ref to build and the release flag come from the inputs (`DEPLOY_REF_NAME`, `IS_RELEASE`), and the source commit sha, time and message come from the `prepare` job, which reads them from the checked-out ref.
* Two side effects on manual `Deploy` runs: a run against a tag ref now takes the release path instead of creating a dist branch named after the tag, and the dist commit gets a real committer, message, timestamp and commit link instead of empty fields.
* A dry run pushes no tag, so the `Deploy to dist` job is skipped there. That also means the `workflow_call` path cannot be rehearsed; the first real exercise is the next RC or release.
* The `Release RC` job exposes the computed RC version as a job output, because the caller has to pass the tag name to build.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the three changed workflow files on this branch in the GitHub UI and confirm they render without YAML errors. `actionlint` 1.7.12 passes on the whole `.github/workflows/` directory. No PHP or JavaScript changed, so the PHP and Grunt checks have nothing to check here. `composer lint` and `composer check-branch-cs` pass locally; the local `composer test` run cannot complete because the installed `doctrine/instantiator` needs PHP 8.4 or newer, so the unit suite is covered by CI on this PR.
* Go to Actions, pick `Release RC`, run it from this branch with `version=99.0` and `dry-run=true`. Confirm the run is accepted and completes, that `Deploy to dist` is skipped, and that the dry-run summary lists the dist deploy among the steps it would have taken. A dry run does not exercise the deploy itself; the `Actionlint` CI job is what checks the call against `deploy.yml` and its inputs.
* After merge, go to Actions, pick `Deploy` and run it against the `4.7` tag. Confirm the run syncs to the dist `main` branch with a commit titled `Release 4.7`, and that `Yoast-dist/duplicate-post` ends up with the `4.7` tag it is missing.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This PR only changes release plumbing; there is nothing to test in the plugin. The `Release RC` run that produces the RC is itself the test: confirm it ends with a `Deploy to dist` job that pushes the RC tag to `Yoast-dist/duplicate-post`.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No plugin code. The `Deploy` workflow is shared with pushes to `trunk`, `release/*`, `hotfix/*` and `feature/*`, so the first push to one of those after merge is worth a look: it should still sync to a same-named dist branch with a `Syncing branch ...` commit.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

The header comment in `release.yml` claimed the tag push triggers `deploy.yml`. It is corrected, and both release workflow headers now describe the dist deploy and why the tag push cannot start it.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #542
